### PR TITLE
[WIP] Add quit check for forms with filled data.

### DIFF
--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1234,10 +1234,12 @@ class ConfirmQuit(List):
                                ('multiple-tabs', "Show a confirmation if "
                                                  "multiple tabs are opened."),
                                ('downloads', "Show a confirmation if "
-                                             "downloads are running"),
+                                             "downloads are running."),
+                               ('forms', "Show a confirmation if a tab has a "
+                                         "filled form."),
                                ('never', "Never show a confirmation."))
     # Values that can be combined with commas
-    combinable_values = ('multiple-tabs', 'downloads')
+    combinable_values = ('multiple-tabs', 'downloads', 'forms')
 
     def validate(self, value):
         values = self.transform(value)

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -344,6 +344,12 @@ class MainWindow(QWidget):
             quit_texts.append("{} {} running.".format(
                 tab_count,
                 "download is" if tab_count == 1 else "downloads are"))
+        # Check if any tabs have filled forms and skip
+        if 'forms' in confirm_quit:
+            for tab in self._tabbed_browser.widgets():
+                if not self._tabbed_browser.check_forms_can_be_destroyed(tab):
+                    e.ignore()
+                return
         # Process all quit messages that user must confirm
         if quit_texts or 'always' in confirm_quit:
             text = '\n'.join(['Really quit?'] + quit_texts)

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -191,6 +191,14 @@ class TabbedBrowser(tabwidget.TabWidget):
         return url
 
     def check_forms_can_be_destroyed(self, tab):
+        """If needed ask user for confirmation to close a tab
+
+        Args:
+            tab: The QWebView to be closed.
+
+        Return:
+            True if tab can be destroyed and false otherwise.
+        """
         # Check for user modified fields in a single tab
         confirm_quit = config.get('ui', 'confirm-quit')
         if tab.isModified() and 'forms' in confirm_quit:

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -191,13 +191,13 @@ class TabbedBrowser(tabwidget.TabWidget):
         return url
 
     def check_forms_can_be_destroyed(self, tab):
-        """If needed ask user for confirmation to close a tab
+        """If needed ask user for confirmation to close a tab.
 
         Args:
             tab: The QWebView to be closed.
 
         Return:
-            True if tab can be destroyed and false otherwise.
+            True if tab can be destroyed and False otherwise.
         """
         # Check for user modified fields in a single tab
         confirm_quit = config.get('ui', 'confirm-quit')


### PR DESCRIPTION
This pull request addresses the second half of #48.  The first half was addressed via pull request #442.

Adds an option to detect modified form fields and ask the user to confirm if they close the tab containing the field or confirm if they quit (close all tabs).

Still need to fix my pylint.  That is next on the list.