### PR TITLE
Add ui.modal-js-dialog to restore the default JS dialogs

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -45,6 +45,7 @@
 |<<ui-hide-statusbar,hide-statusbar>>|Whether to hide the statusbar unless a message is shown.
 |<<ui-window-title-format,window-title-format>>|The format to use for the window title. The following placeholders are defined:
 |<<ui-hide-mouse-cursor,hide-mouse-cursor>>|Whether to hide the mouse cursor.
+|<<ui-model-js-dialog,modal-js-dialog>>|Use standard JavaScript modal dialog for alert() and confirm()
 |==============
 
 .Quick reference for section ``network''

--- a/qutebrowser/browser/webpage.py
+++ b/qutebrowser/browser/webpage.py
@@ -481,6 +481,9 @@ class BrowserPage(QWebPage):
     def javaScriptAlert(self, _frame, msg):
         """Override javaScriptAlert to use the statusbar."""
         log.js.debug("alert: {}".format(msg))
+        if config.get('ui', 'modal-js-dialog'):
+            return super().javaScriptAlert(_frame, msg)
+
         if (self._is_shutting_down or
                 config.get('content', 'ignore-javascript-alert')):
             return
@@ -489,6 +492,9 @@ class BrowserPage(QWebPage):
     def javaScriptConfirm(self, _frame, msg):
         """Override javaScriptConfirm to use the statusbar."""
         log.js.debug("confirm: {}".format(msg))
+        if config.get('ui', 'modal-js-dialog'):
+            return super().javaScriptConfirm(_frame, msg)
+
         if self._is_shutting_down:
             return False
         ans = self._ask("[js confirm] {}".format(msg),

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -305,6 +305,10 @@ def data(readonly=False):
              SettingValue(typ.Bool(), 'false'),
              "Whether to hide the mouse cursor."),
 
+            ('modal-js-dialog',
+             SettingValue(typ.Bool(), 'false'),
+             "Use standard JavaScript modal dialog for alert() and confirm()"),
+
             readonly=readonly
         )),
 


### PR DESCRIPTION
I got too annoyed with the messages in the statusline ... :-/