### PR TITLE
Add url history completion for open.

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -280,7 +280,7 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', name='open',
                        maxsplit=0, scope='window',
-                       completion=[usertypes.Completion.web_history_by_url])
+                       completion=[usertypes.Completion.url_history_and_quickmarks])
     def openurl(self, url=None, bg=False, tab=False, window=False,
                 count: {'special': 'count'}=None):
         """Open a URL in the current/[count]th tab.

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -280,7 +280,7 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', name='open',
                        maxsplit=0, scope='window',
-                       completion=[usertypes.Completion.quickmark_by_url])
+                       completion=[usertypes.Completion.web_history_by_url])
     def openurl(self, url=None, bg=False, tab=False, window=False,
                 count: {'special': 'count'}=None):
         """Open a URL in the current/[count]th tab.

--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -68,7 +68,7 @@ class WebHistory(QWebHistoryInterface):
         _old_miss: How many times an URL was not found in _old_urls.
     """
 
-    changed = pyqtSignal()
+    item_added = pyqtSignal(HistoryEntry)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -89,7 +89,7 @@ class WebHistory(QWebHistoryInterface):
         self._old_hit = 0
         self._old_miss = 0
         objreg.get('save-manager').add_saveable(
-            'history', self.save, self.changed)
+            'history', self.save, self.item_added)
 
     def __repr__(self):
         return utils.get_repr(self, new_length=len(self._new_history))
@@ -122,7 +122,7 @@ class WebHistory(QWebHistoryInterface):
         if not config.get('general', 'private-browsing'):
             entry = HistoryEntry(time.time(), url_string)
             self._new_history.append(entry)
-            self.changed.emit()
+            self.item_added.emit(entry)
 
     def historyContains(self, url_string):
         """Called by WebKit to determine if an URL is contained in the history.

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -85,8 +85,8 @@ class Completer(QObject):
             models.CommandCompletionModel(self), self)
         self._models[usertypes.Completion.helptopic] = CFM(
             models.HelpCompletionModel(self), self)
-        self._models[usertypes.Completion.web_history_by_url] = CFM(
-            models.WebHistoryCompletionModel('url', self), self)
+        self._models[usertypes.Completion.url_history_and_quickmarks] = CFM(
+            models.UrlCompletionModel('url', self), self)
 
     def _init_setting_completions(self):
         """Initialize setting completion models."""

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -85,6 +85,8 @@ class Completer(QObject):
             models.CommandCompletionModel(self), self)
         self._models[usertypes.Completion.helptopic] = CFM(
             models.HelpCompletionModel(self), self)
+        self._models[usertypes.Completion.web_history_by_url] = CFM(
+            models.WebHistoryCompletionModel('url', self), self)
 
     def _init_setting_completions(self):
         """Initialize setting completion models."""

--- a/qutebrowser/completion/models/completion.py
+++ b/qutebrowser/completion/models/completion.py
@@ -215,6 +215,30 @@ class HelpCompletionModel(base.BaseCompletionModel):
                 self.new_item(cat, name, desc)
 
 
+class WebHistoryCompletionModel(base.BaseCompletionModel):
+
+    """A CompletionModel filled with global browsing history."""
+
+    # pylint: disable=abstract-method
+
+    def __init__(self, match_field='url', parent=None):
+        super().__init__(parent)
+
+        self.cat = self.new_category("History")
+        self.history = objreg.get('web-history')
+
+        for entry in self.history:
+            if entry.url:
+                self.new_item(self.cat, entry.url, "")
+
+        self.history.changed.connect(self.history_changed)
+
+    def history_changed(self):
+        # Assuming the web-history.changed signal is emitted once for each
+        # new history item and that signal handlers are run immediately.
+        if self.history._history[-1].url:
+            self.new_item(self.cat, self.history._history[-1].url, "")
+
 class QuickmarkCompletionModel(base.BaseCompletionModel):
 
     """A CompletionModel filled with all quickmarks."""

--- a/qutebrowser/completion/models/completion.py
+++ b/qutebrowser/completion/models/completion.py
@@ -230,9 +230,9 @@ class UrlCompletionModel(base.BaseCompletionModel):
         WebHistoryCompletionModel.fill_model(self, cat=self._histcat)
         QuickmarkCompletionModel.fill_model(self, cat=self._quickcat)
 
