### PR TITLE
hints->auto-follow - let help text match reality

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -180,7 +180,7 @@
 |<<hints-scatter,scatter>>|Whether to scatter hint key chains (like Vimium) or not (like dwb).
 |<<hints-uppercase,uppercase>>|Make chars in hint strings uppercase.
 |<<hints-dictionary,dictionary>>|The dictionary file to be used by the word hints.
-|<<hints-auto-follow,auto-follow>>|Whether to auto-follow a hint if there's only one left.
+|<<hints-auto-follow,auto-follow>>|Follow a hint immediately when the hint text is completely matched.
 |<<hints-next-regexes,next-regexes>>|A comma-separated list of regexes to use for 'next' links.
 |<<hints-prev-regexes,prev-regexes>>|A comma-separated list of regexes to use for 'prev' links.
 |==============

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -896,7 +896,7 @@ def data(readonly=False):
 
             ('auto-follow',
              SettingValue(typ.Bool(), 'true'),
-             "Whether to auto-follow a hint if there's only one left."),
+             "Follow a hint immediately when the hint text is completely matched."),
 
             ('next-regexes',
              SettingValue(typ.RegexList(flags=re.IGNORECASE),


### PR DESCRIPTION
The current help text doesn't match the actual funcionality of the option. Picture as proof (it shouldn't be possible to see a single hint if the option is `true`):
![2016-02-15-144049_1362x746_escrotum](https://cloud.githubusercontent.com/assets/994166/13050200/1efd2836-d3f2-11e5-835b-399335fee17b.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-compiler/qutebrowser/1306)
<!-- Reviewable:end -->
