### PR TITLE
Implement :download-clear command.

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -14,6 +14,7 @@
 |<<close,close>>|Close the current window.
 |<<download,download>>|Download a given URL, or current page if no URL given.
 |<<download-cancel,download-cancel>>|Cancel the last/[count]th download.
+|<<download-clear,download-clear>>|Remove all finished downloads from the list.
 |<<download-delete,download-delete>>|Delete the last/[count]th download from disk.
 |<<download-open,download-open>>|Open the last/[count]th download.
 |<<download-remove,download-remove>>|Remove the last/[count]th download from the list.
@@ -157,6 +158,10 @@ Cancel the last/[count]th download.
 
 ==== count
 The index of the download to cancel.
+
+[[download-clear]]
+=== download-clear
+Remove all finished downloads from the list.
 
 [[download-delete]]
 === download-delete

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -976,10 +976,12 @@ class DownloadManager(QAbstractListModel):
         """Remove the last/[count]th download from the list.
 
         Args:
-            all_: If given removes all finished downloads.
+            all_: Deprecated argument for removing all finished downloads.
             count: The index of the download to cancel.
         """
         if all_:
+            message.warning(self._win_id, ":download-remove --all is "
+                            "deprecated - use :download-clear instead!")
             self.download_clear()
         else:
             try:

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -964,6 +964,12 @@ class DownloadManager(QAbstractListModel):
         """Check if there are finished downloads to clear."""
         return any(download.done for download in self.downloads)
 
+    @cmdutils.register(instance='download-manager', scope='window')
+    def download_clear(self):
+        """Remove all finished downloads from the list."""
+        finished_items = [d for d in self.downloads if d.done]
+        self.remove_items(finished_items)
+
     @cmdutils.register(instance='download-manager', scope='window',
                        count='count')
     def download_remove(self, all_=False, count=0):
@@ -974,8 +980,7 @@ class DownloadManager(QAbstractListModel):
             count: The index of the download to cancel.
         """
         if all_:
-            finished_items = [d for d in self.downloads if d.done]
-            self.remove_items(finished_items)
+            self.download_clear()
         else:
             try:
                 download = self.downloads[count - 1]

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -1497,4 +1497,6 @@ CHANGED_KEY_COMMANDS = [
 
     (re.compile(r'^search *;; *clear-keychain$'), r'clear-keychain ;; search'),
     (re.compile(r'^leave-mode$'), r'clear-keychain ;; leave-mode'),
+
+    (re.compile(r'^download-remove --all$'), r'download-clear'),
 ]

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -1373,7 +1373,7 @@ KEY_DATA = collections.OrderedDict([
         ('inspector', ['wi']),
         ('download', ['gd']),
         ('download-cancel', ['ad']),
-        ('download-remove --all', ['cd']),
+        ('download-clear', ['cd']),
         ('view-source', ['gf']),
         ('tab-focus last', ['<Ctrl-Tab>']),
         ('enter-mode passthrough', ['<Ctrl-V>']),

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -251,6 +251,8 @@ class TestKeyConfigParser:
             ('search;;foo', None),
             ('leave-mode', 'clear-keychain ;; leave-mode'),
             ('leave-mode ;; foo', None),
+
+            ('download-remove --all', 'download-clear'),
         ]
     )
     def test_migrations(self, old, new_expected):


### PR DESCRIPTION
Fixes #1013.

If this gets merged, the --all option from download-remove could be removed. This will however break the 'cd' key binding from existing configurations. Is there a way to change it automatically or it should be left as it is?