### PR TITLE
Update INSTALL.asciidoc

### DIFF
--- a/INSTALL.asciidoc
+++ b/INSTALL.asciidoc
@@ -92,26 +92,23 @@ Then <<tox,install qutebrowser via tox>>.
 On Archlinux
 ------------
 
-There are two Archlinux packages available in the AUR:
-https://aur.archlinux.org/packages/qutebrowser/[qutebrowser] and
-https://aur.archlinux.org/packages/qutebrowser-git/[qutebrowser-git].
-
-You can install them (and the needed pypeg2 dependency) like this:
+qutebrowser is available in the official [community] repository.
 
 ----
-$ wget https://aur.archlinux.org/packages/py/python-pypeg2/python-pypeg2.tar.gz
-$ tar xzf python-pypeg2.tar.gz
-$ cd python-pypeg2
-$ makepkg -si
-$ cd ..
-$ rm -r python-pypeg2 python-pypeg2.tar.gz
+# pacman -S qutebrowser
+----
 
-$ wget https://aur.archlinux.org/packages/qu/qutebrowser/qutebrowser.tar.gz
-$ tar xzf qutebrowser.tar.gz
-$ cd qutebrowser
+There is also a -git version available in the AUR:
+https://aur.archlinux.org/packages/qutebrowser-git/[qutebrowser-git].
+
+You can install it using `makepkg` like this:
+
+----
+$ git clone https://aur.archlinux.org/qutebrowser-git.git
+$ cd qutebrowser-git
 $ makepkg -si
 $ cd ..
-$ rm -r qutebrowser qutebrowser.tar.gz
+$ rm -r qutebrowser-git
 ----
 
 or you could use an AUR helper, e.g. `yaourt -S qutebrowser-git`.


### PR DESCRIPTION
The Arch Linux section has been quite out of date:

* The AUR has a Git backend now, thus the links have been obsolete.
* python-pypeg2 is in [community]
* qutebrowser is in [community]

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-compiler/qutebrowser/1262)
<!-- Reviewable:end -->
