### PR TITLE
Handle URLs with double-colon at the beginning as search strings

### DIFF
--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -193,7 +193,14 @@ def _has_explicit_scheme(url):
     Args:
         url: The URL as QUrl.
     """
-    return url.isValid() and url.scheme() and not url.path().startswith(' ')
+
+    # Note that generic URI syntax actually would allow a second colon
+    # after the scheme delimiter. Since we don't know of any URIs
+    # using this and want to support e.g. searching for scoped C++
+    # symbols, we treat this as not an URI anyways.
+    return (url.isValid() and url.scheme()
+            and not url.path().startswith(' ')
+            and not url.path().startswith(':'))
 
 
 def is_special_url(url):


### PR DESCRIPTION
Closes #544. We might also merge #542 now.