### PR TITLE
Make tab-focus (bound to gt) behave as in VIM

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -882,9 +882,13 @@ class CommandDispatcher:
             index: The tab index to focus, starting with 1. The special value
                    `last` focuses the last focused tab.
             count: The tab index to focus, starting with 1.
+                   If neither count nor index are given, it behaves like tab-next
         """
         if index == 'last':
             self._tab_focus_last()
+            return
+        if index is None and count is None:
+            self.tab_next()
             return
         try:
             idx = cmdutils.arg_or_count(index, count, default=1,

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -1236,7 +1236,7 @@ KEY_DATA = collections.OrderedDict([
         ('tab-move', ['gm']),
         ('tab-move -', ['gl']),
         ('tab-move +', ['gr']),
-        ('tab-next', ['J', 'gt']),
+        ('tab-focus', ['J', 'gt']),
         ('tab-prev', ['K', 'gT']),
         ('tab-clone', ['gC']),
         ('reload', ['r']),


### PR DESCRIPTION
If no count or index is given, tab-focus switches to the next tab (using
tab-next internally). So the keychain gt behaves as gt in vim:

  - gt focuses the next tab
  - 1gt focuses the first tab
  - <n>gt (e.g. 5gt) focuses the n'th (e.g. fith) tab