### PR TITLE
Pdfjs fixes

### DIFF
--- a/qutebrowser/browser/network/qutescheme.py
+++ b/qutebrowser/browser/network/qutescheme.py
@@ -72,9 +72,9 @@ class QuteSchemeError(Exception):
 
     def __init__(self, errorstring, error):
         """Constructor."""
-
         self.errorstring = errorstring
         self.error = error
+        super().__init__(errorstring)
 
 
 class QuteSchemeHandler(schemehandler.SchemeHandler):

--- a/qutebrowser/browser/pdfjs.py
+++ b/qutebrowser/browser/pdfjs.py
@@ -29,9 +29,16 @@ from qutebrowser.utils import utils
 
 class PDFJSNotFound(Exception):
 
-    """Raised when no pdf.js installation is found."""
+    """Raised when no pdf.js installation is found.
 
-    pass
+    Attributes:
+        path: path of the file that was requested but not found.
+    """
+
+    def __init__(self, path):
+        self.path = path
+        message = "Path '{}' not found".format(path)
+        super().__init__(message)
 
 
 def generate_pdfjs_page(url):
@@ -129,7 +136,7 @@ def get_pdfjs_res_and_path(path):
         try:
             content = utils.read_file(res_path, binary=True)
         except FileNotFoundError:
-            raise PDFJSNotFound
+            raise PDFJSNotFound(path) from None
 
     try:
         # Might be script/html or might be binary

--- a/qutebrowser/browser/pdfjs.py
+++ b/qutebrowser/browser/pdfjs.py
@@ -77,21 +77,21 @@ def fix_urls(asset):
     Args:
         asset: js file or html page as string.
     """
-    new_urls = {
-        'viewer.css': 'qute://pdfjs/web/viewer.css',
-        'compatibility.js': 'qute://pdfjs/web/compatibility.js',
-        'locale/locale.properties':
-            'qute://pdfjs/web/locale/locale.properties',
-        'l10n.js': 'qute://pdfjs/web/l10n.js',
-        '../build/pdf.js': 'qute://pdfjs/build/pdf.js',
-        'debugger.js': 'qute://pdfjs/web/debugger.js',
-        'viewer.js': 'qute://pdfjs/web/viewer.js',
-        'compressed.tracemonkey-pldi-09.pdf': '',
-        './images/': 'qute://pdfjs/web/images/',
-        '../build/pdf.worker.js': 'qute://pdfjs/build/pdf.worker.js',
-        '../web/cmaps/': 'qute://pdfjs/web/cmaps/',
-    }
-    for original, new in new_urls.items():
+    new_urls = [
+        ('viewer.css', 'qute://pdfjs/web/viewer.css'),
+        ('compatibility.js', 'qute://pdfjs/web/compatibility.js'),
+        ('locale/locale.properties',
+            'qute,//pdfjs/web/locale/locale.properties'),
+        ('l10n.js', 'qute://pdfjs/web/l10n.js'),
+        ('../build/pdf.js', 'qute://pdfjs/build/pdf.js'),
+        ('debugger.js', 'qute://pdfjs/web/debugger.js'),
+        ('viewer.js', 'qute://pdfjs/web/viewer.js'),
+        ('compressed.tracemonkey-pldi-09.pdf', ''),
+        ('./images/', 'qute://pdfjs/web/images/'),
+        ('../build/pdf.worker.js', 'qute://pdfjs/build/pdf.worker.js'),
+        ('../web/cmaps/', 'qute://pdfjs/web/cmaps/'),
+    ]
+    for original, new in new_urls:
         asset = asset.replace(original, new)
     return asset
 

--- a/tests/unit/browser/network/test_qutescheme.py
+++ b/tests/unit/browser/network/test_qutescheme.py
@@ -1,0 +1,66 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2016 Daniel Schadt
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for qutebrowser.browser.network.qutescheme."""
+
+import pytest
+import logging
+
+from PyQt5.QtCore import QUrl
+from PyQt5.QtNetwork import QNetworkRequest, QNetworkReply
+
+from qutebrowser.browser import pdfjs
+from qutebrowser.browser.network import qutescheme
+
+
+@pytest.fixture
+def handler():
+    return qutescheme.QuteSchemeHandler(win_id=0)
+
+
+class TestPDFJSHandler:
+
+    """Test the qute://pdfjs endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def fake_pdfjs(self, monkeypatch):
+
+        def get_pdfjs_res(path):
+            if path == '/existing/file':
+                return b'foobar'
+            raise pdfjs.PDFJSNotFound(path)
+
+        monkeypatch.setattr('qutebrowser.browser.pdfjs.get_pdfjs_res',
+            get_pdfjs_res)
+
+    def test_existing_resource(self, handler):
+        """Test with a resource that exists."""
+        req = QNetworkRequest(QUrl('qute://pdfjs/existing/file'))
+        reply = handler.createRequest(None, req, None)
+        assert reply.readAll() == b'foobar'
+
+    def test_nonexisting_resource(self, handler, caplog):
+        """Test with a resource that does not exist."""
+        req = QNetworkRequest(QUrl('qute://pdfjs/no/file'))
+        with caplog.at_level(logging.WARNING, 'misc'):
+            reply = handler.createRequest(None, req, None)
+        assert reply.error() == QNetworkReply.ContentNotFoundError
+        assert len(caplog.records) == 1
+        assert (caplog.records[0].message ==
+                'pdfjs resource requested but not found: /no/file')

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -536,7 +536,7 @@ class TestPDFJSVersion:
 
     def test_not_found(self, mocker):
         mocker.patch('qutebrowser.utils.version.pdfjs.get_pdfjs_res_and_path',
-                     side_effect=pdfjs.PDFJSNotFound)
+                     side_effect=pdfjs.PDFJSNotFound('/build/pdf.js'))
         assert version._pdfjs_version() == 'no'
 
     def test_unknown(self, monkeypatch):


### PR DESCRIPTION
(Issue #1280)

This PR attempts to fix the issues raised in the discussion of #1280.

I've used an Exception to signal the qute handler that an `ErrorNetworkReply` should be used, as that seemed to be the cleanest way.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-compiler/qutebrowser/1290)
<!-- Reviewable:end -->
