### PR TITLE
Add setting: 'content.third-party-cookie-policy', fixes #607

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -151,6 +151,7 @@
 |<<content-local-content-can-access-file-urls,local-content-can-access-file-urls>>|Whether locally loaded documents are allowed to access other local urls.
 |<<content-cookies-accept,cookies-accept>>|Whether to accept cookies.
 |<<content-cookies-store,cookies-store>>|Whether to store cookies.
+|<<content-third-party-cookie-policy,third-party-cookie-policy>>|Accept cookies from domains other than the main website
 |<<content-host-block-lists,host-block-lists>>|List of URLs of lists which contain hosts to block.
 |<<content-host-blocking-enabled,host-blocking-enabled>>|Whether host blocking is enabled.
 |==============
@@ -1335,6 +1336,18 @@ Valid values:
  * +false+
 
 Default: +pass:[true]+
+
+[[content-third-party-cookie-policy]]
+=== third-party-cookie-policy
+Accept cookies from domains other than the main website
+
+Valid values:
+
+ * +always+: Always accept.
+ * +never+: Never accept.
+ * +existing+: Only accept if we already have acookie stored for the domain
+
+Default: +pass:[never]+
 
 [[content-host-block-lists]]
 === host-block-lists

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -149,9 +149,8 @@
 |<<content-ignore-javascript-alert,ignore-javascript-alert>>|Whether all javascript alerts should be ignored.
 |<<content-local-content-can-access-remote-urls,local-content-can-access-remote-urls>>|Whether locally loaded documents are allowed to access remote urls.
 |<<content-local-content-can-access-file-urls,local-content-can-access-file-urls>>|Whether locally loaded documents are allowed to access other local urls.
-|<<content-cookies-accept,cookies-accept>>|Whether to accept cookies.
+|<<content-cookies-accept,cookies-accept>>|Control which cookies to accept.
 |<<content-cookies-store,cookies-store>>|Whether to store cookies.
-|<<content-third-party-cookie-policy,third-party-cookie-policy>>|Accept cookies from domains other than the main website
 |<<content-host-block-lists,host-block-lists>>|List of URLs of lists which contain hosts to block.
 |<<content-host-blocking-enabled,host-blocking-enabled>>|Whether host blocking is enabled.
 |==============
@@ -1317,14 +1316,16 @@ Default: +pass:[true]+
 
 [[content-cookies-accept]]
 === cookies-accept
-Whether to accept cookies.
+Control which cookies to accept.
 
 Valid values:
 
- * +default+: Default QtWebKit behavior.
+ * +all+: Accept all cookies.
+ * +no-3rdparty+: Accept cookies from the same origin only.
+ * +no-unknown-3rdparty+: Accept cookies from the same origin only, unless a cookie is already set for the domain.
  * +never+: Don't accept cookies at all.
 
-Default: +pass:[default]+
+Default: +pass:[no-3rdparty]+
 
 [[content-cookies-store]]
 === cookies-store
@@ -1336,18 +1337,6 @@ Valid values:
  * +false+
 
 Default: +pass:[true]+
-
-[[content-third-party-cookie-policy]]
-=== third-party-cookie-policy
-Accept cookies from domains other than the main website
-
-Valid values:
-
- * +always+: Always accept.
- * +never+: Never accept.
- * +existing+: Only accept if we already have acookie stored for the domain
-
-Default: +pass:[never]+
 
 [[content-host-block-lists]]
 === host-block-lists

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -674,16 +674,12 @@ def data(readonly=False):
              "local urls."),
 
             ('cookies-accept',
-             SettingValue(typ.AcceptCookies(), 'default'),
-             "Whether to accept cookies."),
+             SettingValue(typ.AcceptCookies(), 'no-3rdparty'),
+             "Control which cookies to accept."),
 
             ('cookies-store',
              SettingValue(typ.Bool(), 'true'),
              "Whether to store cookies."),
