### PR TITLE
First batch of unit tests for browser cache

### DIFF
--- a/qutebrowser/browser/cache.py
+++ b/qutebrowser/browser/cache.py
@@ -43,7 +43,6 @@ class DiskCache(QNetworkDiskCache):
         self._cache_dir = cache_dir
         self._http_cache_dir = os.path.join(cache_dir, 'http')
         self._maybe_activate()
-        self.setMaximumCacheSize(config.get('storage', 'cache-size'))
         objreg.get('config').changed.connect(self.on_config_changed)
 
     def __repr__(self):
@@ -59,6 +58,7 @@ class DiskCache(QNetworkDiskCache):
         else:
             self._activated = True
             self.setCacheDirectory(self._http_cache_dir)
+            self.setMaximumCacheSize(config.get('storage', 'cache-size'))
 
     @pyqtSlot(str, str)
     def on_config_changed(self, section, option):

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -50,7 +50,8 @@ def test_cache_size_leq_max_cache_size(config_stub, tmpdir):
     preload_cache(disk_cache, 'http://foo.xxx')
     preload_cache(disk_cache, 'http://bar.net')
     assert disk_cache.expire() < limit
-    assert disk_cache.cacheSize() <= limit
+    # Add a threshold to the limit due to unforseeable Qt internals
+    assert disk_cache.cacheSize() < limit+100
 
 
 def test_cache_deactivated_private_browsing(config_stub, tmpdir):

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -68,6 +68,42 @@ def test_cache_deactivated_private_browsing(config_stub, tmpdir):
     assert disk_cache.prepare(metadata) is None
 
 
+def test_cache_deactivated_get_data(config_stub, tmpdir):
+    """Query some data from a deactivated cache."""
+    config_stub.data = {
+        'storage': {'cache-size': 1024},
+        'general': {'private-browsing': True}
+    }
+    disk_cache = cache.DiskCache(str(tmpdir))
+
+    url = QUrl('http://www.example.com/')
+    assert disk_cache.data(url) is None
+
+
+def test_cache_get_nonexistant_data(config_stub, tmpdir):
+    """Test querying some data that was never inserted."""
+    config_stub.data = {
+        'storage': {'cache-size': 1024},
+        'general': {'private-browsing': False}
+    }
+    disk_cache = cache.DiskCache(str(tmpdir))
+    preload_cache(disk_cache, 'https://qutebrowser.org')
+
+    assert disk_cache.data(QUrl('http://qutebrowser.org')) is None
+
+
+def test_cache_deactivated_remove_data(config_stub, tmpdir):
+    """Test removing some data from a deactivated cache."""
+    config_stub.data = {
+        'storage': {'cache-size': 1024},
+        'general': {'private-browsing': True}
+    }
+    disk_cache = cache.DiskCache(str(tmpdir))
+
+    url = QUrl('http://www.example.com/')
+    assert disk_cache.remove(url) == False
+
+
 def test_cache_insert_data(tmpdir):
     """Test if entries inserted into the cache are actually there."""
     url = 'http://qutebrowser.org'

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -37,20 +37,20 @@ def preload_cache(cache, url='http://www.example.com/', content=b'foobar'):
 
 def test_cache_size_leq_max_cache_size(config_stub, tmpdir):
     """Test cacheSize <= MaximumCacheSize when cache is activated."""
-    LIMIT = 100
+    limit = 100
     config_stub.data = {
-        'storage': {'cache-size': LIMIT},
+        'storage': {'cache-size': limit},
         'general': {'private-browsing': False}
     }
     disk_cache = cache.DiskCache(str(tmpdir))
-    assert disk_cache.maximumCacheSize() == LIMIT
+    assert disk_cache.maximumCacheSize() == limit
 
     preload_cache(disk_cache, 'http://www.example.com/')
     preload_cache(disk_cache, 'http://qutebrowser.org')
     preload_cache(disk_cache, 'http://foo.xxx')
     preload_cache(disk_cache, 'http://bar.net')
