### PR TITLE
Make Shift+Ins paste primary selection in insert mode

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1308,10 +1308,10 @@ class CommandDispatcher:
             raise cmdexc.CommandError("Element vanished while editing!")
 
     @cmdutils.register(instance='command-dispatcher',
-                       modes=[KeyMode.insert], hide=True, scope='window')
+                       modes=[KeyMode.insert], hide=True, scope='window',
+                       needs_js=True)
     def paste_primary(self):
-        """Paste the primary selection at cursor position into the curently
-        selected form field.
+        """Paste the primary selection at cursor position.
         """
         frame = self._current_widget().page().currentFrame()
         try:
@@ -1324,14 +1324,14 @@ class CommandDispatcher:
         clipboard = QApplication.clipboard()
         if clipboard.supportsSelection():
             sel = clipboard.text(QClipboard.Selection)
-            log.misc.debug("Pasting primary selection into element {} "
-                "(selection is '{}')".format(elem.debug_text(), sel))
+            log.misc.debug("Pasting primary selection into element {}".format(
+                elem.debug_text()))
             elem.evaluateJavaScript("""
                 var sel = '{}';
                 var event = document.createEvent('TextEvent');
                 event.initTextEvent('textInput', true, true, null, sel);
                 this.dispatchEvent(event);
-                """.format(sel))
+            """.format(webelem.javascript_escape(sel)))
 
     def _clear_search(self, view, text):
         """Clear search string/highlights for the given view.

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1324,21 +1324,14 @@ class CommandDispatcher:
         clipboard = QApplication.clipboard()
         if clipboard.supportsSelection():
             sel = clipboard.text(QClipboard.Selection)
-            log.misc.debug("Pasting selection: '{}'".format(sel))
+            log.misc.debug("Pasting primary selection into element {} "
+                "(selection is '{}')".format(elem.debug_text(), sel))
             elem.evaluateJavaScript("""
