### PR TITLE
no ellipsis is inserted in "big" windows

### DIFF
--- a/tests/unit/mainwindow/statusbar/test_textbase.py
+++ b/tests/unit/mainwindow/statusbar/test_textbase.py
@@ -46,7 +46,7 @@ def test_elided_text(qtbot, elidemode, check):
     """
     label = TextBase(elidemode=elidemode)
     qtbot.add_widget(label)
-    long_string = 'Hello world! ' * 20
+    long_string = 'Hello world! ' * 100
     label.setText(long_string)
     label.resize(100, 50)
     label.show()


### PR DESCRIPTION
When testing in fullscreen layout on my tiling window manager, the `'Hello world! ' * 20` wasn't enough to create an ellipsis. It does work for `Hello world! ' * 100`, but that's not really a great fix. I'll look into a container to ensure the window size, so consider this a work in progress.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-compiler/qutebrowser/1313)
<!-- Reviewable:end -->
