### PR TITLE
misc/editor: Fix tempfile deleted on error / editor crash

### DIFF
--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -58,7 +58,8 @@ class ExternalEditor(QObject):
             return
         try:
             os.close(self._oshandle)
-            os.remove(self._filename)
+            if self._proc.exit_status() != QProcess.CrashExit:
+                os.remove(self._filename)
         except OSError as e:
             # NOTE: Do not replace this with "raise CommandError" as it's
             # executed async.

--- a/qutebrowser/misc/guiprocess.py
+++ b/qutebrowser/misc/guiprocess.py
@@ -151,3 +151,6 @@ class GUIProcess(QObject):
         else:
             message.error(self._win_id, "Error while spawning {}: {}.".format(
                           self._what, self._proc.error()), immediately=True)
+
+    def exit_status(self):
+        return self._proc.exitStatus()

--- a/tests/unit/misc/test_editor.py
+++ b/tests/unit/misc/test_editor.py
@@ -91,19 +91,28 @@ class TestFileHandling:
         filename = editor._filename
         assert os.path.exists(filename)
 
+        editor._proc._proc.exitStatus = mock.Mock(
+                return_value=QProcess.CrashExit)
         editor._proc.finished.emit(1, QProcess.NormalExit)
 
-        assert not os.path.exists(filename)
+        assert os.path.exists(filename)
+
+        os.remove(filename)
 
     def test_crash(self, editor):
         """Test file handling when closing with a crash."""
         editor.edit("")
         filename = editor._filename
         assert os.path.exists(filename)
+
+        editor._proc._proc.exitStatus = mock.Mock(
+                return_value=QProcess.CrashExit)
         editor._proc.error.emit(QProcess.Crashed)
 
         editor._proc.finished.emit(0, QProcess.CrashExit)
-        assert not os.path.exists(filename)
+        assert os.path.exists(filename)
+
+        os.remove(filename)
 
     @pytest.mark.posix
     def test_unreadable(self, message_mock, editor):


### PR DESCRIPTION
This patch attempts to fix an issue where an error occuring in
misc/guiprocess or the editor process crashing would delete the
temporary file thus making it impossible to recover changes not commited
to the form field from the editor.

In its current form, it doesn't pass tests because of an issue.