-    assert disk_cache.expire() < LIMIT
-    assert disk_cache.cacheSize() <= LIMIT
+    assert disk_cache.expire() < limit
+    assert disk_cache.cacheSize() <= limit
 
 
 def test_cache_deactivated_private_browsing(config_stub, tmpdir):
@@ -69,27 +69,27 @@ def test_cache_deactivated_private_browsing(config_stub, tmpdir):
 
 def test_cache_insert_data(tmpdir):
     """Test if entries inserted into the cache are actually there."""
-    URL = 'http://qutebrowser.org'
-    CONTENT = b'foobar'
+    url = 'http://qutebrowser.org'
+    content = b'foobar'
     disk_cache = QNetworkDiskCache()
     disk_cache.setCacheDirectory(str(tmpdir))
     assert disk_cache.cacheSize() == 0
 
-    preload_cache(disk_cache, URL, CONTENT)
+    preload_cache(disk_cache, url, content)
 
     assert disk_cache.cacheSize() != 0
-    assert disk_cache.data(QUrl(URL)).readAll() == CONTENT
+    assert disk_cache.data(QUrl(url)).readAll() == content
 
 
 def test_cache_remove_data(tmpdir):
     """Test if a previously inserted entry can be removed from the cache."""
-    URL = 'http://qutebrowser.org'
+    url = 'http://qutebrowser.org'
     disk_cache = QNetworkDiskCache()
     disk_cache.setCacheDirectory(str(tmpdir))
-    preload_cache(disk_cache, URL)
+    preload_cache(disk_cache, url)
     assert disk_cache.cacheSize() > 0
 
-    assert disk_cache.remove(QUrl(URL))
+    assert disk_cache.remove(QUrl(url))
     assert disk_cache.cacheSize() == 0
 
 
@@ -111,9 +111,9 @@ def test_cache_clear_activated(config_stub, tmpdir):
 
 def test_cache_metadata(tmpdir):
     """Ensure that DiskCache.metaData() returns exactly what was inserted."""
-    URL = 'http://qutebrowser.org'
+    url = 'http://qutebrowser.org'
     metadata = QNetworkCacheMetaData()
-    metadata.setUrl(QUrl(URL))
+    metadata.setUrl(QUrl(url))
     assert metadata.isValid()
     disk_cache = QNetworkDiskCache()
     disk_cache.setCacheDirectory(str(tmpdir))
@@ -121,19 +121,19 @@ def test_cache_metadata(tmpdir):
     device.write(b'foobar')
     disk_cache.insert(device)
 
-    assert disk_cache.metaData(QUrl(URL)) == metadata
+    assert disk_cache.metaData(QUrl(url)) == metadata
 
 
 def test_cache_update_metadata(tmpdir):
     """Test updating the meta data for an existing cache entry."""
-    URL = 'http://qutebrowser.org'
+    url = 'http://qutebrowser.org'
     disk_cache = QNetworkDiskCache()
     disk_cache.setCacheDirectory(str(tmpdir))
-    preload_cache(disk_cache, URL, b'foo')
+    preload_cache(disk_cache, url, b'foo')
     assert disk_cache.cacheSize() > 0
 
     metadata = QNetworkCacheMetaData()
-    metadata.setUrl(QUrl(URL))
+    metadata.setUrl(QUrl(url))
     assert metadata.isValid()
     disk_cache.updateMetaData(metadata)