-
-            ('third-party-cookie-policy',
-             SettingValue(typ.ThirdPartyCookiePolicy(), 'never'),
-             "Accept cookies from domains other than the main website"),
 
             ('host-block-lists',
              SettingValue(

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -681,6 +681,10 @@ def data(readonly=False):
              SettingValue(typ.Bool(), 'true'),
              "Whether to store cookies."),
 
+            ('third-party-cookie-policy',
+             SettingValue(typ.ThirdPartyCookiePolicy(), 'never'),
+             "Accept cookies from domains other than the main website"),
+
             ('host-block-lists',
              SettingValue(
                  typ.UrlList(none_ok=True),

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1323,20 +1323,15 @@ class LastClose(BaseType):
 
 class AcceptCookies(BaseType):
 
-    """Whether to accept a cookie."""
+    """Control which cookies to accept."""
 
-    valid_values = ValidValues(('default', "Default QtWebKit behavior."),
+    valid_values = ValidValues(('all', "Accept all cookies."),
+                               ('no-3rdparty', "Accept cookies from the same"
+                                " origin only."),
+                               ('no-unknown-3rdparty', "Accept cookies from "
+                                "the same origin only, unless a cookie is "
+                                "already set for the domain."),
                                ('never', "Don't accept cookies at all."))
-
-
-class ThirdPartyCookiePolicy(BaseType):
-
-    """Accept cookies from domains other than the main website."""
-
-    valid_values = ValidValues(('always', "Always accept."),
-                               ('never', "Never accept."),
-                               ('existing', "Only accept if we already have a"
-                                   "cookie stored for the domain."))
 
 
 class ConfirmQuit(List):

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1329,6 +1329,16 @@ class AcceptCookies(BaseType):
                                ('never', "Don't accept cookies at all."))
 
 
+class ThirdPartyCookiePolicy(BaseType):
+
+    """Accept cookies from domains other than the main website."""
+
+    valid_values = ValidValues(('always', "Always accept."),
+                               ('never', "Never accept."),
+                               ('existing', "Only accept if we already have a"
+                                   "cookie stored for the domain."))
+
+
 class ConfirmQuit(List):
 
     """Whether to display a confirmation when the window is closed."""

--- a/qutebrowser/config/websettings.py
+++ b/qutebrowser/config/websettings.py
@@ -238,23 +238,23 @@ class GlobalSetter(Setter):
         self._setter(*args)
 
 
-class ThirdPartyCookies(Base):
+class CookiePolicy(Base):
 
     """The ThirdPartyCookiePolicy setting is different from other settings."""
 
-    mapping = (
-        ('always', QWebSettings.AlwaysAllowThirdPartyCookies),
-        ('never', QWebSettings.AlwaysBlockThirdPartyCookies),
-        ('existing', QWebSettings.AllowThirdPartyWithExistingCookies),
-    )
+    MAPPING = {
+        'all': QWebSettings.AlwaysAllowThirdPartyCookies,
+        'no-3rdparty': QWebSettings.AlwaysBlockThirdPartyCookies,
+        'never': QWebSettings.AlwaysBlockThirdPartyCookies,
+        'no-unknown-3rdparty': QWebSettings.AllowThirdPartyWithExistingCookies,
+    }
 
     def get(self, qws=None):
-        policy = QWebSettings.globalSettings().thirdPartyCookiePolicy()
-        return tuple(filter(lambda i: i[1] == policy, self.mapping))[0][0]
+        return config.get('content', 'cookies-accept')
 
     def _set(self, value, qws=None):
-        x = filter(lambda i: i[0] == value, self.mapping)
-        QWebSettings.globalSettings().setThirdPartyCookiePolicy(tuple(x)[0][1])
+        QWebSettings.globalSettings().setThirdPartyCookiePolicy(
+            self.MAPPING[value])
 
 
 MAPPINGS = {
@@ -283,8 +283,8 @@ MAPPINGS = {
             Attribute(QWebSettings.LocalContentCanAccessRemoteUrls),
         'local-content-can-access-file-urls':
             Attribute(QWebSettings.LocalContentCanAccessFileUrls),
-        'third-party-cookie-policy':
-            ThirdPartyCookies(),
+        'cookies-accept':
+            CookiePolicy(),
     },
     'network': {
         'dns-prefetch':

--- a/qutebrowser/config/websettings.py
+++ b/qutebrowser/config/websettings.py
@@ -238,6 +238,25 @@ class GlobalSetter(Setter):
         self._setter(*args)
 
 
+class ThirdPartyCookies(Base):
+
+    """The ThirdPartyCookiePolicy setting is different from other settings."""
+
+    mapping = (
+        ('always', QWebSettings.AlwaysAllowThirdPartyCookies),
+        ('never', QWebSettings.AlwaysBlockThirdPartyCookies),
+        ('existing', QWebSettings.AllowThirdPartyWithExistingCookies),
+    )
+
+    def get(self, qws=None):
+        policy = QWebSettings.globalSettings().thirdPartyCookiePolicy()
+        return tuple(filter(lambda i: i[1] == policy, self.mapping))[0][0]
+
+    def _set(self, value, qws=None):
+        x = filter(lambda i: i[0] == value, self.mapping)
+        QWebSettings.globalSettings().setThirdPartyCookiePolicy(tuple(x)[0][1])
+
+
 MAPPINGS = {
     'content': {
         'allow-images':
@@ -264,6 +283,8 @@ MAPPINGS = {
             Attribute(QWebSettings.LocalContentCanAccessRemoteUrls),
         'local-content-can-access-file-urls':
             Attribute(QWebSettings.LocalContentCanAccessFileUrls),
+        'third-party-cookie-policy':
+            ThirdPartyCookies(),
     },
     'network': {
         'dns-prefetch':


### PR DESCRIPTION
This sets the third-party cookie policy.

- I created a new ThirdPartyCookiePolicy() class, since this setting seems to be
  unique in the way it is set...

- I set the default to 'never', which is the most secure/private setting, but
  *may* break *some* features of a (very) limited number of sites; these are
  usually "non-critical" features.
  For example, on Stack Exchange sites you're logged in all 200+ sites if you
  sign in on one of them, this features required 3rd party cookies. You can
  still sign in with out, but you have to do so 200+ times (this is actually the
  only example I've ever noticed).

  AFAIK all "major" browsers accept 3rd-party cookies by default, except for
  Safari. Firefox also made this change, but reversed it (see:
  https://brendaneich.com/2013/05/c-is-for-cookie/), but they don't offer any
  good arguments to *not* have it IMHO, at least not that I could find.

  In any case, in my humble opinion "secure and private by default" is the best
  way to ship. But you're of course free to change it if you disagree ;-)