### PR TITLE
Add setting to enable/disable mousewheel tab switching. See #374

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -111,6 +111,7 @@
 |<<tabs-indicator-space,indicator-space>>|Spacing between tab edge and indicator.
 |<<tabs-tabs-are-windows,tabs-are-windows>>|Whether to open windows instead of tabs.
 |<<tabs-title-format,title-format>>|The format to use for the tab title. The following placeholders are defined:
+|<<tabs-mousewheel-tab-switching,mousewheel-tab-switching>>|Switch between tabs using the mouse wheel.
 |==============
 
 .Quick reference for section ``storage''
@@ -1030,6 +1031,17 @@ The format to use for the tab title. The following placeholders are defined:
 * `{id}`: The internal tab ID of this tab.
 
 Default: +pass:[{index}: {title}]+
+
+[[tabs-mousewheel-tab-switching]]
+=== mousewheel-tab-switching
+Switch between tabs using the mouse wheel.
+
+Valid values:
+
+ * +true+
+ * +false+
+
+Default: +pass:[true]+
 
 == storage
 Settings related to cache and storage.

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -522,6 +522,10 @@ def data(readonly=False):
              "* `{index}`: The index of this tab.\n"
              "* `{id}`: The internal tab ID of this tab."),
 
+            ('mousewheel-tab-switching',
+             SettingValue(typ.Bool(), 'true'),
+             "Switch between tabs using the mouse wheel."),
+
             readonly=readonly
         )),
 

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -586,3 +586,5 @@ class TabbedBrowser(tabwidget.TabWidget):
         """
         if self._now_focused is not None:
             self._now_focused.wheelEvent(e)
+        else:
+            e.ignore()

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -577,3 +577,12 @@ class TabbedBrowser(tabwidget.TabWidget):
         """
         super().resizeEvent(e)
         self.resized.emit(self.geometry())
+
+    def wheelEvent(self, e):
+        """Override wheelEvent of QWidget to forward it to the focused tab.
+
+        Args:
+            e: The QWheelEvent
+        """
+        if self._now_focused is not None:
+            self._now_focused.wheelEvent(e)

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -480,16 +480,18 @@ class TabBar(QTabBar):
             new_idx = super().insertTab(idx, icon, '')
         self.set_page_title(new_idx, text)
 
-    def wheelEvent(self, event):
-        """Override wheelEvent to make the action configurable."""
+    def wheelEvent(self, e):
+        """Override wheelEvent to make the action configurable.
+
+        Args:
+            e: The QWheelEvent
+        """
         if config.get('tabs', 'mousewheel-tab-switching'):
-            super().wheelEvent(event)
+            super().wheelEvent(e)
         else:
             tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                         window=self._win_id)
-            focused_tab = tabbed_browser.currentWidget()
-            if focused_tab is not None:
-                focused_tab.wheelEvent(event)
+            tabbed_browser.wheelEvent(e)
 
 
 class TabBarStyle(QCommonStyle):

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -480,6 +480,17 @@ class TabBar(QTabBar):
             new_idx = super().insertTab(idx, icon, '')
         self.set_page_title(new_idx, text)
 
+    def wheelEvent(self, event):
+        """Override wheelEvent to make the action configurable."""
+        if config.get('tabs', 'mousewheel-tab-switching'):
+            super().wheelEvent(event)
+        else:
+            tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                        window=self._win_id)
+            focused_tab = tabbed_browser.currentWidget()
+            if focused_tab is not None:
+                focused_tab.wheelEvent(event)
+
 
 class TabBarStyle(QCommonStyle):
 


### PR DESCRIPTION
When the setting is set to true (as by default), nothing changes and the mousewheel can be used for switching between tabs.
When it is disabled, the scroll event does not switch between tabs but is forwarded to the currently focused tab.

Feedback is appreciated. :)