-    assert disk_cache.metaData(QUrl(URL)) == metadata
+    assert disk_cache.metaData(QUrl(url)) == metadata

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -1,0 +1,55 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2015 lamarpavel
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for qutebrowser.browser.cache"""
+
+from unittest import mock
+
+from qutebrowser.browser import cache
+from qutebrowser.utils import objreg
+
+
+def test_cache_size_leq_max_cache_size(config_stub):
+    """Test cacheSize <= MaximumCacheSize when cache is activated."""
+    config_stub.data = {
+            'storage': {'cache-size': 1024},
+            'general': {'private-browsing': False}
+            }
+    disk_cache = cache.DiskCache("/foo/bar")
+    assert(1024 >= disk_cache.cacheSize())
+
+
+def test_cache_deactivated_private_browsing(config_stub):
+    """Test if cache is deactivated in private-browsing mode."""
+    config_stub.data = {
+            'storage': {'cache-size': 1024},
+            'general': {'private-browsing': True}
+            }
+    disk_cache = cache.DiskCache("/foo/bar")
+    assert(0 == disk_cache.cacheSize())
+
+
+def test_cache_deactivated_no_cachedir(config_stub):
+    """Test if cache is deactivated when there is no cache-dir."""
+    config_stub.data = {
+            'storage': {'cache-size': 1024},
+            'general': {'private-browsing': False}
+            }
+    disk_cache = cache.DiskCache("")
+    assert(0 == disk_cache.cacheSize())

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -80,7 +80,7 @@ def test_cache_deactivated_get_data(config_stub, tmpdir):
     assert disk_cache.data(url) is None
 
 
-def test_cache_get_nonexistant_data(config_stub, tmpdir):
+def test_cache_get_nonexistent_data(config_stub, tmpdir):
     """Test querying some data that was never inserted."""
     config_stub.data = {
         'storage': {'cache-size': 1024},

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -53,3 +53,14 @@ def test_cache_deactivated_no_cachedir(config_stub):
             }
     disk_cache = cache.DiskCache("")
     assert(0 == disk_cache.cacheSize())
+
+
+def test_clear_cache_activated(config_stub, tmpdir):
+    """Test if cache empty after clearing it."""
+    config_stub.data = {
+            'storage': {'cache-size': 1024},
+            'general': {'private-browsing': False}
+            }
+    disk_cache = cache.DiskCache(str(tmpdir))
+    disk_cache.clear()
+    assert(0 == disk_cache.cacheSize())

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -19,10 +19,7 @@
 
 """Tests for qutebrowser.browser.cache"""
 
-from unittest import mock
-
 from qutebrowser.browser import cache
-from qutebrowser.utils import objreg
 
 
 def test_cache_size_leq_max_cache_size(config_stub, tmpdir):
@@ -32,7 +29,7 @@ def test_cache_size_leq_max_cache_size(config_stub, tmpdir):
         'general': {'private-browsing': False}
     }
     disk_cache = cache.DiskCache(str(tmpdir))
-    assert(disk_cache.cacheSize() <= 1024)
+    assert disk_cache.cacheSize() <= 1024
 
 
 def test_cache_deactivated_private_browsing(config_stub, tmpdir):
@@ -42,7 +39,7 @@ def test_cache_deactivated_private_browsing(config_stub, tmpdir):
         'general': {'private-browsing': True}
     }
     disk_cache = cache.DiskCache(str(tmpdir))
-    assert(disk_cache.cacheSize() == 0)
+    assert disk_cache.cacheSize() == 0
 
 
 def test_cache_deactivated_no_cachedir(config_stub):
@@ -52,7 +49,7 @@ def test_cache_deactivated_no_cachedir(config_stub):
         'general': {'private-browsing': False}
     }
     disk_cache = cache.DiskCache("")
-    assert(disk_cache.cacheSize() == 0)
+    assert disk_cache.cacheSize() == 0
 
 
 def test_clear_cache_activated(config_stub, tmpdir):
@@ -63,4 +60,4 @@ def test_clear_cache_activated(config_stub, tmpdir):
     }
     disk_cache = cache.DiskCache(str(tmpdir))
     disk_cache.clear()
-    assert(disk_cache.cacheSize() == 0)
+    assert disk_cache.cacheSize() == 0

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -25,23 +25,23 @@ from qutebrowser.browser import cache
 from qutebrowser.utils import objreg
 
 
-def test_cache_size_leq_max_cache_size(config_stub):
+def test_cache_size_leq_max_cache_size(config_stub, tmpdir):
     """Test cacheSize <= MaximumCacheSize when cache is activated."""
     config_stub.data = {
             'storage': {'cache-size': 1024},
             'general': {'private-browsing': False}
             }
-    disk_cache = cache.DiskCache("/foo/bar")
+    disk_cache = cache.DiskCache(str(tmpdir))
     assert(1024 >= disk_cache.cacheSize())
 
 
-def test_cache_deactivated_private_browsing(config_stub):
+def test_cache_deactivated_private_browsing(config_stub, tmpdir):
     """Test if cache is deactivated in private-browsing mode."""
     config_stub.data = {
             'storage': {'cache-size': 1024},
             'general': {'private-browsing': True}
             }
-    disk_cache = cache.DiskCache("/foo/bar")
+    disk_cache = cache.DiskCache(str(tmpdir))
     assert(0 == disk_cache.cacheSize())
 
 

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -63,4 +63,4 @@ def test_clear_cache_activated(config_stub, tmpdir):
     }
     disk_cache = cache.DiskCache(str(tmpdir))
     disk_cache.clear()
-    assert(0 == disk_cache.cacheSize())
+    assert(disk_cache.cacheSize() == 0)

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -45,7 +45,7 @@ def test_cache_size_leq_max_cache_size(config_stub, tmpdir):
     disk_cache = cache.DiskCache(str(tmpdir))
     assert disk_cache.maximumCacheSize() == LIMIT
 
-    preload_cache(disk_cache, 'http://www.example/com/')
+    preload_cache(disk_cache, 'http://www.example.com/')
     preload_cache(disk_cache, 'http://qutebrowser.org')
     preload_cache(disk_cache, 'http://foo.xxx')
     preload_cache(disk_cache, 'http://bar.net')
@@ -93,7 +93,7 @@ def test_cache_remove_data(tmpdir):
     assert disk_cache.cacheSize() == 0
 
 
-def test_clear_cache_activated(config_stub, tmpdir):
+def test_cache_clear_activated(config_stub, tmpdir):
     """Test if cache is empty after clearing it."""
     config_stub.data = {
         'storage': {'cache-size': 1024},
@@ -107,3 +107,33 @@ def test_clear_cache_activated(config_stub, tmpdir):
 
     disk_cache.clear()
     assert disk_cache.cacheSize() == 0
+
+
+def test_cache_metadata(tmpdir):
+    """Ensure that DiskCache.metaData() returns exactly what was inserted."""
+    URL = 'http://qutebrowser.org'
+    metadata = QNetworkCacheMetaData()
+    metadata.setUrl(QUrl(URL))
+    assert metadata.isValid()
+    disk_cache = QNetworkDiskCache()
+    disk_cache.setCacheDirectory(str(tmpdir))
+    device = disk_cache.prepare(metadata)
+    device.write(b'foobar')
+    disk_cache.insert(device)
+
+    assert disk_cache.metaData(QUrl(URL)) == metadata
+
+
+def test_cache_update_metadata(tmpdir):
+    """Test updating the meta data for an existing cache entry."""
+    URL = 'http://qutebrowser.org'
+    disk_cache = QNetworkDiskCache()
+    disk_cache.setCacheDirectory(str(tmpdir))
+    preload_cache(disk_cache, URL, b'foo')
+    assert disk_cache.cacheSize() > 0
+
+    metadata = QNetworkCacheMetaData()
+    metadata.setUrl(QUrl(URL))
+    assert metadata.isValid()
+    disk_cache.updateMetaData(metadata)
+    assert disk_cache.metaData(QUrl(URL)) == metadata

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -28,39 +28,39 @@ from qutebrowser.utils import objreg
 def test_cache_size_leq_max_cache_size(config_stub, tmpdir):
     """Test cacheSize <= MaximumCacheSize when cache is activated."""
     config_stub.data = {
-            'storage': {'cache-size': 1024},
-            'general': {'private-browsing': False}
-            }
+        'storage': {'cache-size': 1024},
+        'general': {'private-browsing': False}
+    }
     disk_cache = cache.DiskCache(str(tmpdir))
-    assert(1024 >= disk_cache.cacheSize())
+    assert(disk_cache.cacheSize() <= 1024)
 
 
 def test_cache_deactivated_private_browsing(config_stub, tmpdir):
     """Test if cache is deactivated in private-browsing mode."""
     config_stub.data = {
-            'storage': {'cache-size': 1024},
-            'general': {'private-browsing': True}
-            }
+        'storage': {'cache-size': 1024},
+        'general': {'private-browsing': True}
+    }
     disk_cache = cache.DiskCache(str(tmpdir))
-    assert(0 == disk_cache.cacheSize())
+    assert(disk_cache.cacheSize() == 0)
 
 
 def test_cache_deactivated_no_cachedir(config_stub):
     """Test if cache is deactivated when there is no cache-dir."""
     config_stub.data = {
-            'storage': {'cache-size': 1024},
-            'general': {'private-browsing': False}
-            }
+        'storage': {'cache-size': 1024},
+        'general': {'private-browsing': False}
+    }
     disk_cache = cache.DiskCache("")
-    assert(0 == disk_cache.cacheSize())
+    assert(disk_cache.cacheSize() == 0)
 
 
 def test_clear_cache_activated(config_stub, tmpdir):
-    """Test if cache empty after clearing it."""
+    """Test if cache is empty after clearing it."""
     config_stub.data = {
-            'storage': {'cache-size': 1024},
-            'general': {'private-browsing': False}
-            }
+        'storage': {'cache-size': 1024},
+        'general': {'private-browsing': False}
+    }
     disk_cache = cache.DiskCache(str(tmpdir))
     disk_cache.clear()
     assert(0 == disk_cache.cacheSize())

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -35,20 +35,6 @@ def preload_cache(cache, url='http://www.example.com/', content=b'foobar'):
     cache.insert(device)
 
 
-def test_cache_insert_data(tmpdir):
-    """Test if entries inserted into the cache are actually there."""
-    URL = 'http://qutebrowser.org'
-    CONTENT = b'foobar'
-    cache = QNetworkDiskCache()
-    cache.setCacheDirectory(str(tmpdir))
-    assert cache.cacheSize() == 0
-
-    preload_cache(cache, URL, CONTENT)
-
-    assert cache.cacheSize() != 0
-    assert cache.data(QUrl(URL)).readAll() == CONTENT
-
-
 def test_cache_size_leq_max_cache_size(config_stub, tmpdir):
     """Test cacheSize <= MaximumCacheSize when cache is activated."""
     LIMIT = 100
@@ -79,6 +65,32 @@ def test_cache_deactivated_private_browsing(config_stub, tmpdir):
     metadata.setUrl(QUrl('http://www.example.com/'))
     assert metadata.isValid()
     assert disk_cache.prepare(metadata) is None
+
+
+def test_cache_insert_data(tmpdir):
+    """Test if entries inserted into the cache are actually there."""
+    URL = 'http://qutebrowser.org'
+    CONTENT = b'foobar'
+    disk_cache = QNetworkDiskCache()
+    disk_cache.setCacheDirectory(str(tmpdir))
+    assert disk_cache.cacheSize() == 0
+
+    preload_cache(disk_cache, URL, CONTENT)
+
+    assert disk_cache.cacheSize() != 0
+    assert disk_cache.data(QUrl(URL)).readAll() == CONTENT
+
+
+def test_cache_remove_data(tmpdir):
+    """Test if a previously inserted entry can be removed from the cache."""
+    URL = 'http://qutebrowser.org'
+    disk_cache = QNetworkDiskCache()
+    disk_cache.setCacheDirectory(str(tmpdir))
+    preload_cache(disk_cache, URL)
+    assert disk_cache.cacheSize() > 0
+
+    assert disk_cache.remove(QUrl(URL))
+    assert disk_cache.cacheSize() == 0
 
 
 def test_clear_cache_activated(config_stub, tmpdir):


### PR DESCRIPTION
These are the first four unit tests for module browser.cache. From what I can see the remaining tests all require construction of files, QIODevices with files or valid QNetWorkCacheMetaData, which is a bit beyond my understanding of pyqt and the qute codebase right now.