### PR TITLE
Change error to warning for text not found on page

### DIFF
--- a/qutebrowser/browser/webview.py
+++ b/qutebrowser/browser/webview.py
@@ -530,7 +530,7 @@ class WebView(QWebView):
                                     "match for: {}".format(text),
                                     immediately=True)
             else:
-                message.error(self.win_id, "Text '{}' not found on "
+                message.warning(self.win_id, "Text '{}' not found on "
                               "page!".format(text), immediately=True)
         else:
             def check_scroll_pos():


### PR DESCRIPTION
This is a purely personal preference, but rather than open an issue and suggest it I thought I would just open a PR and you can decide to include it or not! :smile: It really bugged me every time I saw an 'error' in the log, which was just the result of a failed search. I changed the log level to 'info' first, but i think 'warning' highlights it better, without actually reporting an 'error'.

Now - as I say - this is purely a personal thing, please feel free to close the PR without merging if you don't agree, I won't have any problem with that. Thanks for all your work.