### PR TITLE
Named Windows (Fix #1096)

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -110,7 +110,7 @@ class CommandDispatcher:
             raise cmdexc.CommandError("No WebView available yet!")
         return widget
 
-    def _open(self, url, tab=False, background=False, window=False):
+    def _open(self, url, tab=False, background=False, window=False, name=""):
         """Helper function to open a page.
 
         Args:
@@ -124,6 +124,8 @@ class CommandDispatcher:
         cmdutils.check_exclusive((tab, background, window), 'tbw')
         if window:
             tabbed_browser = self._new_tabbed_browser()
+            if name:
+                tabbed_browser.setName(name)
             tabbed_browser.tabopen(url)
         elif tab:
             tabbed_browser.tabopen(url, background=False, explicit=True)
@@ -286,7 +288,8 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', name='open',
                        maxsplit=0, scope='window', count='count',
                        completion=[usertypes.Completion.url])
-    def openurl(self, url=None, bg=False, tab=False, window=False, count=None):
+    def openurl(self, url=None, bg=False, tab=False, window=False, count=None,
+                *, name=""):
         """Open a URL in the current/[count]th tab.
 
         Args:
@@ -307,8 +310,10 @@ class CommandDispatcher:
                 url = urlutils.fuzzy_url(url)
             except urlutils.InvalidUrlError as e:
                 raise cmdexc.CommandError(e)
+        if (tab or bg) and name:
+            raise cmdexc.CommandError("--name only makes sense with --window!")
         if tab or bg or window:
-            self._open(url, tab, bg, window)
+            self._open(url, tab, bg, window, name)
         else:
             curtab = self._cntwidget(count)
             if curtab is None:

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -273,6 +273,16 @@ class CommandDispatcher:
             self._tabbed_browser.close_tab(tab)
             tabbar.setSelectionBehaviorOnRemove(old_selection_behavior)
 
+    @cmdutils.register(instance='command-dispatcher', name='set-window-name',
+                       maxsplit=0, scope='window')
+    def set_window_name(self, name=""):
+        """Set the current windows name.
+
+        Args:
+            name: The new name of the window.
+        """
+        self._tabbed_browser.setName(name)
+
     @cmdutils.register(instance='command-dispatcher', name='open',
                        maxsplit=0, scope='window', count='count',
                        completion=[usertypes.Completion.url])

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -69,10 +69,10 @@ class CommandDispatcher:
     def __repr__(self):
         return utils.get_repr(self)
 
-    def _new_tabbed_browser(self):
+    def _new_tabbed_browser(self, name=""):
         """Get a tabbed-browser from a new window."""
         from qutebrowser.mainwindow import mainwindow
-        new_window = mainwindow.MainWindow()
+        new_window = mainwindow.MainWindow(name=name)
         new_window.show()
         return new_window.tabbed_browser
 
@@ -123,9 +123,7 @@ class CommandDispatcher:
         tabbed_browser = self._tabbed_browser
         cmdutils.check_exclusive((tab, background, window), 'tbw')
         if window:
-            tabbed_browser = self._new_tabbed_browser()
-            if name:
-                tabbed_browser.setName(name)
+            tabbed_browser = self._new_tabbed_browser(name)
             tabbed_browser.tabopen(url)
         elif tab:
             tabbed_browser.tabopen(url, background=False, explicit=True)

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -307,7 +307,8 @@ def data(readonly=False):
             ('window-title-format',
              SettingValue(typ.FormatString(fields=['perc', 'perc_raw', 'title',
                                                    'title_sep', 'id',
-                                                   'scroll_pos', 'name', 'name_sep']),
+                                                   'scroll_pos', 'name',
+                                                   'name_sep']),
                           '{perc}{title}{title_sep}qutebrowser{name_sep}{name}'),
              "The format to use for the window title. The following "
              "placeholders are defined:\n\n"

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -307,14 +307,17 @@ def data(readonly=False):
             ('window-title-format',
              SettingValue(typ.FormatString(fields=['perc', 'perc_raw', 'title',
                                                    'title_sep', 'id',
-                                                   'scroll_pos']),
-                          '{perc}{title}{title_sep}qutebrowser'),
+                                                   'scroll_pos', 'name', 'name_sep']),
+                          '{perc}{title}{title_sep}qutebrowser{name_sep}{name}'),
              "The format to use for the window title. The following "
              "placeholders are defined:\n\n"
              "* `{perc}`: The percentage as a string like `[10%]`.\n"
              "* `{perc_raw}`: The raw percentage, e.g. `10`\n"
              "* `{title}`: The title of the current web page\n"
              "* `{title_sep}`: The string ` - ` if a title is set, empty "
