### PR TITLE
Add --domain to yank to yank only the domain

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -649,7 +649,7 @@ Yank the current URL/title to the clipboard or primary selection.
 ==== optional arguments
 * +*-t*+, +*--title*+: Yank the title instead of the URL.
 * +*-s*+, +*--sel*+: Use the primary selection instead of the clipboard.
-* +*-d*+, +*--domain*+: Yank only the scheme & domain.
+* +*-d*+, +*--domain*+: Yank only the scheme, domain, and port number.
 
 [[zoom]]
 === zoom

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -642,13 +642,14 @@ Save open pages and quit.
 
 [[yank]]
 === yank
-Syntax: +:yank [*--title*] [*--sel*]+
+Syntax: +:yank [*--title*] [*--sel*] [*--domain*]+
 
 Yank the current URL/title to the clipboard or primary selection.
 
 ==== optional arguments
 * +*-t*+, +*--title*+: Yank the title instead of the URL.
 * +*-s*+, +*--sel*+: Use the primary selection instead of the clipboard.
+* +*-d*+, +*--domain*+: Yank only the scheme & domain.
 
 [[zoom]]
 === zoom

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -696,19 +696,26 @@ class CommandDispatcher:
         frame.scroll(dx, dy)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    def yank(self, title=False, sel=False):
+    def yank(self, title=False, sel=False, domain=False):
         """Yank the current URL/title to the clipboard or primary selection.
 
         Args:
             sel: Use the primary selection instead of the clipboard.
             title: Yank the title instead of the URL.
+            domain: Yank only the scheme & domain.
         """
         clipboard = QApplication.clipboard()
         if title:
             s = self._tabbed_browser.page_title(self._current_index())
+            what = 'title'
+        elif domain:
+            s = '{}://{}'.format(self._current_url().scheme(),
+                                 self._current_url().host())
+            what = 'domain'
         else:
             s = self._current_url().toString(
                 QUrl.FullyEncoded | QUrl.RemovePassword)
+            what = 'URL'
         if sel and clipboard.supportsSelection():
             mode = QClipboard.Selection
             target = "primary selection"
@@ -717,8 +724,8 @@ class CommandDispatcher:
             target = "clipboard"
         log.misc.debug("Yanking to {}: '{}'".format(target, s))
         clipboard.setText(s, mode)
-        what = 'Title' if title else 'URL'
-        message.info(self._win_id, "{} yanked to {}".format(what, target))
+        message.info(self._win_id, "Yanked {} to {}: {}".format(
+                     what, target, s))
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        count='count')

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -702,15 +702,17 @@ class CommandDispatcher:
         Args:
             sel: Use the primary selection instead of the clipboard.
             title: Yank the title instead of the URL.
-            domain: Yank only the scheme & domain.
+            domain: Yank only the scheme, domain, and port number.
         """
         clipboard = QApplication.clipboard()
         if title:
             s = self._tabbed_browser.page_title(self._current_index())
             what = 'title'
         elif domain:
-            s = '{}://{}'.format(self._current_url().scheme(),
-                                 self._current_url().host())
+            port = self._current_url().port()
+            s = '{}://{}{}'.format(self._current_url().scheme(),
+                                   self._current_url().host(),
+                                   ':' + str(port) if port > -1 else '')
             what = 'domain'
         else:
             s = self._current_url().toString(

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -1204,6 +1204,8 @@ KEY_DATA = collections.OrderedDict([
         ('yank -s', ['yY']),
         ('yank -t', ['yt']),
         ('yank -ts', ['yT']),
+        ('yank -d', ['yd']),
+        ('yank -ds', ['yD']),
         ('paste', ['pp']),
         ('paste -s', ['pP']),
         ('paste -t', ['Pp']),


### PR DESCRIPTION
... As I want to copy only the domain fairly frequently.

I also changed the message in the statusline to show the actual text being
copied, which I find helpful. But if you disagree, then just undo it (it's not
that important or anything).