### PR TITLE
Change init_venv to use python 3.x venv

### DIFF
--- a/scripts/init_venv.py
+++ b/scripts/init_venv.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Initialize a virtualenv suitable to be used for qutebrowser."""
+"""Initialize a venv suitable to be used for qutebrowser."""
 
 import os
 import re
@@ -42,26 +42,17 @@ g_args = None
 def parse_args():
     """Parse the commandline arguments."""
     parser = argparse.ArgumentParser()
-    parser.add_argument('--force', help="Force creating a new virtualenv.",
+    parser.add_argument('--clear', help="Clear venv in case it already exists.",
+                        action='store_true')
+    parser.add_argument('--upgrade', help="Upgrade venv to use this version of "
+                        "Python, assuming Python has been upgraded in-place.",
                         action='store_true')
     parser.add_argument('--dev', help="Set up an environment suitable for "
-                                      "developing qutebrowser.",
+                        "developing qutebrowser.",
                         action='store_true')
-    parser.add_argument('path', help="Path to the virtualenv folder",
+    parser.add_argument('path', help="Path to the venv folder",
                         default='.venv', nargs='?')
     return parser.parse_args()
-
-
-def check_exists():
-    """Check if the virtualenv already exists."""
-    if os.path.exists(g_path):
-        if g_args.force:
-            print("Deleting old virtualenv at {}".format(g_path))
-            shutil.rmtree(g_path)
-        else:
-            print("virtualenv at {} does already exist!".format(g_path),
-                  file=sys.stderr)
-            sys.exit(1)
 
 
 def get_dev_packages(short=False):
@@ -88,7 +79,7 @@ def install_dev_packages():
 
 
 def venv_python(*args, output=False):
-    """Call the virtualenv's python with the given arguments."""
+    """Call the venv's python with the given arguments."""
     subdir = 'Scripts' if os.name == 'nt' else 'bin'
     executable = os.path.join(g_path, subdir, os.path.basename(sys.executable))
     if output:
@@ -101,6 +92,7 @@ def venv_python(*args, output=False):
 def test_toolchain():
     """Test if imports work properly."""
     utils.print_title("Checking toolchain")
+
     packages = ['sip', 'PyQt5.QtCore', 'PyQt5.QtWebKit', 'qutebrowser.app']
     if g_args.dev:
         packages += get_dev_packages(short=True)
@@ -112,19 +104,22 @@ def test_toolchain():
 
 
 def link_pyqt():
-    """Symlink the systemwide PyQt/sip into the virtualenv."""
+    """Symlink the systemwide PyQt/sip into the venv."""
     if os.name == 'nt':
         return
     utils.print_title("Softlinking PyQt5")
+
     sys_path = distutils.sysconfig.get_python_lib()
     venv_path = venv_python(
         '-c', 'from distutils.sysconfig import get_python_lib\n'
               'print(get_python_lib())', output=True).rstrip()
+
     globbed_sip = (glob.glob(os.path.join(sys_path, 'sip*.so')) +
                    glob.glob(os.path.join(sys_path, 'sip*.pyd')))
     if not globbed_sip:
         print("Did not find sip in {}!".format(sys_path), file=sys.stderr)
         sys.exit(1)
+
     files = [
         'PyQt5',
     ]
@@ -134,19 +129,28 @@ def link_pyqt():
         link_name = os.path.join(venv_path, fn)
         if not os.path.exists(source):
             raise FileNotFoundError(source)
+        if os.path.exists(link_name):
+            os.unlink(link_name)
         print('{} -> {}'.format(source, link_name))
         os.symlink(source, link_name)
 
 
 def create_venv():
-    """Create a new virtualenv."""
-    utils.print_title("Creating virtualenv")
+    """Create a new venv."""
+    utils.print_title("Creating venv using pyvenv")
+
     if os.name == 'nt':
         sys_site = ['--system-site-packages']
     else:
         sys_site = []
-    subprocess.check_call(['virtualenv'] + sys_site +
-                          ['-p', sys.executable, g_path])
+
+    command = ['pyvenv'] + sys_site
+    if g_args.clear:
+        command += ['--clear']
+    if g_args.upgrade:
+        command += ['--upgrade']
+    command += [g_path]
+    subprocess.check_call(command)
 
 
 def main():
@@ -157,10 +161,12 @@ def main():
         print("Refusing to run with empty path!", file=sys.stderr)
         sys.exit(1)
     g_path = os.path.abspath(g_args.path)
-    check_exists()
+
     create_venv()
-    utils.print_title("Calling setup.py")
+
+    utils.print_title("Calling: setup.py develop")
     venv_python('setup.py', 'develop')
+
     if g_args.dev:
         utils.print_title("Installing developer packages")
         install_dev_packages()

--- a/scripts/init_venv.py
+++ b/scripts/init_venv.py
@@ -47,6 +47,8 @@ def parse_args():
     parser.add_argument('--upgrade', help="Upgrade venv to use this version of "
                         "Python, assuming Python has been upgraded in-place.",
                         action='store_true')
+    parser.add_argument('--force', help=argparse.SUPPRESS,
+                        action='store_true')
     parser.add_argument('--dev', help="Set up an environment suitable for "
                         "developing qutebrowser.",
                         action='store_true')
@@ -145,7 +147,7 @@ def create_venv():
         sys_site = []
 
     command = ['pyvenv'] + sys_site
-    if g_args.clear:
+    if g_args.clear or g_args.force:
         command += ['--clear']
     if g_args.upgrade:
         command += ['--upgrade']


### PR DESCRIPTION
--force was replaced in favor of --clear and --upgrade which
correspond to the respective pyvenv options. The pyvenv help is
not explicit on the behavior if --clear is not given but the path
exists. https://docs.python.org/3/library/venv.html states pyvenv
would fail in that case, but it does not with Python 3.4.2, which
I don't consider a problem however.
Added a newline here and there for better readability.

note: check_exists was removed because normally a missing
--clear should make pyvenv fail, but it doesn't on my system.
The behavior is fine however, in my opinion, please test.