-        self._histstore.changed.connect(lambda :
+        self._histstore.item_added.connect(lambda e:
                                         WebHistoryCompletionModel.history_changed(
-                                            self, self._histcat, self._histstore))
+                                            self, e, self._histcat))
 
     def sort(self, column, order=Qt.AscendingOrder):
         # sort on atime, descending
@@ -255,9 +255,8 @@ class WebHistoryCompletionModel(base.BaseCompletionModel):
 
         self.fill_model(self, self._histcat, self._histstore)
 
-        self._histstore.changed.connect(lambda :
-                                        self.history_changed(self._histcat,
-                                                             self._histstore))
+        self._histstore.item_added.connect(lambda e:
+                                        self.history_changed(e, self._histcat))
 
     @staticmethod
     def fill_model(model, cat=None, histstore=None):
@@ -269,14 +268,9 @@ class WebHistoryCompletionModel(base.BaseCompletionModel):
         for entry in histstore:
             model.new_item(cat, entry.url, "", entry.atime)
 
-    def history_changed(self, cat, histstore=None):
-        if not histstore:
-            histstore = objreg.get('web-history')
-        # Assuming the web-history.changed signal is emitted once for each
-        # new history item and that signal handlers are run immediately.
-        if histstore._history[-1].url:
-            self.new_item(cat, histstore._history[-1].url, "",
-                         str(histstore._history[-1].atime))
+    def history_changed(self, entry, cat):
+        if entry.url:
+            self.new_item(cat, entry.url, "", str(entry.atime))
 
 class QuickmarkCompletionModel(base.BaseCompletionModel):
 

--- a/qutebrowser/completion/models/sortfilter.py
+++ b/qutebrowser/completion/models/sortfilter.py
@@ -129,6 +129,8 @@ class CompletionFilterModel(QSortFilterProxyModel):
         # TODO more sophisticated filtering
         if not self.pattern:
             return True
+        if not data:
+            return False
         return self.pattern.casefold() in data.casefold()
 
     def lessThan(self, lindex, rindex):

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -237,7 +237,8 @@ KeyMode = enum('KeyMode', ['normal', 'hint', 'command', 'yesno', 'prompt',
 # Available command completions
 Completion = enum('Completion', ['command', 'section', 'option', 'value',
                                  'helptopic', 'quickmark_by_url',
-                                 'quickmark_by_name', 'sessions'])
+                                 'quickmark_by_name', 'web_history_by_url',
+                                 'sessions'])
 
 
 class Question(QObject):

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -237,8 +237,8 @@ KeyMode = enum('KeyMode', ['normal', 'hint', 'command', 'yesno', 'prompt',
 # Available command completions
 Completion = enum('Completion', ['command', 'section', 'option', 'value',
                                  'helptopic', 'quickmark_by_url',
-                                 'quickmark_by_name', 'web_history_by_url',
-                                 'sessions'])
+                                 'quickmark_by_name',
+                                 'url_history_and_quickmarks', 'sessions'])
 
 
 class Question(QObject):


### PR DESCRIPTION
Add url history completion for open.

I mostly just copied this off of the quickmark completion. It probably
isn't done yet but I had some questions to raise. Also I see you have a
newhistory branch but can't see any conflicts on there yet.

I wanted to have the open command complete on history and on quickmarks
(well, I don't care about completing on quickmarks but I don't want to
break it). When commands are registered multiple completion models can
be passed in but it seems that only one of them is used. Is there any
way to chain completions or should I just create a new
OpenCommandCompletionModel or something which does both?

When the WebHistoryCompletionModel gets a history changed signal it just
pops off the most recent history to add to the completion model. I am
not sure how these signals are handled. Is it possible the history to be
appended to a second time before the signal gets handled? If so I will
either change it to walk backwards through history until it sees one it
has seen before or change the signal to a typed signal (I think these
are a thing) that passes the new history entry to the handlers.

Lastly there was a NoneType has no method casefold() exception being
thrown when using this new completion model and I don't know why that
wasn't showing up when using the quickmarks completion. To reproduce it
just remove the `if not data` check and try to open a new page by using
the open command and not selecting one of the completion options. I don't
know whether this is a bug I have caused or just exposed.

Lastly it would be nice to be able to complete based on page title too.
Since the QWebHistoryInterface API doesn't pass this information would
you consider adding history items at an appropriate stage of loading
from in qutebrowser? Like these guys did: https://git.reviewboard.kde.org/r/104257/diff/2/#1