### PR TITLE
Relax editor templating

### DIFF
--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1094,7 +1094,7 @@ class ShellCommand(BaseType):
             shlex.split(value)
         except ValueError as e:
             raise configexc.ValidationError(value, str(e))
-        if self.placeholder and '{}' not in self.transform(value):
+        if self.placeholder and '{}' not in value:
             raise configexc.ValidationError(value, "needs to contain a "
                                             "{}-placeholder.")
 

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -124,6 +124,6 @@ class ExternalEditor(QObject):
         self._proc.error.connect(self.on_proc_error)
         editor = config.get('general', 'editor')
         executable = editor[0]
-        args = [arg.replace('{}', self._filename) if '{}' in arg else arg for arg in editor[1:]]
+        args = [arg.replace('{}', self._filename) for arg in editor[1:]]
         log.procs.debug("Calling \"{}\" with args {}".format(executable, args))
         self._proc.start(executable, args)

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -124,6 +124,6 @@ class ExternalEditor(QObject):
         self._proc.error.connect(self.on_proc_error)
         editor = config.get('general', 'editor')
         executable = editor[0]
-        args = [self._filename if arg == '{}' else arg for arg in editor[1:]]
+        args = [arg.replace('{}', self._filename) if '{}' in arg else arg for arg in editor[1:]]
         log.procs.debug("Calling \"{}\" with args {}".format(executable, args))
         self._proc.start(executable, args)

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -1580,6 +1580,8 @@ class TestShellCommand:
         ({'none_ok': True}, ''),
         ({}, 'foobar'),
         ({'placeholder': '{}'}, 'foo {} bar'),
+        ({'placeholder': '{}'}, 'foo{}bar'),
+        ({'placeholder': '{}'}, 'foo "bar {}"')
     ])
     def test_validate_valid(self, klass, kwargs, val):
         klass(**kwargs).validate(val)
@@ -1587,6 +1589,7 @@ class TestShellCommand:
     @pytest.mark.parametrize('kwargs, val', [
         ({}, ''),
         ({'placeholder': '{}'}, 'foo bar'),
+        ({'placeholder': '{}'}, 'foo { } bar')
         ({}, 'foo"'),  # not splittable with shlex
     ])
     def test_validate_invalid(self, klass, kwargs, val):

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -1581,7 +1581,7 @@ class TestShellCommand:
         ({}, 'foobar'),
         ({'placeholder': '{}'}, 'foo {} bar'),
         ({'placeholder': '{}'}, 'foo{}bar'),
-        ({'placeholder': '{}'}, 'foo "bar {}"')
+        ({'placeholder': '{}'}, 'foo "bar {}"'),
     ])
     def test_validate_valid(self, klass, kwargs, val):
         klass(**kwargs).validate(val)
@@ -1589,7 +1589,7 @@ class TestShellCommand:
     @pytest.mark.parametrize('kwargs, val', [
         ({}, ''),
         ({'placeholder': '{}'}, 'foo bar'),
-        ({'placeholder': '{}'}, 'foo { } bar')
+        ({'placeholder': '{}'}, 'foo { } bar'),
         ({}, 'foo"'),  # not splittable with shlex
     ])
     def test_validate_invalid(self, klass, kwargs, val):

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -1586,7 +1586,6 @@ class TestShellCommand:
 
     @pytest.mark.parametrize('kwargs, val', [
         ({}, ''),
-        ({'placeholder': '{}'}, 'foo{} bar'),
         ({'placeholder': '{}'}, 'foo bar'),
         ({}, 'foo"'),  # not splittable with shlex
     ])

--- a/tests/unit/misc/test_editor.py
+++ b/tests/unit/misc/test_editor.py
@@ -57,7 +57,7 @@ class TestArg:
         editor: The ExternalEditor instance to test.
     """
 
-    @pytest.mark.parametrize('args', [[], ['foo', 'bar'], ['foo{}bar']])
+    @pytest.mark.parametrize('args', [[], ['foo'], ['foo', 'bar']])
     def test_start_no_placeholder(self, config_stub, editor, args):
         """Test starting editor without arguments."""
         config_stub.data['general']['editor'] = ['bin'] + args


### PR DESCRIPTION
I tried to set my editor to `termite -e "vim -f {}"`, termite being a
pretty cool and light terminal I use within my i3wm Arch linux box.

So when I open my editor I want it to launch a terminal with Vim inside
instead of GVim for various reasons.

The validation rejected this at first because it was looking for '{}'
inside ['foo', 'bar', 'baz {}'], essentially. So I need it to look
inside the sub-strings, not just the list.

Then after validation I need to perform the '{}' replacement inside the
sub-string too, not just replacing the whole string.

--------------------

I'm not sure what I'm supposed to do testing wise, I haven't written production Python for quite a few years. Let me know if there's anything you'd like me to do or if this approach is a bad one! Happy to change it, I just would like this sub string thing to work :)

The main issue I has was that you're looking for a standalone '{}' token from shlex, but if you use quotes in your editor command it ends up grouping the '{}' token with other tokens found inside the string.

Thoughts?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-compiler/qutebrowser/1263)
<!-- Reviewable:end -->
