### PR TITLE
Avoid separated registering of qute: handlers

### DIFF
--- a/qutebrowser/browser/network/qutescheme.py
+++ b/qutebrowser/browser/network/qutescheme.py
@@ -49,6 +49,15 @@ class QuteSchemeHandler(schemehandler.SchemeHandler):
 
     """Scheme handler for qute: URLs."""
 
+    handlers = dict()
+
+    @staticmethod
+    def addHandler(name):
+        """Add a handler to the qute: sheme."""
+        def namedecorator(function):
+            QuteSchemeHandler.handlers[name] = function
+        return namedecorator
+
     def createRequest(self, _op, request, _outgoing_data):
         """Create a new request.
 
@@ -66,10 +75,10 @@ class QuteSchemeHandler(schemehandler.SchemeHandler):
         log.misc.debug("url: {}, path: {}, host {}".format(
             request.url().toDisplayString(), path, host))
         try:
-            handler = HANDLERS[path]
+            handler = QuteSchemeHandler.handlers[path]
         except KeyError:
             try:
-                handler = HANDLERS[host]
+                handler = QuteSchemeHandler.handlers[host]
             except KeyError:
                 errorstr = "No handler found for {}!".format(
                     request.url().toDisplayString())
@@ -108,6 +117,7 @@ class JSBridge(QObject):
             message.error(win_id, e)
 
 
+@QuteSchemeHandler.addHandler('pyeval')
 def qute_pyeval(_win_id, _request):
     """Handler for qute:pyeval. Return HTML content as bytes."""
     html = jinja.env.get_template('pre.html').render(
@@ -123,6 +133,7 @@ def qute_version(_win_id, _request):
     return html.encode('UTF-8', errors='xmlcharrefreplace')
 
 
+@QuteSchemeHandler.addHandler('plainlog')
 def qute_plainlog(_win_id, _request):
     """Handler for qute:plainlog. Return HTML content as bytes."""
     if log.ram_handler is None:
@@ -133,6 +144,7 @@ def qute_plainlog(_win_id, _request):
     return html.encode('UTF-8', errors='xmlcharrefreplace')
 
 
+@QuteSchemeHandler.addHandler('log')
 def qute_log(_win_id, _request):
     """Handler for qute:log. Return HTML content as bytes."""
     if log.ram_handler is None:
@@ -144,11 +156,13 @@ def qute_log(_win_id, _request):
     return html.encode('UTF-8', errors='xmlcharrefreplace')
 
 
+@QuteSchemeHandler.addHandler('gpl')
 def qute_gpl(_win_id, _request):
     """Handler for qute:gpl. Return HTML content as bytes."""
     return utils.read_file('html/COPYING.html').encode('ASCII')
 
 
+@QuteSchemeHandler.addHandler('help')
 def qute_help(win_id, request):
     """Handler for qute:help. Return HTML content as bytes."""
     try:
@@ -176,6 +190,7 @@ def qute_help(win_id, request):
     return utils.read_file(path).encode('UTF-8', errors='xmlcharrefreplace')
 
 
+@QuteSchemeHandler.addHandler('settings')
 def qute_settings(win_id, _request):
     """Handler for qute:settings. View/change qute configuration."""
     config_getter = functools.partial(objreg.get('config').get, raw=True)
@@ -184,13 +199,3 @@ def qute_settings(win_id, _request):
         confget=config_getter)
     return html.encode('UTF-8', errors='xmlcharrefreplace')
 
-
-HANDLERS = {
-    'pyeval': qute_pyeval,
-    'version': qute_version,
-    'plainlog': qute_plainlog,
-    'log': qute_log,
-    'gpl': qute_gpl,
-    'help': qute_help,
-    'settings': qute_settings,
-}

--- a/qutebrowser/browser/network/qutescheme.py
+++ b/qutebrowser/browser/network/qutescheme.py
@@ -45,10 +45,10 @@ from qutebrowser.config import configexc, configdata
 pyeval_output = ":pyeval was never called"
 
 
-HANDLERS = dict()
+HANDLERS = {}
 
-def addHandler(name):
-    """Add a handler to the qute: sheme."""
+def add_handler(name):
+    """Add a handler to the qute: scheme."""
     def namedecorator(function):
         HANDLERS[name] = function
     return namedecorator

--- a/qutebrowser/browser/network/qutescheme.py
+++ b/qutebrowser/browser/network/qutescheme.py
@@ -45,18 +45,17 @@ from qutebrowser.config import configexc, configdata
 pyeval_output = ":pyeval was never called"
 
 
+HANDLERS = dict()
+
+def addHandler(name):
+    """Add a handler to the qute: sheme."""
+    def namedecorator(function):
+        HANDLERS[name] = function
+    return namedecorator
+
 class QuteSchemeHandler(schemehandler.SchemeHandler):
 
     """Scheme handler for qute: URLs."""
-
-    handlers = dict()
-
-    @classmethod
-    def addHandler(cls, name):
-        """Add a handler to the qute: sheme."""
-        def namedecorator(function):
-            cls.handlers[name] = function
-        return namedecorator
 
     def createRequest(self, _op, request, _outgoing_data):
         """Create a new request.
@@ -75,10 +74,10 @@ class QuteSchemeHandler(schemehandler.SchemeHandler):
         log.misc.debug("url: {}, path: {}, host {}".format(
             request.url().toDisplayString(), path, host))
         try:
-            handler = QuteSchemeHandler.handlers[path]
+            handler = HANDLERS[path]
         except KeyError:
             try:
