### PR TITLE
Hide the border of the completionwidget

### DIFF
--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -59,6 +59,7 @@ class CompletionView(QTreeView):
             {{ color['completion.bg'] }}
             alternate-background-color: {{ color['completion.alternate-bg'] }};
             outline: 0;
+            border: 0px;
         }
 
         QTreeView::item:disabled {


### PR DESCRIPTION
Having a light Qt theme but a dark qutebrowser theme, one can see an
ugly white border around the completion widget which is some relict from
the underlying Qt widget QTreeView. As qutebrowser has its own theming
settings for the mainwindow, it should hide the Qt theme as far as
possible.
![completionwidgetborder](https://cloud.githubusercontent.com/assets/9048813/9462363/9b1e0342-4b15-11e5-865d-0bd725664663.png)

Be encouraged to rebase this onto the current master if there are new commits in the meantime.