### PR TITLE
toggle boolean with :set & 'permanent' tab bar unconditionally

### DIFF
--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -209,7 +209,6 @@ class ConfigManager(QObject):
         ('colors', 'tab.indicator.stop'): 'tabs.indicator.stop',
         ('colors', 'tab.indicator.error'): 'tabs.indicator.error',
         ('colors', 'tab.indicator.system'): 'tabs.indicator.system',
-        ('tabs', 'always-hide'): 'hide-always',
         ('tabs', 'auto-hide'): 'hide-auto',
     }
     DELETED_OPTIONS = [

--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -528,10 +528,10 @@ class ConfigManager(QObject):
             elif optname.endswith('!'):
                 val = self.get(sectname, optname[:-1])
                 layer = 'temp' if temp else 'conf'
-                if type(val) == type(True):
+                if isinstance(val, bool):
                     self.set(layer, sectname, optname[:-1], str(not val))
                 else:
-                    raise cmdexc.CommandError("set: Attempted inversion of non-boolean value. Aborting.")
+                    raise cmdexc.CommandError("set: Attempted inversion of non-boolean value.")
             else:
                 if value is None:
                     raise cmdexc.CommandError("set: The following arguments "

--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -499,6 +499,8 @@ class ConfigManager(QObject):
         If the option name ends with '?', the value of the option is shown
         instead.
 
+        If the option name ends with '!' and it is a boolean value, toggle it.
+
         //
 
         Wrapper for self.set() to output exceptions in the status bar.
@@ -523,6 +525,13 @@ class ConfigManager(QObject):
                 val = self.get(sectname, optname[:-1], transformed=False)
                 message.info(win_id, "{} {} = {}".format(
                     sectname, optname[:-1], val), immediately=True)
+            elif optname.endswith('!'):
+                val = self.get(sectname, optname[:-1])
+                layer = 'temp' if temp else 'conf'
+                if type(val) == type(True):
+                    self.set(layer, sectname, optname[:-1], str(not val))
+                else:
+                    raise cmdexc.CommandError("set: Attempted inversion of non-boolean value. Aborting.")
             else:
                 if value is None:
                     raise cmdexc.CommandError("set: The following arguments "

--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -209,6 +209,8 @@ class ConfigManager(QObject):
         ('colors', 'tab.indicator.stop'): 'tabs.indicator.stop',
         ('colors', 'tab.indicator.error'): 'tabs.indicator.error',
         ('colors', 'tab.indicator.system'): 'tabs.indicator.system',
+        ('tabs', 'always-hide'): 'hide-always',
+        ('tabs', 'auto-hide'): 'hide-auto',
     }
     DELETED_OPTIONS = [
         ('colors', 'tab.seperator'),

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -356,11 +356,11 @@ DATA = collections.OrderedDict([
          SettingValue(typ.LastClose(), 'ignore'),
          "Behaviour when the last tab is closed."),
 
-        ('auto-hide',
+        ('hide-auto',
          SettingValue(typ.Bool(), 'false'),
          "Hide the tabbar if only one tab is open."),
 
-        ('always-hide',
+        ('hide-always',
          SettingValue(typ.Bool(), 'false'),
          "Always hide the tabbar."),
 

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -360,9 +360,9 @@ DATA = collections.OrderedDict([
          SettingValue(typ.Bool(), 'false'),
          "Hide the tabbar if only one tab is open."),
 
-        ('perm-hide',
+        ('always-hide',
          SettingValue(typ.Bool(), 'false'),
-         "Hide permanently."),
+         "Always hide the tabbar."),
 
         ('wrap',
          SettingValue(typ.Bool(), 'true'),

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -360,6 +360,10 @@ DATA = collections.OrderedDict([
          SettingValue(typ.Bool(), 'false'),
          "Hide the tabbar if only one tab is open."),
 
+        ('perm-hide',
+         SettingValue(typ.Bool(), 'false'),
+         "Hide permanently."),
+
         ('wrap',
          SettingValue(typ.Bool(), 'true'),
          "Whether to wrap when changing tabs."),

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -120,7 +120,6 @@ class TabBar(QTabBar):
         else:
             self.show()
 
-
     def refresh(self):
         """Properly repaint the tab bar and relayout tabs."""
         # This is a horrible hack, but we need to do this so the underlaying Qt

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -102,12 +102,12 @@ class TabBar(QTabBar):
     def __repr__(self):
         return utils.get_repr(self, count=self.count())
 
-    @config.change_filter('tabs', 'auto-hide')
+    @config.change_filter('tabs', 'hide-auto')
     def autohide(self):
         """Auto-hide the tabbar if needed."""
-        auto_hide = config.get('tabs', 'auto-hide')
-        always_hide = config.get('tabs', 'always-hide')
-        if always_hide or auto_hide and self.count() == 1:
+        hide_auto = config.get('tabs', 'hide-auto')
+        hide_always = config.get('tabs', 'hide-always')
+        if hide_always or hide_auto and self.count() == 1:
             self.hide()
         else:
             self.show()

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -97,6 +97,7 @@ class TabBar(QTabBar):
         config_obj.changed.connect(self.set_colors)
         QTimer.singleShot(0, self.autohide)
         config_obj.changed.connect(self.autohide)
+        config_obj.changed.connect(self.alwayshide)
         config_obj.changed.connect(self.on_tab_colors_changed)
 
     def __repr__(self):
@@ -104,13 +105,22 @@ class TabBar(QTabBar):
 
     @config.change_filter('tabs', 'hide-auto')
     def autohide(self):
+        self.tabhide()
+        
+    @config.change_filter('tabs', 'hide-always')
+    def alwayshide(self):
+        self.tabhide()
+
+    def tabhide(self):
         """Auto-hide the tabbar if needed."""
         hide_auto = config.get('tabs', 'hide-auto')
         hide_always = config.get('tabs', 'hide-always')
+        print('draw')
         if hide_always or hide_auto and self.count() == 1:
             self.hide()
         else:
             self.show()
+
 
     def refresh(self):
         """Properly repaint the tab bar and relayout tabs."""

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -106,7 +106,8 @@ class TabBar(QTabBar):
     def autohide(self):
         """Auto-hide the tabbar if needed."""
         auto_hide = config.get('tabs', 'auto-hide')
-        if auto_hide and self.count() == 1:
+        perm_hide = config.get('tabs', 'perm-hide')
+        if perm_hide or auto_hide and self.count() == 1:
             self.hide()
         else:
             self.show()

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -115,7 +115,6 @@ class TabBar(QTabBar):
         """Auto-hide the tabbar if needed."""
         hide_auto = config.get('tabs', 'hide-auto')
         hide_always = config.get('tabs', 'hide-always')
-        print('draw')
         if hide_always or hide_auto and self.count() == 1:
             self.hide()
         else:

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -106,8 +106,8 @@ class TabBar(QTabBar):
     def autohide(self):
         """Auto-hide the tabbar if needed."""
         auto_hide = config.get('tabs', 'auto-hide')
-        perm_hide = config.get('tabs', 'perm-hide')
-        if perm_hide or auto_hide and self.count() == 1:
+        always_hide = config.get('tabs', 'always-hide')
+        if always_hide or auto_hide and self.count() == 1:
             self.hide()
         else:
             self.show()


### PR DESCRIPTION
I already committed this, but as per certain things expressed in IRC, I decided to resubmit it after changing small formatting things and splitting it into 'one commit per feature' :)

You may now toggle boolean values with the `:set` command by appending an exclamation point to the option name (ex: `:set tab auto-hide!`). You may also entirely disable the tab bar with the `tab perm-hide` variable.