### PR TITLE
Fix license issue

### DIFF
--- a/qutebrowser/html/version.html
+++ b/qutebrowser/html/version.html
@@ -21,6 +21,6 @@ GNU General Public License for more details.
 <p>
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <a href="http://www.gnu.org/licenses/">
-http://www.gnu.org/licenses/</a> or open <a href="qute:gpl">qute:gpl</a>.
+http://www.gnu.org/licenses/</a> or open <a href="qute://gpl">qute://gpl</a>.
 </p>
 {% endblock %}


### PR DESCRIPTION
If you call the page "qute:version" the link to the full GPL license works fine, but if you call "qute://version" it doesn't work. This pull request will fix this little issue.