### PR TITLE
Fixed issue #1008.

### DIFF
--- a/qutebrowser/completion/models/urlmodel.py
+++ b/qutebrowser/completion/models/urlmodel.py
@@ -169,8 +169,9 @@ class UrlCompletionModel(base.BaseCompletionModel):
         """
         index = completion.currentIndex()
         qtutils.ensure_valid(index)
-        url = index.data()
         category = index.parent()
+        index = category.child(index.row(), self.URL_COLUMN)
+        url = index.data()
         qtutils.ensure_valid(category)
 
         if category.data() == 'Bookmarks':


### PR DESCRIPTION
This fixes issue #1008.

I found that this bug only happens when I click on the name of the bookmark.
It does not happen when I click on the URL.
It it probably because I can select both the name and the URL with the mouse.