+             "otherwise.\n"
+             "* `{name}`: The name of the current web page\n"
+             "* `{name_sep}`: The string `-` if a name is set, empty "
              "otherwise.\n"
              "* `{id}`: The internal window ID of this window.\n"
              "* `{scroll_pos}`: The page scroll position."),

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -102,7 +102,7 @@ class MainWindow(QWidget):
         _commandrunner: The main CommandRunner instance.
     """
 
-    def __init__(self, geometry=None, parent=None):
+    def __init__(self, geometry=None, name="", parent=None):
         """Create a new main window.
 
         Args:
@@ -113,6 +113,9 @@ class MainWindow(QWidget):
         self.setAttribute(Qt.WA_DeleteOnClose)
         self._commandrunner = None
         self.win_id = next(win_id_gen)
+        self._name = name
+        self.update_window_title()
+
         self.registry = objreg.ObjectRegistry()
         objreg.window_registry[self.win_id] = self
         objreg.register('main-window', self, scope='window',
@@ -125,7 +128,6 @@ class MainWindow(QWidget):
         objreg.register('message-bridge', message_bridge, scope='window',
                         window=self.win_id)
 
-        self.setWindowTitle('qutebrowser')
         self._vbox = QVBoxLayout(self)
         self._vbox.setContentsMargins(0, 0, 0, 0)
         self._vbox.setSpacing(0)
@@ -186,6 +188,31 @@ class MainWindow(QWidget):
         #self.retranslateUi(MainWindow)
         #self.tabWidget.setCurrentIndex(0)
         #QtCore.QMetaObject.connectSlotsByName(MainWindow)
+
+    def update_window_title(self, title=""):
+        """Update window title.
+
+        :title: A format string for the window title.
+        """
+        fields = {}
+        if not title:
+            fields['perc'] = ''
+            fields['perc_raw'] = ''
+            fields['title'] = ''
+            fields['title_sep'] = ''
+            fields['scroll_pos'] = ''
+
+        fields['id'] = self.win_id
+        fields['name_sep'] = '-' if self._name else ''
+        fields['name'] = self._name
+        self.setWindowTitle(title.format(**fields))
+
+    def name(self):
+        return self._name
+
+    def setName(self, name):
+        self._name = name
+        self.update_window_title()
 
     def __repr__(self):
         return utils.get_repr(self)

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -100,6 +100,7 @@ class TabbedBrowser(tabwidget.TabWidget):
     def __init__(self, win_id, parent=None):
         super().__init__(win_id, parent)
         self._win_id = win_id
+        self._name = ""
         self._tab_insert_idx_left = 0
         self._tab_insert_idx_right = -1
         self._shutting_down = False
@@ -145,6 +146,10 @@ class TabbedBrowser(tabwidget.TabWidget):
             w.append(self.widget(i))
         return w
 
+    def setName(self, name):
+        self._name = name
+        self.update_window_title()
+
     @config.change_filter('ui', 'window-title-format')
     def update_window_title(self):
         """Change the window title to match the current tab."""
@@ -165,6 +170,8 @@ class TabbedBrowser(tabwidget.TabWidget):
         fields['title'] = tabtitle
         fields['title_sep'] = ' - ' if tabtitle else ''
         fields['id'] = self._win_id
+        fields['name_sep'] = '-' if self._name else ''
+        fields['name'] = self._name
         y = widget.scroll_pos[1]
         if y <= 0:
             scroll_pos = 'top'

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -146,6 +146,9 @@ class TabbedBrowser(tabwidget.TabWidget):
             w.append(self.widget(i))
         return w
 
+    def name(self):
+        return self._name
+
     def setName(self, name):
         self._name = name
         self.update_window_title()

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -146,13 +146,6 @@ class TabbedBrowser(tabwidget.TabWidget):
             w.append(self.widget(i))
         return w
 
-    def name(self):
-        return self._name
-
-    def setName(self, name):
-        self._name = name
-        self.update_window_title()
-
     @config.change_filter('ui', 'window-title-format')
     def update_window_title(self):
         """Change the window title to match the current tab."""
@@ -165,16 +158,13 @@ class TabbedBrowser(tabwidget.TabWidget):
         widget = self.widget(idx)
 
         fields = {}
-        if widget.load_status == webview.LoadStatus.loading:
+        if widget and widget.load_status == webview.LoadStatus.loading:
             fields['perc'] = '[{}%] '.format(widget.progress)
         else:
             fields['perc'] = ''
         fields['perc_raw'] = widget.progress
         fields['title'] = tabtitle
         fields['title_sep'] = ' - ' if tabtitle else ''
-        fields['id'] = self._win_id
-        fields['name_sep'] = '-' if self._name else ''
-        fields['name'] = self._name
         y = widget.scroll_pos[1]
         if y <= 0:
             scroll_pos = 'top'
@@ -184,8 +174,13 @@ class TabbedBrowser(tabwidget.TabWidget):
             scroll_pos = '{:2}%'.format(y)
 
         fields['scroll_pos'] = scroll_pos
+
+        # there's a better/cleaner solution: http://stackoverflow.com/a/11284026
+        fields['id'] = "{id}"
+        fields['name_sep'] = "{name_sep}"
+        fields['name'] = "{name}"
         fmt = config.get('ui', 'window-title-format')
-        self.window().setWindowTitle(fmt.format(**fields))
+        self.window().update_window_title(fmt.format(**fields))
 
     def _connect_tab_signals(self, tab):
         """Set up the needed signals for tab."""

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -178,6 +178,8 @@ class SessionManager(QObject):
                                      window=win_id)
             win_data = {}
             active_window = QApplication.instance().activeWindow()
