### PR TITLE
add scroll_pos to title-format (fix #894)

### DIFF
--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -308,7 +308,7 @@ def data(readonly=False):
              "* `{title}`: The title of the current web page\n"
              "* `{title_sep}`: The string ` - ` if a title is set, empty "
              "otherwise.\n"
-             "* `{id}`: The internal window ID of this window."
+             "* `{id}`: The internal window ID of this window.\n"
              "* `{scroll_pos}`: The page scroll position."),
 
             ('hide-mouse-cursor',
@@ -544,7 +544,7 @@ def data(readonly=False):
              "* `{title_sep}`: The string ` - ` if a title is set, empty "
              "otherwise.\n"
              "* `{index}`: The index of this tab.\n"
-             "* `{id}`: The internal tab ID of this tab."
+             "* `{id}`: The internal tab ID of this tab.\n"
              "* `{scroll_pos}`: The page scroll position."),
 
             ('mousewheel-tab-switching',

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -299,7 +299,8 @@ def data(readonly=False):
 
             ('window-title-format',
              SettingValue(typ.FormatString(fields=['perc', 'perc_raw', 'title',
-                                                   'title_sep', 'id', 'scroll_pos']),
+                                                   'title_sep', 'id',
+                                                   'scroll_pos']),
                           '{perc}{title}{title_sep}qutebrowser'),
              "The format to use for the window title. The following "
              "placeholders are defined:\n\n"

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -534,7 +534,7 @@ def data(readonly=False):
             ('title-format',
              SettingValue(typ.FormatString(
                  fields=['perc', 'perc_raw', 'title', 'title_sep', 'index',
-                         'id']), '{index}: {title}'),
+                         'id', 'scroll_pos']), '{index}: {title}'),
              "The format to use for the tab title. The following placeholders "
              "are defined:\n\n"
              "* `{perc}`: The percentage as a string like `[10%]`.\n"

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -299,7 +299,7 @@ def data(readonly=False):
 
             ('window-title-format',
              SettingValue(typ.FormatString(fields=['perc', 'perc_raw', 'title',
-                                                   'title_sep', 'id']),
+                                                   'title_sep', 'id', 'scroll_pos']),
                           '{perc}{title}{title_sep}qutebrowser'),
              "The format to use for the window title. The following "
              "placeholders are defined:\n\n"
@@ -308,7 +308,8 @@ def data(readonly=False):
              "* `{title}`: The title of the current web page\n"
              "* `{title_sep}`: The string ` - ` if a title is set, empty "
              "otherwise.\n"
-             "* `{id}`: The internal window ID of this window."),
+             "* `{id}`: The internal window ID of this window."
+             "* `{scroll_pos}`: The page scroll position."),
 
             ('hide-mouse-cursor',
              SettingValue(typ.Bool(), 'false'),
@@ -543,7 +544,8 @@ def data(readonly=False):
              "* `{title_sep}`: The string ` - ` if a title is set, empty "
              "otherwise.\n"
              "* `{index}`: The index of this tab.\n"
-             "* `{id}`: The internal tab ID of this tab."),
+             "* `{id}`: The internal tab ID of this tab."
+             "* `{scroll_pos}`: The page scroll position."),
 
             ('mousewheel-tab-switching',
              SettingValue(typ.Bool(), 'true'),

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -165,6 +165,15 @@ class TabbedBrowser(tabwidget.TabWidget):
         fields['title'] = tabtitle
         fields['title_sep'] = ' - ' if tabtitle else ''
         fields['id'] = self._win_id
+        y = widget.scroll_pos[1]
+        if y <= 0:
+            scroll_pos = 'top'
+        elif y >= 100:
+            scroll_pos = 'bot'
+        else:
+            scroll_pos = '{:2}%'.format(y)
+
+        fields['scroll_pos'] = str(scroll_pos)
         fmt = config.get('ui', 'window-title-format')
         self.window().setWindowTitle(fmt.format(**fields))
 
@@ -185,6 +194,7 @@ class TabbedBrowser(tabwidget.TabWidget):
             self._filter.create(self.cur_statusbar_message, tab))
         tab.scroll_pos_changed.connect(
             self._filter.create(self.cur_scroll_perc_changed, tab))
