### PR TITLE
Favicon sizing is messed up with tabs -> orientation = west #847

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -309,13 +309,9 @@ class TabBar(QTabBar):
     def set_font(self):
         """Set the tab bar font."""
         self.setFont(config.get('fonts', 'tabbar'))
+        size = self.fontInfo().pixelSize() - 1
+        self.setIconSize(QSize(size, size))
 
-    def resizeEvent(self, e):
-        """Set the favicon size to the tabbar size minus some padding."""
-        height = e.size().height()
-        if height != 0 and e.oldSize().height() != height:
-            height = math.ceil(height - height / 7)
-            self.setIconSize(QSize(height, height))
 
     @config.change_filter('colors', 'tabs.bg.bar')
     def set_colors(self):


### PR DESCRIPTION
Here's a patch which seems to work well in my initial testing. We now use the
font size rather than the tabbar size, since the tabbar size is the window
size when it's vertical.

This also works nicer with the new tabs.padding setting (which didn't exist when
I wrote the first patch).