### PR TITLE
Add a command to show the keystring for a key.

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -813,6 +813,7 @@ How many steps to zoom out.
 |<<scroll-px,scroll-px>>|Scroll the current tab by 'count * dx/dy' pixels.
 |<<search-next,search-next>>|Continue the search to the ([count]th) next term.
 |<<search-prev,search-prev>>|Continue the search to the ([count]th) previous term.
+|<<show-keystring,show-keystring>>|Show the keystring for the next pressed key.
 |<<toggle-selection,toggle-selection>>|Toggle caret selection mode.
 |==============
 [[clear-keychain]]
@@ -1164,6 +1165,10 @@ Continue the search to the ([count]th) previous term.
 
 ==== count
 How many elements to ignore.
+
+[[show-keystring]]
+=== show-keystring
+Show the keystring for the next pressed key.
 
 [[toggle-selection]]
 === toggle-selection

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -1178,6 +1178,8 @@ KEY_FIRST_COMMENT = """
 # with Shift. For special keys (with `<>`-signs), you need to explicitly add
 # `Shift-` to match a key pressed with shift.  You can bind multiple commands
 # by separating them with `;;`.
+#
+# You can use <Ctrl-k> to get the name of a key.
 """
 
 KEY_SECTION_DESC = {
@@ -1355,6 +1357,7 @@ KEY_DATA = collections.OrderedDict([
         ('open qute:settings', ['Ss']),
         ('follow-selected', RETURN_KEYS),
         ('follow-selected -t', ['<Ctrl-Return>', '<Ctrl-Enter>']),
+        ('show-keystring', ['<Ctrl-k>']),
     ])),
 
     ('insert', collections.OrderedDict([

--- a/qutebrowser/utils/message.py
+++ b/qutebrowser/utils/message.py
@@ -141,8 +141,13 @@ def info(win_id, message, immediately=True):
     _wrapper(win_id, 'info', message, immediately)
 
 
+def set_text(win_id, txt):
+    """Convienience function to set the normal text of the statusbar."""
+    _wrapper(win_id, 'set_text', txt)
+
+
 def set_cmd_text(win_id, txt):
-    """Convienience function to Set the statusbar command line to a text."""
+    """Convienience function to set the statusbar command line to a text."""
     _wrapper(win_id, 'set_cmd_text', txt)
 
 


### PR DESCRIPTION
This fixes at least part of #658. Note that this is not the same as `<C-v>` in
Vim. In Vim, `<C-v>` is used to insert keys (not show their keystring). You can do
cool stuff like `<C-v>x07` to insert `0x07`, or `<C-v>u2713` to insert ✓

Adding that to the input bar and/or insert mode in text forms is another thing
altogether...

I've mapped in to `<C-k>` by the way, as `<C-v>` is already taken...