### PR TITLE
More user-friendly link text matching.

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -833,7 +833,7 @@ class HintManager(QObject):
         for elems in self._context.elems.values():
             try:
                 if (filterstr is None or
-                        str(elems.elem).lower().startswith(filterstr)):
+                        filterstr.lower() in str(elems.elem).lower()):
                     if self._is_hidden(elems.label):
                         # hidden element which matches again -> unhide it
                         self._show_elem(elems.label)


### PR DESCRIPTION
Allow the user to type any part of the link text when filtering down the
links, not just the start of the text. The start is often obscured by a
hint, or begins with a number making it impossible to select.

Also allow for uppercase characters when filtering. Previously any
uppercase character would abort matching.