### PR TITLE
Document the need for source-highlight to be installed for asciidoc2html to work fully

### DIFF
--- a/INSTALL.asciidoc
+++ b/INSTALL.asciidoc
@@ -57,7 +57,7 @@ To generate the documentation for the `:help` command, when using the git
 repository (rather than a release):
 
 ----
-# apt-get install asciidoc
+# apt-get install asciidoc source-highlight
 $ python3 scripts/asciidoc2html.py
 ----
 
@@ -83,7 +83,7 @@ To generate the documentation for the `:help` command, when using the git
 repository (rather than a release):
 
 ----
-# dnf install asciidoc
+# dnf install asciidoc source-highlight
 $ python3 scripts/asciidoc2html.py
 ----
 


### PR DESCRIPTION
Update INSTALL.md to recommend installing source-highlight before building the docs.