### PR TITLE
Histcomplete some fixes for #547

### DIFF
--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -99,8 +99,7 @@ class WebHistory(QWebHistoryInterface):
         return self._new_history[key]
 
     def __iter__(self):
-        return itertools.chain(self._old_urls.values(),
-                               iter(self._new_history))
+        return self._old_urls.values().__iter__()
 
     def get_recent(self):
         """Get the most recent history entries."""
@@ -123,6 +122,7 @@ class WebHistory(QWebHistoryInterface):
         if not config.get('general', 'private-browsing'):
             entry = HistoryEntry(time.time(), url_string)
             self._new_history.append(entry)
+            self._old_urls[url_string] = entry
             self.item_added.emit(entry)
 
     def historyContains(self, url_string):

--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -79,11 +79,11 @@ class WebHistory(QWebHistoryInterface):
         with self._lineparser.open():
             for line in self._lineparser:
                 atime, url = line.rstrip().split(maxsplit=1)
-                # This de-duplicates history entries. We keep later ones in the
-                # file which usually the last ones accessed. If you want
-                # to keep information about multiple hits change the
-                # items in old_urls to be lists or change HistoryEntry
-                # to have a list of atimes.
+                # This de-duplicates history entries; only the latest
+                # entry for each URL is kept. If you want to keep
+                # information about previous hits change the items in
+                # old_urls to be lists or change HistoryEntry to have a
+                # list of atimes.
                 self._old_urls[url] = HistoryEntry(atime, url)
         self._new_history = []
         self._saved_count = 0


### PR DESCRIPTION
Here's a couple of commits for the histcomplete branch. I cleaned up that confusing comment (which is there in case anyone goes looking for history stats like number if hits for some reason and wonders why we are throwing that info away, for now). And added some code to remove duplicates, both when iterating `WebHistory` and in the completion model.