### PR TITLE
Use less CPU when downloading files

### DIFF
--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -148,7 +148,7 @@ class DownloadItemStats(QObject):
 
     @pyqtSlot(int, int)
     def on_download_progress(self, bytes_done, bytes_total):
-        """Upload local variables when the download progress changed.
+        """Update local variables when the download progress changed.
 
         Args:
             bytes_done: How many bytes are downloaded.
@@ -158,7 +158,6 @@ class DownloadItemStats(QObject):
             bytes_total = None
         self.done = bytes_done
         self.total = bytes_total
-        self.updated.emit()
 
 
 class DownloadItem(QObject):


### PR DESCRIPTION
When downloading a bunch (7 or 8) of files I noticed qutebrowser was using a lot
of CPU (>60%).

I did some looking, and in the `downloadProgress` callback qutebrower emits the
updated signal which causes everything to be updated. We don't really need this,
since _update_speed() calls it every 500ms anyway.

I tested by downloading 3 copies of the 1GB file [on this
page]( http://www.thinkbroadband.com/download.html ) qutebrowser consistently
pulls about 25% CPU on my system.

When removing this call, the system pulls about 17% CPU. Not a great amount, but
still significant enough to warrant a pull request ;-)

Some other notes:

- wget uses about 1.5%-2% for each process when downloading.
- When not doing any UI updates & speed calculations qutebrowser uses about 15%.
- Doing some quick profiling and strategic commenting seems to indicate there
  isn't any other low hanging fruit to be improved on here.