### PR TITLE
Implement pasting of mulitple urls

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -827,7 +827,7 @@ class CommandDispatcher:
             raise cmdexc.CommandError("{} is empty.".format(target))
         log.misc.debug("{} contained: '{}'".format(target,
                                                    text.replace('\n', '\\n')))
-        text_urls = enumerate([u for u in text.split('\n') if u != ''])
+        text_urls = enumerate(u for u in text.split('\n') if u)
         for i, text_url in text_urls:
             if not window and i > 0:
                 tab = False

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -825,12 +825,18 @@ class CommandDispatcher:
         text = clipboard.text(mode)
         if not text:
             raise cmdexc.CommandError("{} is empty.".format(target))
-        log.misc.debug("{} contained: '{}'".format(target, text))
-        try:
-            url = urlutils.fuzzy_url(text)
-        except urlutils.InvalidUrlError as e:
-            raise cmdexc.CommandError(e)
-        self._open(url, tab, bg, window)
+        log.misc.debug("{} contained: '{}'".format(target,
+                                                   text.replace('\n', '\\n')))
+        text_urls = enumerate([u for u in text.split('\n') if u != ''])
+        for i, text_url in text_urls:
+            if not window and i > 0:
+                tab = False
+                bg = True
+            try:
+                url = urlutils.fuzzy_url(text_url)
+            except urlutils.InvalidUrlError as e:
+                raise cmdexc.CommandError(e)
+            self._open(url, tab, bg, window)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        count='count')

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -168,6 +168,7 @@ def fuzzy_url(urlstr, cwd=None, relative=False, do_search=True):
     Return:
         A target QUrl to a search page or the original URL.
     """
+    urlstr = urlstr.strip()
     expanded = os.path.expanduser(urlstr)
     if os.path.isabs(expanded):
         path = expanded
@@ -181,7 +182,6 @@ def fuzzy_url(urlstr, cwd=None, relative=False, do_search=True):
     else:
         path = None
 
-    stripped = urlstr.strip()
     if path is not None and os.path.exists(path):
         log.url.debug("URL is a local file")
         url = QUrl.fromLocalFile(path)

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -185,7 +185,7 @@ def fuzzy_url(urlstr, cwd=None, relative=False, do_search=True):
     if path is not None and os.path.exists(path):
         log.url.debug("URL is a local file")
         url = QUrl.fromLocalFile(path)
-    elif (not do_search) or is_url(stripped):
+    elif (not do_search) or is_url(urlstr):
         # probably an address
         log.url.debug("URL is a fuzzy address")
         url = qurl_from_user_input(urlstr)
@@ -194,7 +194,7 @@ def fuzzy_url(urlstr, cwd=None, relative=False, do_search=True):
         try:
             url = _get_search_url(urlstr)
         except ValueError:  # invalid search engine
-            url = qurl_from_user_input(stripped)
+            url = qurl_from_user_input(urlstr)
     log.url.debug("Converting fuzzy term {} to URL -> {}".format(
                   urlstr, url.toDisplayString()))
     if do_search and config.get('general', 'auto-search'):

--- a/tests/integration/features/conftest.py
+++ b/tests/integration/features/conftest.py
@@ -199,6 +199,7 @@ def selection_supported(qapp):
 def fill_clipboard(qtbot, qapp, httpbin, what, content):
     mode = _clipboard_mode(qapp, what)
     content = content.replace('(port)', str(httpbin.port))
+    content = content.replace('\\n', '\n')
 
     clipboard = qapp.clipboard()
     with qtbot.waitSignal(clipboard.changed):

--- a/tests/integration/features/conftest.py
+++ b/tests/integration/features/conftest.py
@@ -199,11 +199,18 @@ def selection_supported(qapp):
 def fill_clipboard(qtbot, qapp, httpbin, what, content):
     mode = _clipboard_mode(qapp, what)
     content = content.replace('(port)', str(httpbin.port))
-    content = content.replace('\\n', '\n')
 
     clipboard = qapp.clipboard()
     with qtbot.waitSignal(clipboard.changed):
         clipboard.setText(content, mode)
+
+
+@bdd.when(bdd.parsers.re(r'I put the following lines into the '
+                         r'(?P<what>primary selection|clipboard):\n'
+                         r'(?P<content>.+)$', flags=re.DOTALL))
+def fill_clipboard_multiline(qtbot, qapp, httpbin, what, content):
+    content = '\n'.join(l.strip() for l in content.strip().split('\n'))
+    fill_clipboard(qtbot, qapp, httpbin, what, content)
 
 
 ## Then

--- a/tests/integration/features/conftest.py
+++ b/tests/integration/features/conftest.py
@@ -25,6 +25,7 @@ import json
 import os.path
 import logging
 import collections
+import textwrap
 
 import pytest
 import yaml
@@ -209,8 +210,7 @@ def fill_clipboard(qtbot, qapp, httpbin, what, content):
                          r'(?P<what>primary selection|clipboard):\n'
                          r'(?P<content>.+)$', flags=re.DOTALL))
 def fill_clipboard_multiline(qtbot, qapp, httpbin, what, content):
-    content = '\n'.join(l.strip() for l in content.strip().split('\n'))
-    fill_clipboard(qtbot, qapp, httpbin, what, content)
+    fill_clipboard(qtbot, qapp, httpbin, what, textwrap.dedent(content))
 
 
 ## Then

--- a/tests/integration/features/yankpaste.feature
+++ b/tests/integration/features/yankpaste.feature
@@ -107,11 +107,10 @@ Feature: Yanking and pasting.
 
     Scenario: Pasting multiple urls in a new tab
         Given I have a fresh instance
-        When I run :tab-only
-        And I put the following lines into the clipboard:
-           http://localhost:(port)/data/hello.txt
-           http://localhost:(port)/data/hello2.txt
-           http://localhost:(port)/data/hello3.txt
+        When I put the following lines into the clipboard:
+            http://localhost:(port)/data/hello.txt
+            http://localhost:(port)/data/hello2.txt
+            http://localhost:(port)/data/hello3.txt
         And I run :paste -t
         And I wait until data/hello.txt is loaded
         And I wait until data/hello2.txt is loaded
@@ -126,9 +125,9 @@ Feature: Yanking and pasting.
         Given I open about:blank
         When I run :tab-only
         And I put the following lines into the clipboard:
-           http://localhost:(port)/data/hello.txt
-           http://localhost:(port)/data/hello2.txt
-           http://localhost:(port)/data/hello3.txt
+            http://localhost:(port)/data/hello.txt
+            http://localhost:(port)/data/hello2.txt
+            http://localhost:(port)/data/hello3.txt
         And I run :paste -b
         And I wait until data/hello.txt is loaded
         And I wait until data/hello2.txt is loaded
@@ -142,9 +141,9 @@ Feature: Yanking and pasting.
     Scenario: Pasting multiple urls in new windows
         Given I have a fresh instance
         When I put the following lines into the clipboard:
-           http://localhost:(port)/data/hello.txt
-           http://localhost:(port)/data/hello2.txt
-           http://localhost:(port)/data/hello3.txt
+            http://localhost:(port)/data/hello.txt
+            http://localhost:(port)/data/hello2.txt
+            http://localhost:(port)/data/hello3.txt
         And I run :paste -w
         And I wait until data/hello.txt is loaded
         And I wait until data/hello2.txt is loaded

--- a/tests/integration/features/yankpaste.feature
+++ b/tests/integration/features/yankpaste.feature
@@ -104,3 +104,62 @@ Feature: Yanking and pasting.
         And I put "foo bar" into the clipboard
         And I run :paste
         Then the error "Invalid URL" should be shown
+
+    Scenario: Pasting multiple urls in a new tab
+        Given I have a fresh instance
+        When I run :tab-only
+        And I put "http://localhost:(port)/data/hello.txt\nhttp://localhost:(port)/data/hello2.txt\nhttp://localhost:(port)/data/hello3.txt" into the clipboard
+        And I run :paste -t
+        And I wait until data/hello.txt is loaded
+        And I wait until data/hello2.txt is loaded
+        And I wait until data/hello3.txt is loaded
+        Then the following tabs should be open:
+            - about:blank
+            - data/hello.txt (active)
+            - data/hello2.txt
+            - data/hello3.txt
+
+    Scenario: Pasting multiple urls in a background tab
+        Given I open about:blank
+        When I run :tab-only
+        And I put "http://localhost:(port)/data/hello.txt\nhttp://localhost:(port)/data/hello2.txt\nhttp://localhost:(port)/data/hello3.txt" into the clipboard
+        And I run :paste -b
+        And I wait until data/hello.txt is loaded
+        And I wait until data/hello2.txt is loaded
+        And I wait until data/hello3.txt is loaded
+        Then the following tabs should be open:
+            - about:blank (active)
+            - data/hello.txt
+            - data/hello2.txt
+            - data/hello3.txt
+
+    Scenario: Pasting multiple urls in new windows
+        Given I have a fresh instance
+        When I put "http://localhost:(port)/data/hello.txt\nhttp://localhost:(port)/data/hello2.txt\nhttp://localhost:(port)/data/hello3.txt" into the clipboard
+        And I run :paste -w
+        And I wait until data/hello.txt is loaded
+        And I wait until data/hello2.txt is loaded
+        And I wait until data/hello3.txt is loaded
+        Then the session should look like:
+            windows:
+            - tabs:
+              - active: true
+                history:
+                - active: true
+                  url: about:blank
+            - tabs:
+              - active: true
+                history:
+                - active: true
+                  url: http://localhost:*/data/hello.txt
+            - tabs:
+              - active: true
+                history:
+                - active: true
+                  url: http://localhost:*/data/hello2.txt
+            - tabs:
+              - active: true
+                history:
+                - active: true
+                  url: http://localhost:*/data/hello3.txt
+

--- a/tests/integration/features/yankpaste.feature
+++ b/tests/integration/features/yankpaste.feature
@@ -108,7 +108,10 @@ Feature: Yanking and pasting.
     Scenario: Pasting multiple urls in a new tab
         Given I have a fresh instance
         When I run :tab-only
-        And I put "http://localhost:(port)/data/hello.txt\nhttp://localhost:(port)/data/hello2.txt\nhttp://localhost:(port)/data/hello3.txt" into the clipboard
+        And I put the following lines into the clipboard:
+           http://localhost:(port)/data/hello.txt
+           http://localhost:(port)/data/hello2.txt
+           http://localhost:(port)/data/hello3.txt
         And I run :paste -t
         And I wait until data/hello.txt is loaded
         And I wait until data/hello2.txt is loaded
@@ -122,7 +125,10 @@ Feature: Yanking and pasting.
     Scenario: Pasting multiple urls in a background tab
         Given I open about:blank
         When I run :tab-only
-        And I put "http://localhost:(port)/data/hello.txt\nhttp://localhost:(port)/data/hello2.txt\nhttp://localhost:(port)/data/hello3.txt" into the clipboard
+        And I put the following lines into the clipboard:
+           http://localhost:(port)/data/hello.txt
+           http://localhost:(port)/data/hello2.txt
+           http://localhost:(port)/data/hello3.txt
         And I run :paste -b
         And I wait until data/hello.txt is loaded
         And I wait until data/hello2.txt is loaded
@@ -135,7 +141,10 @@ Feature: Yanking and pasting.
 
     Scenario: Pasting multiple urls in new windows
         Given I have a fresh instance
-        When I put "http://localhost:(port)/data/hello.txt\nhttp://localhost:(port)/data/hello2.txt\nhttp://localhost:(port)/data/hello3.txt" into the clipboard
+        When I put the following lines into the clipboard:
+           http://localhost:(port)/data/hello.txt
+           http://localhost:(port)/data/hello2.txt
+           http://localhost:(port)/data/hello3.txt
         And I run :paste -w
         And I wait until data/hello.txt is loaded
         And I wait until data/hello2.txt is loaded

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -166,13 +166,17 @@ class TestFuzzyUrl:
         assert not os_mock.path.exists.called
         assert url == QUrl('http://foo')
 
-    def test_file_absolute(self, os_mock):
+    @pytest.mark.parametrize('path, expected', [
+        ('/foo', QUrl('file:///foo')),
+        ('/bar\n', QUrl('file:///bar')),
+    ])
+    def test_file_absolute(self, path, expected, os_mock):
         """Test with an absolute path."""
         os_mock.path.exists.return_value = True
         os_mock.path.isabs.return_value = True
 
-        url = urlutils.fuzzy_url('/foo')
-        assert url == QUrl('file:///foo')
+        url = urlutils.fuzzy_url(path)
+        assert url == expected
 
     @pytest.mark.posix
     def test_file_absolute_expanded(self, os_mock):


### PR DESCRIPTION
This patch fixed a problem when pasting a local path that ends with newline (I think it is safe to strip paths as well). Do you think that it would be maybe better to strip only newlines and not all whitespace characters?

The second functionality added is the possibility to paste multiple URLs separated by newline. The paste command now splits the content of the clipboard on newlines and open each element while respecting the supplied options (window, tab, bg tab).

hcraT

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-compiler/qutebrowser/1217)
<!-- Reviewable:end -->
