### PR TITLE
Fix TypeError in ConfigManager.remove_option

### DIFF
--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -619,7 +619,7 @@ class ConfigManager(QObject):
         optname = self.optionxform(optname)
         existed = optname in sectdict
         if existed:
-            del sectdict[optname]
+            sectdict.delete(optname)
             # WORKAROUND for https://bitbucket.org/logilab/pylint/issues/659/
             self.get.cache_clear()  # pylint: disable=no-member
         return existed

--- a/qutebrowser/config/sections.py
+++ b/qutebrowser/config/sections.py
@@ -73,7 +73,7 @@ class Section:
         return self.values.keys()
 
     def delete(self, key):
-        """Delete item with given key"""
+        """Delete item with given key."""
         del self.values[key]
 
     def setv(self, layer, key, value, interpolated):

--- a/qutebrowser/config/sections.py
+++ b/qutebrowser/config/sections.py
@@ -72,6 +72,10 @@ class Section:
         """Get value keys."""
         return self.values.keys()
 
+    def delete(self, key):
+        """Delete item with given key"""
+        del self.values[key]
+
     def setv(self, layer, key, value, interpolated):
         """Set the value on a layer.
 


### PR DESCRIPTION
Calling remove_option() from config.config.ConfigManager raises a TypeError since 'Key Value' object does not support item deletion. This function isn't currently used in the project.
