### PR TITLE
Flexible Link Hint Filtering

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -864,7 +864,7 @@ class HintManager(QObject):
         for elems in self._context.elems.values():
             try:
                 if (filterstr is None or
-                        str(elems.elem).lower().startswith(filterstr)):
+                        filterstr.casefold() in str(elems.elem).casefold()):
                     if self._is_hidden(elems.label):
                         # hidden element which matches again -> show it
                         self._show_elem(elems.label)


### PR DESCRIPTION
I think it makes more sense to filter for any text within a link rather
than just the text at the beginning. I've been playing around with this
a little and I like it a lot better.

When using numbers as link hints, It would be awesome if the link hint
strings themselves could also be updated based on how many links are
left, but I'm still figuring out how to do this.

What do you think?