### PR TITLE
Add navigate option to scroll_page()

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -657,6 +657,9 @@ class CommandDispatcher:
             count: multiplier
         """
         frame = self._current_widget().page().currentFrame()
+        if not frame.url().isValid() == '':  # Issue 701
+            return
+
         if (bottom_navigate is not None and
                 frame.scrollPosition().y() >=
                 frame.scrollBarMaximum(Qt.Vertical)):

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -657,7 +657,7 @@ class CommandDispatcher:
             count: multiplier
         """
         frame = self._current_widget().page().currentFrame()
-        if not frame.url().isValid() == '':  # Issue 701
+        if not frame.url().isValid():  # Issue 701
             return
 
         if (bottom_navigate is not None and

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -643,14 +643,23 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', hide=True,
                        scope='window', count='count')
-    def scroll_page(self, x: {'type': float}, y: {'type': float}, count=1):
+    def scroll_page(self, x: {'type': float}, y: {'type': float},
+            navigate=None, count=1):
         """Scroll the frame page-wise.
 
         Args:
             x: How many pages to scroll to the right.
             y: How many pages to scroll down.
+            navigate: :navigate to the next page on bottom
             count: multiplier
         """
+        frame = self._current_widget().page().currentFrame()
+        if (navigate is not None and
+                frame.scrollPosition().y() >=
+                frame.scrollBarMaximum(Qt.Vertical)):
+            self.navigate(navigate)
+            return
+
         mult_x = count * x
         mult_y = count * y
         if mult_y.is_integer():
@@ -663,7 +672,6 @@ class CommandDispatcher:
             mult_y = 0
         if mult_x == 0 and mult_y == 0:
             return
-        frame = self._current_widget().page().currentFrame()
         size = frame.geometry()
         dx = mult_x * size.width()
         dy = mult_y * size.height()

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -643,21 +643,27 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', hide=True,
                        scope='window', count='count')
-    def scroll_page(self, x: {'type': float}, y: {'type': float},
-            navigate=None, count=1):
+    def scroll_page(self, x: {'type': float}, y: {'type': float}, *,
+                    top_navigate: {'type': ('prev', 'decrement')}=None,
+                    bottom_navigate: {'type': ('next', 'increment')}=None,
+                    count=1):
         """Scroll the frame page-wise.
 
         Args:
             x: How many pages to scroll to the right.
             y: How many pages to scroll down.
-            navigate: :navigate to the next page on bottom
+            bottom_navigate: :navigate to the next page on bottom
+            top_navigate: :navigate to the previous page on top
             count: multiplier
         """
         frame = self._current_widget().page().currentFrame()
-        if (navigate is not None and
+        if (bottom_navigate is not None and
                 frame.scrollPosition().y() >=
                 frame.scrollBarMaximum(Qt.Vertical)):
-            self.navigate(navigate)
+            self.navigate(bottom_navigate)
+            return
+        elif top_navigate is not None and frame.scrollPosition().y() == 0:
+            self.navigate(top_navigate)
             return
 
         mult_x = count * x


### PR DESCRIPTION
So you can scroll down & navigate when you're at the bottom.

To bind this to space:

    scroll-page --navigate next 0 1
        <Space>


Not sure if it's a good idea to bind this by default? May surprise some
people...

See #696