-                handler = QuteSchemeHandler.handlers[host]
+                handler = HANDLERS[host]
             except KeyError:
                 errorstr = "No handler found for {}!".format(
                     request.url().toDisplayString())
@@ -117,7 +116,7 @@ class JSBridge(QObject):
             message.error(win_id, e)
 
 
-@QuteSchemeHandler.addHandler('pyeval')
+@addHandler('pyeval')
 def qute_pyeval(_win_id, _request):
     """Handler for qute:pyeval. Return HTML content as bytes."""
     html = jinja.env.get_template('pre.html').render(
@@ -133,7 +132,7 @@ def qute_version(_win_id, _request):
     return html.encode('UTF-8', errors='xmlcharrefreplace')
 
 
-@QuteSchemeHandler.addHandler('plainlog')
+@addHandler('plainlog')
 def qute_plainlog(_win_id, _request):
     """Handler for qute:plainlog. Return HTML content as bytes."""
     if log.ram_handler is None:
@@ -144,7 +143,7 @@ def qute_plainlog(_win_id, _request):
     return html.encode('UTF-8', errors='xmlcharrefreplace')
 
 
-@QuteSchemeHandler.addHandler('log')
+@addHandler('log')
 def qute_log(_win_id, _request):
     """Handler for qute:log. Return HTML content as bytes."""
     if log.ram_handler is None:
@@ -156,13 +155,13 @@ def qute_log(_win_id, _request):
     return html.encode('UTF-8', errors='xmlcharrefreplace')
 
 
-@QuteSchemeHandler.addHandler('gpl')
+@addHandler('gpl')
 def qute_gpl(_win_id, _request):
     """Handler for qute:gpl. Return HTML content as bytes."""
     return utils.read_file('html/COPYING.html').encode('ASCII')
 
 
-@QuteSchemeHandler.addHandler('help')
+@addHandler('help')
 def qute_help(win_id, request):
     """Handler for qute:help. Return HTML content as bytes."""
     try:
@@ -190,7 +189,7 @@ def qute_help(win_id, request):
     return utils.read_file(path).encode('UTF-8', errors='xmlcharrefreplace')
 
 
-@QuteSchemeHandler.addHandler('settings')
+@addHandler('settings')
 def qute_settings(win_id, _request):
     """Handler for qute:settings. View/change qute configuration."""
     config_getter = functools.partial(objreg.get('config').get, raw=True)

--- a/qutebrowser/browser/network/qutescheme.py
+++ b/qutebrowser/browser/network/qutescheme.py
@@ -51,6 +51,7 @@ def add_handler(name):
     """Add a handler to the qute: scheme."""
     def namedecorator(function):
         HANDLERS[name] = function
+        return function
     return namedecorator
 
 class QuteSchemeHandler(schemehandler.SchemeHandler):
@@ -116,7 +117,7 @@ class JSBridge(QObject):
             message.error(win_id, e)
 
 
-@addHandler('pyeval')
+@add_handler('pyeval')
 def qute_pyeval(_win_id, _request):
     """Handler for qute:pyeval. Return HTML content as bytes."""
     html = jinja.env.get_template('pre.html').render(
@@ -132,7 +133,7 @@ def qute_version(_win_id, _request):
     return html.encode('UTF-8', errors='xmlcharrefreplace')
 
 
-@addHandler('plainlog')
+@add_handler('plainlog')
 def qute_plainlog(_win_id, _request):
     """Handler for qute:plainlog. Return HTML content as bytes."""
     if log.ram_handler is None:
@@ -143,7 +144,7 @@ def qute_plainlog(_win_id, _request):
     return html.encode('UTF-8', errors='xmlcharrefreplace')
 
 
-@addHandler('log')
+@add_handler('log')
 def qute_log(_win_id, _request):
     """Handler for qute:log. Return HTML content as bytes."""
     if log.ram_handler is None:
@@ -155,13 +156,13 @@ def qute_log(_win_id, _request):
     return html.encode('UTF-8', errors='xmlcharrefreplace')
 
 
-@addHandler('gpl')
+@add_handler('gpl')
 def qute_gpl(_win_id, _request):
     """Handler for qute:gpl. Return HTML content as bytes."""
     return utils.read_file('html/COPYING.html').encode('ASCII')
 
 
-@addHandler('help')
+@add_handler('help')
 def qute_help(win_id, request):
     """Handler for qute:help. Return HTML content as bytes."""
     try:
@@ -189,7 +190,7 @@ def qute_help(win_id, request):
     return utils.read_file(path).encode('UTF-8', errors='xmlcharrefreplace')
 
 
-@addHandler('settings')
+@add_handler('settings')
 def qute_settings(win_id, _request):
     """Handler for qute:settings. View/change qute configuration."""
     config_getter = functools.partial(objreg.get('config').get, raw=True)

--- a/qutebrowser/browser/network/qutescheme.py
+++ b/qutebrowser/browser/network/qutescheme.py
@@ -51,11 +51,11 @@ class QuteSchemeHandler(schemehandler.SchemeHandler):
 
     handlers = dict()
 
-    @staticmethod
-    def addHandler(name):
+    @classmethod
+    def addHandler(cls, name):
         """Add a handler to the qute: sheme."""
         def namedecorator(function):
-            QuteSchemeHandler.handlers[name] = function
+            cls.handlers[name] = function
         return namedecorator
 
     def createRequest(self, _op, request, _outgoing_data):


### PR DESCRIPTION
I was looking at implementing a new qute: handler for downloads, so I was studying the handlers file. Imho, registration decorators are easier to maintain than a global constant.