-                var sel = '%s';
-                if (this.selectionStart || this.selectionStart == '0') {
-                    var startPos = this.selectionStart;
-                    var endPos = this.selectionEnd;
-                    this.value = this.value.substring(0, startPos)
-                        + sel
-                        + this.value.substring(endPos, this.value.length);
-                    this.selectionStart = startPos + sel.length;
-                    this.selectionEnd = startPos + sel.length;
-                } else {
-                    this.value += sel;
-                }
-                """ % sel)
+                var sel = '{}';
+                var event = document.createEvent('TextEvent');
+                event.initTextEvent('textInput', true, true, null, sel);
+                this.dispatchEvent(event);
+                """.format(sel))
 
     def _clear_search(self, view, text):
         """Clear search string/highlights for the given view.

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1311,8 +1311,7 @@ class CommandDispatcher:
                        modes=[KeyMode.insert], hide=True, scope='window',
                        needs_js=True)
     def paste_primary(self):
-        """Paste the primary selection at cursor position.
-        """
+        """Paste the primary selection at cursor position."""
         frame = self._current_widget().page().currentFrame()
         try:
             elem = webelem.focus_elem(frame)

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -1324,7 +1324,8 @@ KEY_SECTION_DESC = {
         "Since normal keypresses are passed through, only special keys are "
         "supported in this mode.\n"
         "Useful hidden commands to map in this section:\n\n"
-        " * `open-editor`: Open a texteditor with the focused field."),
+        " * `open-editor`: Open a texteditor with the focused field.\n"
+        " * `paste-primary`: Paste primary selection at cursor position."),
     'hint': (
         "Keybindings for hint mode.\n"
         "Since normal keypresses are passed through, only special keys are "
@@ -1495,6 +1496,7 @@ KEY_DATA = collections.OrderedDict([
 
     ('insert', collections.OrderedDict([
         ('open-editor', ['<Ctrl-E>']),
+        ('paste-primary', ['<Shift-Ins>']),
     ])),
 
     ('hint', collections.OrderedDict([

--- a/tests/integration/data/paste_primary.html
+++ b/tests/integration/data/paste_primary.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Paste primary selection</title>
+    </head>
+    <body>
+        <textarea id="qute-textarea"></textarea>
+    </body>
+</html>

--- a/tests/integration/features/yankpaste.feature
+++ b/tests/integration/features/yankpaste.feature
@@ -170,3 +170,53 @@ Feature: Yanking and pasting.
                 history:
                 - active: true
                   url: http://localhost:*/data/hello3.txt
+
+    Scenario: Pasting the primary selection into an empty text field
+        When selection is supported
+        And I open data/paste_primary.html
+        And I put "Hello world" into the primary selection
+        # Click the text field
+        And I run :hint all
+        And I run :follow-hint a
+        And I run :paste-primary
+        # Compare
+        And I run :jseval console.log(document.getElementById('qute-textarea').value);
+        Then the javascript message "Hello world" should be logged
+
+    Scenario: Pasting the primary selection into a text field at specific position
+        When selection is supported
+        And I open data/paste_primary.html
+        And I run :jseval document.getElementById('qute-textarea').value = 'one two three four';
+        And I put " Hello world" into the primary selection
+        # Click the text field
+        And I run :hint all
+        And I run :follow-hint a
+        # Move to the beginning and two words to the right
+        And I press the keys "<Home>"
+        And I press the key "<Ctrl+Right>"
+        And I press the key "<Ctrl+Right>"
+        And I run :paste-primary
+        # Compare
+        And I run :jseval console.log(document.getElementById('qute-textarea').value);
+        Then the javascript message "one two Hello world three four" should be logged
+
+    Scenario: Pasting the primary selection into a text field with undo
+        When selection is supported
+        And I open data/paste_primary.html
+        And I run :jseval document.getElementById('qute-textarea').value = 'one two three four';
+        And I put " Hello world" into the primary selection
+        # Click the text field
+        And I run :hint all
+        And I run :follow-hint a
+        # Move to the beginning and after the first word
+        And I press the keys "<Home>"
+        And I press the key "<Ctrl+Right>"
+        # Paste and undo
+        And I run :paste-primary
+        And I press the key "<Ctrl+z>"
+        # One word to the right
+        And I press the key "<Ctrl+Right>"
+        And I run :paste-primary
+        # Compare
+        And I run :jseval console.log(document.getElementById('qute-textarea').value);
+        Then the javascript message "one two Hello world three four" should be logged

--- a/tests/integration/features/yankpaste.feature
+++ b/tests/integration/features/yankpaste.feature
@@ -203,20 +203,16 @@ Feature: Yanking and pasting.
     Scenario: Pasting the primary selection into a text field with undo
         When selection is supported
         And I open data/paste_primary.html
-        And I run :jseval document.getElementById('qute-textarea').value = 'one two three four';
-        And I put " Hello world" into the primary selection
         # Click the text field
         And I run :hint all
         And I run :follow-hint a
-        # Move to the beginning and after the first word
-        And I press the keys "<Home>"
-        And I press the key "<Ctrl+Right>"
         # Paste and undo
+        And I put "This text should be undone" into the primary selection
         And I run :paste-primary
         And I press the key "<Ctrl+z>"
-        # One word to the right
-        And I press the key "<Ctrl+Right>"
+        # Paste final text
+        And I put "This text should stay" into the primary selection
         And I run :paste-primary
         # Compare
         And I run :jseval console.log(document.getElementById('qute-textarea').value);
-        Then the javascript message "one two Hello world three four" should be logged
+        Then the javascript message "This text should stay" should be logged


### PR DESCRIPTION
This is the ugly hack to fix the annoying behaviour of [Shift+Ins pasting wrong selection](https://bbs.archlinux.org/viewtopic.php?pid=1597753#p1597753). It works pretty well for me, though there might be some problems with editability checks on some pages (I haven't figured out if I need to check also `elem.is_content_editable()` or not).

You might want to update other parts of the documentation, or just point them out and I'll try to do so. I'll also happily address any "nitpicks" ;-)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-compiler/qutebrowser/1271)
<!-- Reviewable:end -->
