### PR TITLE
Remove unnecessary 'usage:' from argument parser.

### DIFF
--- a/qutebrowser/qutebrowser.py
+++ b/qutebrowser/qutebrowser.py
@@ -44,7 +44,7 @@ from qutebrowser.misc import earlyinit
 
 def get_argparser():
     """Get the argparse parser."""
-    parser = argparse.ArgumentParser("usage: qutebrowser",
+    parser = argparse.ArgumentParser(prog='qutebrowser',
                                      description=qutebrowser.__description__)
     parser.add_argument('-c', '--confdir', help="Set config directory (empty "
                         "for no config storage).")


### PR DESCRIPTION
`prog` parameter in `ArgumentParser` is `"usage: qutebrowser"` but the word `usage` gets already printed in the help message generated from argparse. So the output of `qutebrowser --help` ends up starting with `usage: usage: qutebrowser`. This PR fixes it.