### PR TITLE
Use duckduckgo.com instead of www.duckduckgo.com

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -304,7 +304,7 @@ Default: +pass:[true]+
 === startpage
 The default page(s) to open at the start, separated by commas.
 
-Default: +pass:[https://www.duckduckgo.com]+
+Default: +pass:[https://duckduckgo.com]+
 
 [[general-default-page]]
 === default-page

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -140,7 +140,7 @@ def data(readonly=False):
              "end."),
 
             ('startpage',
-             SettingValue(typ.List(), 'https://www.duckduckgo.com'),
+             SettingValue(typ.List(), 'https://duckduckgo.com'),
              "The default page(s) to open at the start, separated by commas."),
 
             ('default-page',


### PR DESCRIPTION
https://www.duckduckgo.com gives a `301 Moved Permanently` to https://duckduckgo.com.

This made things more complicated for another improvement I'm working on at the moment.