### PR TITLE
misc: sessions: Fallback title to tab title or url

### DIFF
--- a/qutebrowser/browser/tabhistory.py
+++ b/qutebrowser/browser/tabhistory.py
@@ -48,7 +48,10 @@ class TabHistoryItem:
             self.original_url = url
         else:
             self.original_url = original_url
-        self.title = title
+        if title:
+            self.title = title
+        else:
+            self.title = bytes(url.toEncoded()).decode('ascii')
         self.active = active
         self.user_data = user_data
 


### PR DESCRIPTION
An attempted workaround for issue #879. This patch attempts to solve the
issue of sessions not storing titles correctly by first falling back to
the tab title if the most recent history entry is being saved,
otherwise, fall back to the url of the entry. (Which appears to be always
present.