### PR TITLE
Remove unused tab on undo

### DIFF
--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -311,8 +311,10 @@ class TabbedBrowser(tabwidget.TabWidget):
                 'startpage': QUrl(config.get('general', 'startpage')[0]),
                 'default-page': config.get('general', 'default-page'),
             }
-            first_tab_url = self.widget(0).url()
-            last_close_url_used = first_tab_url == urls[last_close]
+            first_tab_url = self.widget(0).page().mainFrame().requestedUrl()
+            last_close_urlstr = urls[last_close].toString().rstrip('/')
+            first_tab_urlstr = first_tab_url.toString().rstrip('/')
+            last_close_url_used = first_tab_urlstr == last_close_urlstr
 
             if only_one_tab_open and no_history and last_close_url_used:
                 self.removeTab(0)

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -301,7 +301,6 @@ class TabbedBrowser(tabwidget.TabWidget):
 
     def undo(self):
         """Undo removing of a tab."""
-
         # Remove unused tab which may be created after the last tab is closed
         last_close = config.get('tabs', 'last-close')
         if last_close in ['blank', 'startpage', 'default-page']:

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -301,6 +301,23 @@ class TabbedBrowser(tabwidget.TabWidget):
 
     def undo(self):
         """Undo removing of a tab."""
+
+        # Remove unused tab which may be created after the last tab is closed
+        last_close = config.get('tabs', 'last-close')
+        if last_close in ['blank', 'startpage', 'default-page']:
+            only_one_tab_open = self.count() == 1
+            no_history = self.widget(0).history().count() == 1
+            urls = {
+                'blank': QUrl('about:blank'),
+                'startpage': QUrl(config.get('general', 'startpage')[0]),
+                'default-page': config.get('general', 'default-page'),
+            }
+            first_tab_url = self.widget(0).url()
+            last_close_url_used = first_tab_url == urls[last_close]
+
+            if only_one_tab_open and no_history and last_close_url_used:
+                self.removeTab(0)
+
         url, history_data = self._undo_stack.pop()
         newtab = self.tabopen(url, background=False)
         qtutils.deserialize(history_data, newtab.history())


### PR DESCRIPTION
This is the improvement I've been talking about in the IRC.

The idea is the following: Given you have the setting `last-close` with one of the values `blank`, `startpage` or `defaultpage`, when you close the last tab, a new tab is created. If you undo closing the last tab, this created tab is still there. With this patch the created tab gets removed again, given that it has not been used.

I only modified the `undo()` function. There are 3 things that are checked before the closed tab is restored:

1. Is there only one tab open?
2. Does this tab have an empty history?
3. Does this tab have the url of a tab that is created when the last remaining tab has been closed?

If all conditions are true, the tab is removed. I think we need all these checks to prevent tabs from being removed accidentially when another tab is restored.

There are unfortunately still two issues with the 3rd check:

* If the browser gets redirected on the startpage (i.e. 'https://www.duckduckgo.com' -> 'https://duckduckgo.com') the urls don't match
* If the configuration value does not end with a `/`, the urls don't matach (i.e. config: 'https://duckduckgo.com', browser: 'https://duckduckgo.com/') the urls don't match either

Both issues cause the tab not to be removed.