### PR TITLE
multi instances with profiles (#519 POC)

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -108,11 +108,11 @@ class Application(QApplication):
             sys.exit(0)
 
         try:
-            sent = ipc.send_to_running_instance(self._args.command)
+            sent = ipc.send_to_running_instance(self._args.command, self._args.profile)
             if sent:
                 sys.exit(0)
             log.init.debug("Starting IPC server...")
-            ipc.init()
+            ipc.init(self._args.profile)
         except ipc.IPCError as e:
             text = ('{}\n\nMaybe another instance is running but '
                     'frozen?'.format(e))
@@ -249,7 +249,7 @@ class Application(QApplication):
     def _init_crashlogfile(self):
         """Start a new logfile and redirect faulthandler to it."""
         path = standarddir.get(QStandardPaths.DataLocation)
-        logname = os.path.join(path, 'crash.log')
+        logname = os.path.join(path, 'crash-%s.log' % self._args.profile)
         try:
             self._crashlogfile = open(logname, 'w', encoding='ascii')
         except OSError:

--- a/qutebrowser/qutebrowser.py
+++ b/qutebrowser/qutebrowser.py
@@ -53,6 +53,8 @@ def get_argparser():
                         "this session.", nargs=3, action='append',
                         dest='temp_settings', default=[],
                         metavar=('SECTION', 'OPTION', 'VALUE'))
+    parser.add_argument('-p', '--profile', help="Restore a named profile.",
+                        dest='profile', default='default')
     parser.add_argument('-r', '--restore', help="Restore a named session.",
                         dest='session', default='default')
 


### PR DESCRIPTION
This is a proof of concept for using multiple instances with profiles.

Lauching two instances with different profiles works:
```bash
qutebrowser &
qutebrowser -p test &
```

You can now open an new link in each of the instances with:
```bash
qutebrowser http://ddg.gg &              # will open in the default (first) instance
qutebrowser -p test http://example.com & # will open in the test (second) instance
```

Since these are separate instances I can set `WM_NAME` for each individually