### PR TITLE
pdf.js fixes

### DIFF
--- a/qutebrowser/browser/pdfjs.py
+++ b/qutebrowser/browser/pdfjs.py
@@ -63,7 +63,7 @@ def _generate_pdfjs_script(url):
 
 
 def fix_urls(asset):
-    """Take a html page and replace each relative URL wth an absolute.
+    """Take a html page and replace each relative URL with an absolute.
 
     This is specialized for pdf.js files and not a general purpose function.
 
@@ -90,9 +90,13 @@ def fix_urls(asset):
 
 
 SYSTEM_PDFJS_PATHS = [
-    '/usr/share/pdf.js/',  # Debian pdf.js-common
-    '/usr/share/javascript/pdf/',  # Debian libjs-pdf
-    os.path.expanduser('~/.local/share/qutebrowser/pdfjs/'),  # fallback
+    # Debian pdf.js-common
+    # Arch Linux pdfjs (AUR)
+    '/usr/share/pdf.js/',
+    # Debian libjs-pdf
+    '/usr/share/javascript/pdf/',
+    # fallback
+    os.path.expanduser('~/.local/share/qutebrowser/pdfjs/'),
 ]
 
 

--- a/qutebrowser/browser/pdfjs.py
+++ b/qutebrowser/browser/pdfjs.py
@@ -100,21 +100,26 @@ SYSTEM_PDFJS_PATHS = [
 ]
 
 
-def get_pdfjs_res(path):
+def get_pdfjs_res_and_path(path):
     """Get a pdf.js resource in binary format.
+
+    Returns a (content, path) tuple, where content is the file content and path
+    is the path where the file was found. If path is None, the bundled version
+    was used.
 
     Args:
         path: The path inside the pdfjs directory.
     """
     path = path.lstrip('/')
     content = None
+    file_path = None
 
     # First try a system wide installation
     # System installations might strip off the 'build/' or 'web/' prefixes.
     # qute expects them, so we need to adjust for it.
     names_to_try = [path, _remove_prefix(path)]
     for system_path in SYSTEM_PDFJS_PATHS:
-        content = _read_from_system(system_path, names_to_try)
+        content, file_path = _read_from_system(system_path, names_to_try)
         if content is not None:
             break
 
@@ -130,9 +135,19 @@ def get_pdfjs_res(path):
         # Might be script/html or might be binary
         text_content = content.decode('utf-8')
     except UnicodeDecodeError:
-        return content
+        return (content, file_path)
     text_content = fix_urls(text_content)
-    return text_content.encode('utf-8')
+    return (text_content.encode('utf-8'), file_path)
+
+
+def get_pdfjs_res(path):
+    """Get a pdf.js resource in binary format.
+
+    Args:
+        path: The path inside the pdfjs directory.
+    """
+    content, _path = get_pdfjs_res_and_path(path)
+    return content
 
 
 def _remove_prefix(path):
@@ -151,10 +166,13 @@ def _remove_prefix(path):
 def _read_from_system(system_path, names):
     """Try to read a file with one of the given names in system_path.
 
+    Returns a (content, path) tuple, where the path is the filepath that was
+    used.
+
     Each file in names is considered equal, the first file that is found
     is read and its binary content returned.
 
-    Returns None if no file could be found
+    Returns (None, None) if no file could be found
 
     Args:
         system_path: The folder where the file should be searched.
@@ -162,11 +180,12 @@ def _read_from_system(system_path, names):
     """
     for name in names:
         try:
-            with open(os.path.join(system_path, name), 'rb') as f:
-                return f.read()
+            full_path = os.path.join(system_path, name)
+            with open(full_path, 'rb') as f:
+                return (f.read(), full_path)
         except OSError:
             continue
-    return None
+    return (None, None)
 
 
 def is_available():

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -192,16 +192,20 @@ def _pdfjs_version():
         A string with the version number.
     """
     try:
-        pdfjs_file = pdfjs.get_pdfjs_res('build/pdf.js').decode('utf-8')
+        pdfjs_file, file_path = pdfjs.get_pdfjs_res_and_path('build/pdf.js')
     except pdfjs.PDFJSNotFound:
         return 'no'
     else:
+        pdfjs_file = pdfjs_file.decode('utf-8')
         version_re = re.compile(r"^PDFJS\.version = '([^']+)';$", re.MULTILINE)
         match = version_re.search(pdfjs_file)
         if not match:
-            return 'unknown'
+            pdfjs_version = 'unknown'
         else:
-            return match.group(1)
+            pdfjs_version = match.group(1)
+        if file_path is None:
+            file_path = 'bundled'
+        return '{} ({})'.format(pdfjs_version, file_path)
 
 
 def version(short=False):

--- a/scripts/dev/update_3rdparty.py
+++ b/scripts/dev/update_3rdparty.py
@@ -82,6 +82,7 @@ def update_pdfjs(target_version=None):
 
 
 def main():
+    """Update 3rd party modules."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--pdfjs', '-p',

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -535,14 +535,15 @@ class TestPDFJSVersion:
     """Tests for _pdfjs_version."""
 
     def test_not_found(self, mocker):
-        mocker.patch('qutebrowser.utils.version.pdfjs.get_pdfjs_res',
+        mocker.patch('qutebrowser.utils.version.pdfjs.get_pdfjs_res_and_path',
                      side_effect=pdfjs.PDFJSNotFound)
         assert version._pdfjs_version() == 'no'
 
     def test_unknown(self, monkeypatch):
-        monkeypatch.setattr('qutebrowser.utils.version.pdfjs.get_pdfjs_res',
-                            lambda path: b'foobar')
-        assert version._pdfjs_version() == 'unknown'
+        monkeypatch.setattr(
+            'qutebrowser.utils.version.pdfjs.get_pdfjs_res_and_path',
+            lambda path: (b'foobar', None))
+        assert version._pdfjs_version() == 'unknown (bundled)'
 
     def test_known(self, monkeypatch):
         pdfjs_code = textwrap.dedent("""
@@ -558,9 +559,10 @@ class TestPDFJSVersion:
               // Use strict in our context only - users might not want it
               'use strict';
         """).strip().encode('utf-8')
-        monkeypatch.setattr('qutebrowser.utils.version.pdfjs.get_pdfjs_res',
-                            lambda path: pdfjs_code)
-        assert version._pdfjs_version() == '1.2.109'
+        monkeypatch.setattr(
+            'qutebrowser.utils.version.pdfjs.get_pdfjs_res_and_path',
+            lambda path: (pdfjs_code, '/foo/bar/pdf.js'))
+        assert version._pdfjs_version() == '1.2.109 (/foo/bar/pdf.js)'
 
 
 class FakeQSslSocket:


### PR DESCRIPTION
This adds the file path to the pdfjs version output (or "bundled" if a bundled version is used).

Additionally, I've modified the `update_3rdparty` script so that a specific pdfjs version can be installed, e.g. for debugging purposes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-compiler/qutebrowser/1276)
<!-- Reviewable:end -->
