### PR TITLE
Add adblock host whitelisting

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -159,6 +159,7 @@
 |<<content-cookies-store,cookies-store>>|Whether to store cookies.
 |<<content-host-block-lists,host-block-lists>>|List of URLs of lists which contain hosts to block.
 |<<content-host-blocking-enabled,host-blocking-enabled>>|Whether host blocking is enabled.
+|<<content-host-blocking-whitelist,host-blocking-whitelist>>|List of domains that should always be loaded, despite being ad-blocked.
 |==============
 
 .Quick reference for section ``hints''
@@ -1432,6 +1433,16 @@ Valid values:
  * +false+
 
 Default: +pass:[true]+
+
+[[content-host-blocking-whitelist]]
+=== host-blocking-whitelist
+List of domains that should always be loaded, despite being ad-blocked.
+
+Domains may contain * and ? wildcards and are otherwise required to exactly match the requested domain.
+
+Local domains are always exempt from hostblocking.
+
+Default: empty
 
 == hints
 Hinting settings.

--- a/qutebrowser/browser/adblock.py
+++ b/qutebrowser/browser/adblock.py
@@ -25,7 +25,6 @@ import functools
 import posixpath
 import zipfile
 import fnmatch
-import re
 
 from qutebrowser.config import config
 from qutebrowser.utils import objreg, standarddir, log, message
@@ -67,14 +66,12 @@ def is_whitelisted_domain(host):
     Args:
         host: The host as given by the adblocker as string.
     """
-    whitelist = objreg.get('config').get('content', 'host-blocking-whitelist')
+    whitelist = config.get('content', 'host-blocking-whitelist')
     if whitelist is None:
         return False
 
-    for domain in whitelist:
-        fnmatch_translated = fnmatch.translate(domain)
-        domain_regex = re.compile(fnmatch_translated, re.IGNORECASE)
-        if domain_regex.match(host):
+    for pattern in whitelist:
+        if fnmatch.fnmatch(host, pattern.lower()):
             return True
     return False
 

--- a/qutebrowser/browser/adblock.py
+++ b/qutebrowser/browser/adblock.py
@@ -24,6 +24,8 @@ import os.path
 import functools
 import posixpath
 import zipfile
+import fnmatch
+import re
 
 from qutebrowser.config import config
 from qutebrowser.utils import objreg, standarddir, log, message
@@ -57,6 +59,24 @@ def get_fileobj(byte_io):
     else:
         byte_io.seek(0)  # rewind what zipfile.is_zipfile did
     return io.TextIOWrapper(byte_io, encoding='utf-8')
+
+
+def is_whitelisted_domain(host):
+    """Check if the given host is on the adblock whitelist.
+
+    Args:
+        host: The host as given by the adblocker as string.
+    """
+    whitelist = objreg.get('config').get('content', 'host-blocking-whitelist')
+    if whitelist is None:
+        return False
+
+    for domain in whitelist:
+        fnmatch_translated = fnmatch.translate(domain)
+        domain_regex = re.compile(fnmatch_translated, re.IGNORECASE)
+        if domain_regex.match(host):
+            return True
+    return False
 
 
 class FakeDownload:
@@ -188,7 +208,8 @@ class HostBlocker:
             else:
                 error_count += 1
                 continue
-            if host not in self.WHITELISTED:
+            if (host not in self.WHITELISTED
+                    and not is_whitelisted_domain(host)):
                 self.blocked_hosts.add(host)
         log.misc.debug("{}: read {} lines".format(byte_io.name, line_count))
         if error_count > 0:

--- a/qutebrowser/browser/adblock.py
+++ b/qutebrowser/browser/adblock.py
@@ -24,7 +24,6 @@ import os.path
 import functools
 import posixpath
 import zipfile
-import fnmatch
 
 from qutebrowser.config import config
 from qutebrowser.utils import objreg, standarddir, log, message
@@ -58,22 +57,6 @@ def get_fileobj(byte_io):
     else:
         byte_io.seek(0)  # rewind what zipfile.is_zipfile did
     return io.TextIOWrapper(byte_io, encoding='utf-8')
-
-
-def is_whitelisted_domain(host):
-    """Check if the given host is on the adblock whitelist.
-
-    Args:
-        host: The host as given by the adblocker as string.
-    """
-    whitelist = config.get('content', 'host-blocking-whitelist')
-    if whitelist is None:
-        return False
-
-    for pattern in whitelist:
-        if fnmatch.fnmatch(host, pattern.lower()):
-            return True
-    return False
 
 
 class FakeDownload:
@@ -205,8 +188,7 @@ class HostBlocker:
             else:
                 error_count += 1
                 continue
-            if (host not in self.WHITELISTED
-                    and not is_whitelisted_domain(host)):
+            if host not in self.WHITELISTED:
                 self.blocked_hosts.add(host)
         log.misc.debug("{}: read {} lines".format(byte_io.name, line_count))
         if error_count > 0:

--- a/qutebrowser/browser/network/networkmanager.py
+++ b/qutebrowser/browser/network/networkmanager.py
@@ -54,7 +54,7 @@ def is_whitelisted_domain(host):
     """Check if the given host is on the adblock whitelist.
 
     Args:
-        host: The host as given by the adblocker as string.
+        host: The host of the request as string.
     """
     whitelist = config.get('content', 'host-blocking-whitelist')
     if whitelist is None:

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -735,6 +735,14 @@ def data(readonly=False):
              SettingValue(typ.Bool(), 'true'),
              "Whether host blocking is enabled."),
 
+            ('host-blocking-whitelist',
+             SettingValue(typ.List(none_ok=True), ''),
+             "List of domains that should always be loaded, despite being "
+             "ad-blocked.\n\n"
+             "Domains may contain * and ? wildcards and are otherwise "
+             "required to exactly match the requested domain.\n\n"
+             "Local domains are always exempt from hostblocking."),
+
             readonly=readonly
         )),
 


### PR DESCRIPTION
The config option "content host-blocking-whitelist" may contain comma
separated domains that are exempt from host blocking.

The listed domains may contain the wildcards "*" and "?" to match many
and one character, respectively.

~~You need to run :adblock-update after modifying the list.~~
:adblock-update no longer needed since the code is now in `networkmanager.py`

Should fix #948, though the exact config option might need to be tuned a bit - should the wildcards be kept, should we use a filepath instead (so a user can have a `~/.host_whitelist` or something like that), ...

The local domains are still hardcoded in `adblock.py` and cannot be removed with this config setting.