### PR TITLE
Fixes #977 with non deprecated call.

### DIFF
--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -162,7 +162,7 @@ def _os_info():
     lines = []
     releaseinfo = None
     if sys.platform == 'linux':
-        osver = ', '.join([e for e in platform.dist() if e])
+        osver = ', '.join([e for e in platform.linux_distribution() if e])
         releaseinfo = _release_info()
     elif sys.platform == 'win32':
         osver = ', '.join(platform.win32_ver())

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -162,7 +162,7 @@ def _os_info():
     lines = []
     releaseinfo = None
     if sys.platform == 'linux':
-        osver = ', '.join([e for e in platform.linux_distribution() if e])
+        osver = ''
         releaseinfo = _release_info()
     elif sys.platform == 'win32':
         osver = ', '.join(platform.win32_ver())

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -460,13 +460,13 @@ class TestOsInfo:
         """Test with a fake Linux.
 
         Args:
-            dist: The value to set platform.dist() to.
+            dist: The value to set platform.linux_distribution() to.
             dist_str: The expected distribution string in version._os_info().
         """
         monkeypatch.setattr('qutebrowser.utils.version.sys.platform', 'linux')
         monkeypatch.setattr('qutebrowser.utils.version._release_info',
                             lambda: [('releaseinfo', 'Hello World')])
-        monkeypatch.setattr('qutebrowser.utils.version.platform.dist',
+        monkeypatch.setattr('qutebrowser.utils.version.platform.linux_distribution',
                             lambda: dist)
         ret = version._os_info()
         expected = ['OS Version: {}'.format(dist_str), '',

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -451,25 +451,16 @@ class TestOsInfo:
 
     """Tests for _os_info."""
 
-    @pytest.mark.parametrize('dist, dist_str', [
-        (('x', '', 'y'), 'x, y'),
-        (('a', 'b', 'c'), 'a, b, c'),
-        (('', '', ''), ''),
-    ])
-    def test_linux_fake(self, monkeypatch, dist, dist_str):
+    def test_linux_fake(self, monkeypatch):
         """Test with a fake Linux.
 
-        Args:
-            dist: The value to set platform.linux_distribution() to.
-            dist_str: The expected distribution string in version._os_info().
+        No args because osver is set to '' if the OS is linux.
         """
         monkeypatch.setattr('qutebrowser.utils.version.sys.platform', 'linux')
         monkeypatch.setattr('qutebrowser.utils.version._release_info',
                             lambda: [('releaseinfo', 'Hello World')])
-        monkeypatch.setattr('qutebrowser.utils.version.platform.linux_distribution',
-                            lambda: dist)
         ret = version._os_info()
-        expected = ['OS Version: {}'.format(dist_str), '',
+        expected = ['OS Version: ', '',
                     '--- releaseinfo ---', 'Hello World']
         assert ret == expected
 


### PR DESCRIPTION
First contribution, low hanging fruit.

ref: https://docs.python.org/3/library/platform.html#unix-platforms

![output](http://i.imgur.com/FISAknD.png)

Would I need to change here too?
https://github.com/The-Compiler/qutebrowser/blob/6d1b0ba2603a93d9e4c85ac28cb38c4b14d295d5/tests/unit/utils/test_version.py#L469

