### PR TITLE
Fix progressbar height to statusbar height.

### DIFF
--- a/qutebrowser/mainwindow/statusbar/progress.py
+++ b/qutebrowser/mainwindow/statusbar/progress.py
@@ -79,5 +79,9 @@ class Progress(QProgressBar):
     def sizeHint(self):
         """Set the height to the text height plus some padding."""
         width = super().sizeHint().width()
-        height = self.fontMetrics().height() + 3
+        height = self.fontMetrics().height()
         return QSize(width, height)
+
+    def minimumSizeHint(self):
+        """Set the height to the text height plus some padding."""
+        return self.sizeHint()


### PR DESCRIPTION
Formerly, the statusbar height changed when the progressbar was visible.
This was caused by the default font-size of the progressbar text (though
invisible). Now, the font-size is set small enought such that the
statusbar height does not change anymore.

With empty qutebrowser configuration, I got the following statusbar behaviour on reloading:
![qutebrowser-progressbar-jump](https://cloud.githubusercontent.com/assets/9048813/9461429/f99d4088-4b0e-11e5-90e0-0d54d06a1a27.gif)
After the attched patch, the statusbar height does not change anymore.