### PR TITLE
removes extra space in tab bar when window width % tab count != 0

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -407,7 +407,12 @@ class TabBar(QTabBar):
         else:
             # If we *do* have enough space, tabs should occupy the whole window
             # width.
-            size = QSize(self.width() / self.count(), height)
+            width = self.width() / self.count()
+            # If width is not divisible by count, add a pixel to some tabs so
+            # that there is no ugly leftover space.
+            if index < self.width() % self.count():
+                width += 1
+            size = QSize(width, height)
         qtutils.ensure_valid(size)
         return size
 


### PR DESCRIPTION
Occasionally there are extra pixels leftover in the tab bar on the right (see screenshot: http://lawrence.lu/sc/8a54bb3a04.png). This is due to the tab width being an integer and the window width is not always divisible by the tab count. This is fixed by adding an extra pixel to a subset of tabs.

Screenshot afterwards: http://lawrence.lu/sc/2bc9b8bf41.png 