+            if tabbed_browser.name():
+                win_data['name'] = tabbed_browser.name()
             if getattr(active_window, 'win_id', None) == win_id:
                 win_data['active'] = True
             win_data['geometry'] = bytes(main_window.saveGeometry())
@@ -307,6 +309,8 @@ class SessionManager(QObject):
             window.show()
             tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                         window=window.win_id)
+            if 'name' in win:
+                tabbed_browser.setName(win['name'])
             tab_to_focus = None
             for i, tab in enumerate(win['tabs']):
                 new_tab = tabbed_browser.tabopen()

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -178,8 +178,8 @@ class SessionManager(QObject):
                                      window=win_id)
             win_data = {}
             active_window = QApplication.instance().activeWindow()
-            if tabbed_browser.name():
-                win_data['name'] = tabbed_browser.name()
+            if main_window.name():
+                win_data['name'] = main_window.name()
             if getattr(active_window, 'win_id', None) == win_id:
                 win_data['active'] = True
             win_data['geometry'] = bytes(main_window.saveGeometry())
@@ -305,12 +305,10 @@ class SessionManager(QObject):
             raise SessionError(e)
         log.sessions.debug("Loading session {} from {}...".format(name, path))
         for win in data['windows']:
-            window = mainwindow.MainWindow(geometry=win['geometry'])
+            window = mainwindow.MainWindow(geometry=win['geometry'],name=win['name'])
             window.show()
             tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                         window=window.win_id)
-            if 'name' in win:
-                tabbed_browser.setName(win['name'])
             tab_to_focus = None
             for i, tab in enumerate(win['tabs']):
                 new_tab = tabbed_browser.tabopen()


### PR DESCRIPTION
- [ui]window-title-format
  - [x] Add {name}  and {name_sep} field
  - [ ] Change the default to {perc}{title}{title_sep}qutebrowser{name_sep}{name}

- Commands
  * [x] `:open -w -n <window-name>`: opens a new window the name `<window-name>`
  * [ ] Fix completion
  * [x] `:set-window-name <window-name>`: set the name of the current window and updates window title

- Session
  - [x] Save the window name into the session files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-compiler/qutebrowser/1101)
<!-- Reviewable:end -->
