### PR TITLE
Follow-up to test-browser-cache

### DIFF
--- a/qutebrowser/browser/cache.py
+++ b/qutebrowser/browser/cache.py
@@ -65,7 +65,8 @@ class DiskCache(QNetworkDiskCache):
         """Update cache size/activated if the config was changed."""
         if (section, option) == ('storage', 'cache-size'):
             self.setMaximumCacheSize(config.get('storage', 'cache-size'))
-        elif (section, option) == ('general', 'private-browsing'):
+        elif (section, option) == ('general', # pragma: no branch
+                'private-browsing'):
             self._maybe_activate()
 
     def cacheSize(self):

--- a/qutebrowser/browser/cache.py
+++ b/qutebrowser/browser/cache.py
@@ -65,8 +65,8 @@ class DiskCache(QNetworkDiskCache):
         """Update cache size/activated if the config was changed."""
         if (section, option) == ('storage', 'cache-size'):
             self.setMaximumCacheSize(config.get('storage', 'cache-size'))
-        elif (section, option) == ('general', # pragma: no branch
-                'private-browsing'):
+        elif (section, option) == ('general',   # pragma: no branch
+                                   'private-browsing'):
             self._maybe_activate()
 
     def cacheSize(self):

--- a/scripts/dev/check_coverage.py
+++ b/scripts/dev/check_coverage.py
@@ -48,6 +48,8 @@ PERFECT_FILES = [
     ('tests/unit/commands/test_argparser.py',
         'qutebrowser/commands/argparser.py'),
 
+    ('tests/unit/browser/test_cache.py',
+        'qutebrowser/browser/cache.py'),
     ('tests/unit/browser/test_cookies.py',
         'qutebrowser/browser/cookies.py'),
     ('tests/unit/browser/test_tabhistory.py',

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -160,7 +160,7 @@ def test_cache_remove_data(tmpdir):
     preload_cache(disk_cache, url)
     assert disk_cache.cacheSize() > 0
 
-    assert disk_cache.remove(QUrl(url))
+    assert disk_cache.remove(QUrl(url)) == True
     assert disk_cache.cacheSize() == 0
 
 
@@ -208,6 +208,21 @@ def test_cache_update_metadata(tmpdir):
     assert metadata.isValid()
     disk_cache.updateMetaData(metadata)
     assert disk_cache.metaData(QUrl(url)) == metadata
+
+
+def test_cache_deactivated_update_metadata(config_stub, tmpdir):
+    """Test updating the meta data when cache is not activated."""
+    config_stub.data = {
+        'storage': {'cache-size': 1024},
+        'general': {'private-browsing': True}
+    }
+    url = 'http://qutebrowser.org'
+    disk_cache = cache.DiskCache(str(tmpdir))
+
+    metadata = QNetworkCacheMetaData()
+    metadata.setUrl(QUrl(url))
+    assert metadata.isValid()
+    assert disk_cache.updateMetaData(metadata) is None
 
 
 def test_cache_full(config_stub, tmpdir):

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -136,10 +136,9 @@ def test_cache_existing_metadata_file(config_stub, tmpdir):
     disk_cache.insert(device)
     disk_cache.updateMetaData(metadata)
 
-    # TODO: Get path and name of file that device has been writing to
-    #fname = str(tmpdir) + "/cache_" + url + ".cache"
-    #assert disk_cache.fileMetaData(fname) == metadata
-    assert True
+    files = list(tmpdir.visit(fil=lambda path: path.isfile()))
+    assert len(files) == 1
+    assert disk_cache.fileMetaData(str(files[0])) == metadata
 
 
 def test_cache_nonexistent_metadata_file(config_stub, tmpdir):

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -19,7 +19,7 @@
 
 """Tests for qutebrowser.browser.cache"""
 
-from PyQt5.QtCore import QUrl, QDateTime, QDataStream
+from PyQt5.QtCore import QUrl, QDateTime
 from PyQt5.QtNetwork import QNetworkDiskCache, QNetworkCacheMetaData
 
 from qutebrowser.browser import cache
@@ -150,7 +150,7 @@ def test_cache_deactivated_insert_data(config_stub, tmpdir):
     }
 
     deactivated_cache = cache.DiskCache(str(tmpdir))
-    assert disk_cache.insert(device) is None
+    assert deactivated_cache.insert(device) is None
 
 
 

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -64,6 +64,54 @@ def test_cache_size_deactivated(config_stub, tmpdir):
     assert disk_cache.cacheSize() == 0
 
 
+def test_cache_existing_metadata_file(config_stub, tmpdir):
+    """Test querying existing meta data file from activated cache."""
+    config_stub.data = {
+        'storage': {'cache-size': 1024},
+        'general': {'private-browsing': False}
+    }
+    url = 'http://qutebrowser.org'
+    content = b'foobar'
+
+    metadata = QNetworkCacheMetaData()
+    metadata.setUrl(QUrl(url))
+    assert metadata.isValid()
+
+    disk_cache = cache.DiskCache(str(tmpdir))
+    device = disk_cache.prepare(metadata)
+    assert device is not None
+    device.write(content)
+    disk_cache.insert(device)
+    disk_cache.updateMetaData(metadata)
+
+    # TODO: Get path and name of file that device has been writing to
+    #fname = str(tmpdir) + "/cache_" + url + ".cache"
+    #assert disk_cache.fileMetaData(fname) == metadata
+    assert True
+
+
+def test_cache_nonexistent_metadata_file(config_stub, tmpdir):
+    """Test querying nonexistent meta data file from activated cache."""
+    config_stub.data = {
+        'storage': {'cache-size': 1024},
+        'general': {'private-browsing': False}
+    }
+
+    disk_cache = cache.DiskCache(str(tmpdir))
+    cache_file = disk_cache.fileMetaData("nosuchfile")
+    assert cache_file.isValid() == False
+
+
+def test_cache_deactivated_metadata_file(config_stub, tmpdir):
+    """Test querying meta data file when cache is deactivated."""
+    config_stub.data = {
+        'storage': {'cache-size': 1024},
+        'general': {'private-browsing': True}
+    }
+    disk_cache = cache.DiskCache(str(tmpdir))
+    assert disk_cache.fileMetaData("foo") == QNetworkCacheMetaData()
+
+
 def test_cache_deactivated_private_browsing(config_stub, tmpdir):
     """Test if cache is deactivated in private-browsing mode."""
     config_stub.data = {

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -261,7 +261,7 @@ def test_cache_remove_data(config_stub, tmpdir):
     preload_cache(disk_cache, url)
     assert disk_cache.cacheSize() > 0
 
-    assert disk_cache.remove(QUrl(url)) == True
+    assert disk_cache.remove(QUrl(url))
     assert disk_cache.cacheSize() == 0
 
 

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -152,11 +152,14 @@ def test_cache_deactivated_insert_data(config_stub, tmpdir):
 
 
 
-def test_cache_remove_data(tmpdir):
+def test_cache_remove_data(config_stub, tmpdir):
     """Test if a previously inserted entry can be removed from the cache."""
+    config_stub.data = {
+        'storage': {'cache-size': 1024},
+        'general': {'private-browsing': False}
+    }
     url = 'http://qutebrowser.org'
-    disk_cache = QNetworkDiskCache()
-    disk_cache.setCacheDirectory(str(tmpdir))
+    disk_cache = cache.DiskCache(str(tmpdir))
     preload_cache(disk_cache, url)
     assert disk_cache.cacheSize() > 0
 

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -213,6 +213,18 @@ def test_cache_metadata(config_stub, tmpdir):
     assert disk_cache.metaData(QUrl(url)) == metadata
 
 
+def test_cache_deactivated_metadata(config_stub, tmpdir):
+    """Test querying metaData() on not activated cache."""
+    config_stub.data = {
+        'storage': {'cache-size': 1024},
+        'general': {'private-browsing': True}
+    }
+    url = 'http://qutebrowser.org'
+
+    disk_cache = cache.DiskCache(str(tmpdir))
+    assert disk_cache.metaData(QUrl(url)) == QNetworkCacheMetaData()
+
+
 def test_cache_update_metadata(config_stub, tmpdir):
     """Test updating the meta data for an existing cache entry."""
     config_stub.data = {

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -180,6 +180,16 @@ def test_cache_clear_activated(config_stub, tmpdir):
     assert disk_cache.cacheSize() == 0
 
 
+def test_cache_clear_deactivated(config_stub, tmpdir):
+    """Test method clear() on deactivated cache."""
+    config_stub.data = {
+        'storage': {'cache-size': 1024},
+        'general': {'private-browsing': True}
+    }
+    disk_cache = cache.DiskCache(str(tmpdir))
+    assert disk_cache.clear() is None
+
+
 def test_cache_metadata(tmpdir):
     """Ensure that DiskCache.metaData() returns exactly what was inserted."""
     url = 'http://qutebrowser.org'

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -45,8 +45,7 @@ def test_cache_config_change_cache_size(config_stub, tmpdir):
     disk_cache = cache.DiskCache(str(tmpdir))
     assert disk_cache.maximumCacheSize() == max_cache_size
 
-    config_stub.data['storage']['cache-size'] = max_cache_size * 2
-    config_stub.changed.emit('storage', 'cache-size')
+    config_stub.set('storage', 'cache-size', max_cache_size * 2)
     assert disk_cache.maximumCacheSize() == max_cache_size * 2
 
 
@@ -61,8 +60,7 @@ def test_cache_config_enable_private_browsing(config_stub, tmpdir):
     preload_cache(disk_cache)
     assert disk_cache.cacheSize() > 0
 
-    config_stub.data['general']['private-browsing'] = True
-    config_stub.changed.emit('general', 'private-browsing')
+    config_stub.set('general', 'private-browsing', True)
     assert disk_cache.cacheSize() == 0
 
 
@@ -80,8 +78,7 @@ def test_cache_config_disable_private_browsing(config_stub, tmpdir):
     disk_cache = cache.DiskCache(str(tmpdir))
     assert disk_cache.prepare(metadata) is None
 
-    config_stub.data['general']['private-browsing'] = False
-    config_stub.changed.emit('general', 'private-browsing')
+    config_stub.set('general', 'private-browsing', False)
     content = b'cute'
     preload_cache(disk_cache, url, content)
     assert disk_cache.data(QUrl(url)).readAll() == content


### PR DESCRIPTION
This includes a few more tests and fixes all the tests that weren't actually using qutebrowsers DiskCache class but rather Qts QNetworkDiskCache (thus not actually testing any code paths in cache.py).

It's not 100% coverage of cache.py yet, but much closer. Missing paths (WIP):

- [x] on_config_changed (cache-size)
- [x] on_config_changed (private-browsing)
- [x] fileMetaData (activated)
- [x] fileMetaData (deactivated)
- [x] insert (deactivated)
- [x] metaData (deactivated)

ref #999