+        tab.scroll_pos_changed.connect(self.on_scroll_pos_changed)
         tab.url_text_changed.connect(
             self._filter.create(self.cur_url_text_changed, tab))
         tab.load_status_changed.connect(
@@ -576,6 +586,12 @@ class TabbedBrowser(tabwidget.TabWidget):
         self.update_tab_title(idx)
         if idx == self.currentIndex():
             self.update_window_title()
+
+    @pyqtSlot(int, int)
+    def on_scroll_pos_changed(self, x, y):
+        """Update tab and window title when scroll position changed."""
+        self.update_window_title()
+        self.update_tab_titles()
 
     def resizeEvent(self, e):
         """Extend resizeEvent of QWidget to emit a resized signal afterwards.

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -587,8 +587,8 @@ class TabbedBrowser(tabwidget.TabWidget):
         if idx == self.currentIndex():
             self.update_window_title()
 
-    @pyqtSlot(int, int)
-    def on_scroll_pos_changed(self, x, y):
+    @pyqtSlot()
+    def on_scroll_pos_changed(self, *args):
         """Update tab and window title when scroll position changed."""
         self.update_window_title()
         self.update_tab_titles()

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -588,7 +588,7 @@ class TabbedBrowser(tabwidget.TabWidget):
             self.update_window_title()
 
     @pyqtSlot()
-    def on_scroll_pos_changed(self, *args):
+    def on_scroll_pos_changed(self):
         """Update tab and window title when scroll position changed."""
         self.update_window_title()
         self.update_tab_titles()

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -120,7 +120,7 @@ class TabWidget(QTabWidget):
         else:
             scroll_pos = '{:2}%'.format(y)
 
-        fields['scroll_pos'] = '{}'.format(scroll_pos)
+        fields['scroll_pos'] = str(scroll_pos)
 
         fmt = config.get('tabs', 'title-format')
         self.tabBar().setTabText(idx, fmt.format(**fields))
@@ -167,7 +167,6 @@ class TabWidget(QTabWidget):
             text = text_or_empty
             new_idx = super().addTab(page, icon, '')
         self.set_page_title(new_idx, text)
-        page.scroll_pos_changed.connect(lambda: self.update_tab_title(new_idx))
         return new_idx
 
     def insertTab(self, idx, page, icon_or_text, text_or_empty=None):
@@ -198,7 +197,6 @@ class TabWidget(QTabWidget):
             text = text_or_empty
             new_idx = super().insertTab(idx, page, icon, '')
         self.set_page_title(new_idx, text)
-        page.scroll_pos_changed.connect(lambda: self.update_tab_title(new_idx))
         return new_idx
 
     @pyqtSlot(int)

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -112,6 +112,15 @@ class TabWidget(QTabWidget):
         fields['index'] = idx + 1
         fields['id'] = widget.tab_id
         fields['title_sep'] = ' - ' if page_title else ''
+        y = widget.scroll_pos[1]
+        if y <= 0:
+            scroll_pos = 'top'
+        elif y >= 100:
+            scroll_pos = 'bot'
+        else:
+            scroll_pos = '{:2}%'.format(y)
+
+        fields['scroll_pos'] = '{}'.format(scroll_pos)
 
         fmt = config.get('tabs', 'title-format')
         self.tabBar().setTabText(idx, fmt.format(**fields))
@@ -158,6 +167,7 @@ class TabWidget(QTabWidget):
             text = text_or_empty
             new_idx = super().addTab(page, icon, '')
         self.set_page_title(new_idx, text)
+        page.scroll_pos_changed.connect(lambda: self.update_tab_title(new_idx))
         return new_idx
 
     def insertTab(self, idx, page, icon_or_text, text_or_empty=None):
@@ -188,6 +198,7 @@ class TabWidget(QTabWidget):
             text = text_or_empty
             new_idx = super().insertTab(idx, page, icon, '')
         self.set_page_title(new_idx, text)
+        page.scroll_pos_changed.connect(lambda: self.update_tab_title(new_idx))
         return new_idx
 
     @pyqtSlot(int)


### PR DESCRIPTION
Fix #894, add scroll_pos to title-format and connect page.scroll_pos_changed to update_tab_title

I wont use this feature, but it was interesting