### PR TITLE
Issue #943 and changed the docs accordingly

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -261,7 +261,7 @@ Start hinting.
  - With `spawn`: The executable and arguments to spawn.
  `{hint-url}` will get replaced by the selected
  URL.
- - With `userscript`: The userscript to execute.
+ - With `userscript`: The userscript to execute. Either store the userscript in your data directory or use an absolute path. 
  - With `fill`: The command to fill the statusbar with.
  `{hint-url}` will get replaced by the selected
  URL.
@@ -580,7 +580,7 @@ Note the {url} variable which gets replaced by the current URL might be useful h
 * +'cmdline'+: The commandline to execute.
 
 ==== optional arguments
-* +*-u*+, +*--userscript*+: Run the command as a userscript.
+* +*-u*+, +*--userscript*+: Run the command as a userscript. Either store it in your data directory or use an absolute path. 
 * +*-v*+, +*--verbose*+: Show notifications when the command started/exited.
 * +*-d*+, +*--detach*+: Whether the command should be detached from qutebrowser.
 

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -261,7 +261,7 @@ Start hinting.
  - With `spawn`: The executable and arguments to spawn.
  `{hint-url}` will get replaced by the selected
  URL.
- - With `userscript`: The userscript to execute. Either store the userscript in your data directory or use an absolute path. 
+ - With `userscript`: The userscript to execute.
  - With `fill`: The command to fill the statusbar with.
  `{hint-url}` will get replaced by the selected
  URL.
@@ -580,7 +580,7 @@ Note the {url} variable which gets replaced by the current URL might be useful h
 * +'cmdline'+: The commandline to execute.
 
 ==== optional arguments
-* +*-u*+, +*--userscript*+: Run the command as a userscript. Either store it in your data directory or use an absolute path. 
+* +*-u*+, +*--userscript*+: Run the command as a userscript.
 * +*-v*+, +*--verbose*+: Show notifications when the command started/exited.
 * +*-d*+, +*--detach*+: Whether the command should be detached from qutebrowser.
 

--- a/doc/userscripts.asciidoc
+++ b/doc/userscripts.asciidoc
@@ -15,6 +15,10 @@ mpv, a simple key binding to something like `:spawn mpv {url}` should suffice.
 Also note userscripts need to have the executable bit set (`chmod +x`) for
 qutebrowser to run them.
 
+To call a userscript, it needs to be stored in your data directory under
+`userscripts` (for example: `~/.local/share/qutebrowser/userscripts/myscript`), 
+or just use an absolute path.
+
 Getting information
 -------------------
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -948,7 +948,9 @@ class CommandDispatcher:
         useful here.
 
         Args:
-            userscript: Run the command as a userscript.
+            userscript: Run the command as a userscript. Either store the
+                        userscript in ~/.local/share/qutebrowser/userscripts
+                        (or $XDG_DATA_DIR), or use an absolute path.
             verbose: Show notifications when the command started/exited.
             detach: Whether the command should be detached from qutebrowser.
             cmdline: The commandline to execute.

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -749,7 +749,10 @@ class HintManager(QObject):
                 - With `spawn`: The executable and arguments to spawn.
                                 `{hint-url}` will get replaced by the selected
                                 URL.
-                - With `userscript`: The userscript to execute.
+                - With `userscript`: The userscript to execute. Either store
+                                     the userscript in
+                                     ~/.local/share/qutebrowser/userscripts (or
+                                     $XDG_DATA_DIR), or use an absolute path.
                 - With `fill`: The command to fill the statusbar with.
                                 `{hint-url}` will get replaced by the selected
                                 URL.

--- a/qutebrowser/commands/userscripts.py
+++ b/qutebrowser/commands/userscripts.py
@@ -345,12 +345,11 @@ def run(cmd, *args, win_id, env, verbose=False):
         env['QUTE_USER_AGENT'] = user_agent
     cmd = os.path.expanduser(cmd)
 
-    # check if userscript is in absolute path or in $XDG_DATA_DIRS
+    # if cmd is not given as an absolute path, look it up
+    # ~/.local/share/qutebrowser/userscripts (or $XDG_DATA_DIR)
     if not os.path.isabs(cmd):
-        log.misc.debug("{} is no absoulte path".format(cmd))
-        c = os.path.join(standarddir.data(), "userscripts", cmd)
-        if os.path.isfile(c):
-            cmd = c
+        log.misc.debug("{} is no absolute path".format(cmd))
+        cmd = os.path.join(standarddir.data(), "userscripts", cmd)
 
     runner.run(cmd, *args, env=env, verbose=verbose)
     runner.finished.connect(commandrunner.deleteLater)

--- a/qutebrowser/commands/userscripts.py
+++ b/qutebrowser/commands/userscripts.py
@@ -344,6 +344,14 @@ def run(cmd, *args, win_id, env, verbose=False):
     if user_agent is not None:
         env['QUTE_USER_AGENT'] = user_agent
     cmd = os.path.expanduser(cmd)
+
+    # check if userscript is in absolute path or in $XDG_DATA_DIRS
+    if not os.path.isabs(cmd) :
+        log.misc.debug("{} is no absoulte path".format(cmd))
+        c = os.path.join(standarddir.data(),"userscripts", cmd)
+        if os.path.isfile(c):
+            cmd = c
+
     runner.run(cmd, *args, env=env, verbose=verbose)
     runner.finished.connect(commandrunner.deleteLater)
     runner.finished.connect(runner.deleteLater)

--- a/qutebrowser/commands/userscripts.py
+++ b/qutebrowser/commands/userscripts.py
@@ -346,9 +346,9 @@ def run(cmd, *args, win_id, env, verbose=False):
     cmd = os.path.expanduser(cmd)
 
     # check if userscript is in absolute path or in $XDG_DATA_DIRS
-    if not os.path.isabs(cmd) :
+    if not os.path.isabs(cmd):
         log.misc.debug("{} is no absoulte path".format(cmd))
-        c = os.path.join(standarddir.data(),"userscripts", cmd)
+        c = os.path.join(standarddir.data(), "userscripts", cmd)
         if os.path.isfile(c):
             cmd = c
 


### PR DESCRIPTION
Userscripts can now be stored in the data directory (for example: ~/.local/share/qutebrowser/userscripts) and called from there or using an absolute path. 