### PR TITLE
Stop the icon database from being created when private-browsing is set to true

### DIFF
--- a/doc/qutebrowser.1.asciidoc
+++ b/doc/qutebrowser.1.asciidoc
@@ -90,6 +90,7 @@ It was inspired by other browsers/addons like dwb and Vimperator/Pentadactyl.
 - '~/.config/qutebrowser/quickmarks': Saved quickmarks.
 - '~/.config/qutebrowser/keys.conf': Defined keybindings.
 - '~/.local/share/qutebrowser/': Various state information
+- '~/.cache/qutebrowser': Cached information
 
 == BUGS
 Bugs are tracked in the Github issue tracker at 

--- a/doc/qutebrowser.1.asciidoc
+++ b/doc/qutebrowser.1.asciidoc
@@ -90,7 +90,6 @@ It was inspired by other browsers/addons like dwb and Vimperator/Pentadactyl.
 - '~/.config/qutebrowser/quickmarks': Saved quickmarks.
 - '~/.config/qutebrowser/keys.conf': Defined keybindings.
 - '~/.local/share/qutebrowser/': Various state information
-- '~/.cache/qutebrowser': Cached information
 
 == BUGS
 Bugs are tracked in the Github issue tracker at 

--- a/qutebrowser/config/websettings.py
+++ b/qutebrowser/config/websettings.py
@@ -195,7 +195,10 @@ def _set_setting(typ, arg, default=UNSET, value=UNSET):
 def init():
     """Initialize the global QWebSettings."""
     cachedir = standarddir.get(QStandardPaths.CacheLocation)
-    QWebSettings.setIconDatabasePath(cachedir)
+    if config.get('general', 'private-browsing'):
+        QWebSettings.setIconDatabasePath('')
+    else:
+        QWebSettings.setIconDatabasePath(cachedir)
     QWebSettings.setOfflineWebApplicationCachePath(
         os.path.join(cachedir, 'application-cache'))
     datadir = standarddir.get(QStandardPaths.DataLocation)


### PR DESCRIPTION
There is a database created by QtWebkit in the cache folder called WebpageIcons.db. It has a table called PageURL, which stores a history of all visited URLs. The private-browsing setting does not stop this behaviour.  

Passing a blank string to "QWebSettings.setIconDatabasePath" stops the creation of the icon database in the cache folder. This change should fix the problem. 
