### PR TITLE
Download filename handling

### DIFF
--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -38,6 +38,7 @@ from qutebrowser.config import config
 from qutebrowser.commands import cmdexc, cmdutils
 from qutebrowser.utils import (message, usertypes, log, utils, urlutils,
                                objreg, standarddir, qtutils)
+from qutebrowser.browser import http
 from qutebrowser.browser.network import networkmanager
 
 
@@ -723,6 +724,8 @@ class DownloadManager(QAbstractListModel):
                 suggested_filename = os.path.basename(filename)
             elif fileobj is not None and getattr(fileobj, 'name', None):
                 suggested_filename = fileobj.name
+            else:
+                _, suggested_filename = http.parse_content_disposition(reply)
         log.downloads.debug("fetch: {} -> {}".format(reply.url(),
                                                      suggested_filename))
         download = DownloadItem(reply, self._win_id, self)

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -65,7 +65,8 @@ def _path_suggestion(filename):
     """
     suggestion = config.get('completion', 'download-path-suggestion')
     if suggestion == 'path':
-        return _download_dir() + os.sep
+        # add trailing '/' if not present
+        return os.path.join(_download_dir(), '')
     elif suggestion == 'filename':
         return filename
     elif suggestion == 'both':

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -289,7 +289,7 @@ class DownloadItem(QObject):
         download_dir = config.get('storage', 'download-directory')
         if download_dir is None:
             download_dir = standarddir.get(QStandardPaths.DownloadLocation)
-        return download_dir + os.sep
+        return download_dir
 
     def _die(self, msg):
         """Abort the download and emit an error."""
@@ -375,11 +375,13 @@ class DownloadItem(QObject):
         """Get the suggestion of file path"""
         suggestion = config.get('completion', 'download-path-suggestion')
         if suggestion == 'path':
-            return self._download_dir()
+            return self._download_dir() + os.sep
         elif suggestion == 'filename':
             return self.basename
-        else:
+        elif suggestion == 'both':
             return os.path.join(self._download_dir(), self.basename)
+        else:
+            raise ValueError("Invalid suggestion value {}!".format(suggestion))
 
     def delete(self):
         """Delete the downloaded file"""

--- a/qutebrowser/browser/webpage.py
+++ b/qutebrowser/browser/webpage.py
@@ -280,12 +280,13 @@ class BrowserPage(QWebPage):
         At some point we might want to implement the MIME Sniffing standard
         here: http://mimesniff.spec.whatwg.org/
         """
-        inline, _suggested_filename = http.parse_content_disposition(reply)
+        inline, suggested_filename = http.parse_content_disposition(reply)
         download_manager = objreg.get('download-manager', scope='window',
                                       window=self._win_id)
         if not inline:
             # Content-Disposition: attachment -> force download
-            download_manager.fetch(reply)
+            download_manager.fetch(reply,
+                                   suggested_filename=suggested_filename)
             return
         mimetype, _rest = http.parse_content_type(reply)
         if mimetype == 'image/jpg':
@@ -300,7 +301,8 @@ class BrowserPage(QWebPage):
                     self.display_content, reply, 'image/jpeg'))
         else:
             # Unknown mimetype, so download anyways.
-            download_manager.fetch(reply)
+            download_manager.fetch(reply,
+                                   suggested_filename=suggested_filename)
 
     @pyqtSlot()
     def on_load_started(self):

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -305,6 +305,10 @@ DATA = collections.OrderedDict([
     )),
 
     ('completion', sect.KeyValue(
+        ('download-path-suggestion',
+         SettingValue(typ.DownloadPath(), 'path'),
+         "What to show in the suggestion for the download question."),
+
         ('show',
          SettingValue(typ.Bool(), 'true'),
          "Whether to show the autocompletion window."),

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -306,8 +306,8 @@ DATA = collections.OrderedDict([
 
     ('completion', sect.KeyValue(
         ('download-path-suggestion',
-         SettingValue(typ.DownloadPath(), 'path'),
-         "What to show in the suggestion for the download question."),
+         SettingValue(typ.DownloadPathSuggestion(), 'path'),
+         "What to display in the download filename input."),
 
         ('show',
          SettingValue(typ.Bool(), 'true'),

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1416,6 +1416,15 @@ class NewInstanceOpenTarget(BaseType):
                                ('window', "Open in a new window."))
 
 
+class DownloadPath(BaseType):
+
+    """How to format the question when downloading."""
+
+    valid_values = ValidValues(('path', "Show only the download path."),
+                               ('filename', "Show only download filename."),
+                               ('both', "Show download path and filename."))
+
+
 class UserAgent(BaseType):
 
     """The user agent to use."""

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1416,7 +1416,7 @@ class NewInstanceOpenTarget(BaseType):
                                ('window', "Open in a new window."))
 
 
-class DownloadPath(BaseType):
+class DownloadPathSuggestion(BaseType):
 
     """How to format the question when downloading."""
 


### PR DESCRIPTION
This should address issue #505.
If a directory is given as the second argument to the `:download` command there will be an error. I don't really know how to fix that in a nice way. But maybe that is the desired behaviour, as the documentation says you should give a file path.