### PR TITLE
Adds completion for tab-focus.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -170,11 +170,11 @@ Contributors, sorted by the number of commits in descending order:
 * ZDarian
 * Milan Svoboda
 * John ShaggyTwoDope Jenkins
+* Jimmy
 * Peter Vilim
 * Clayton Craft
 * Oliver Caldwell
 * Jonas Schürmann
-* Jimmy
 * Panagiotis Ktistakis
 * Jakub Klinkovský
 * skinnay

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -11,6 +11,7 @@
 |<<bookmark-add,bookmark-add>>|Save the current page as a bookmark.
 |<<bookmark-del,bookmark-del>>|Delete a bookmark.
 |<<bookmark-load,bookmark-load>>|Load a bookmark.
+|<<buffer,buffer>>|Select tab by index or url/title best match.
 |<<close,close>>|Close the current window.
 |<<download,download>>|Download a given URL, or current page if no URL given.
 |<<download-cancel,download-cancel>>|Cancel the last/[count]th download.
@@ -141,6 +142,18 @@ Load a bookmark.
 ==== note
 * This command does not split arguments after the last argument and handles quotes literally.
 * With this command, +;;+ is interpreted literally instead of splitting off a second command.
+
+[[buffer]]
+=== buffer
+Syntax: +:buffer 'index'+
+
+Select tab by index or url/title best match.
+
+Focuses window if necessary.
+
+==== positional arguments
+* +'index'+: The [win_id/]index of the tab to focus. Or a substring in which case the closest match will be focused.
+
 
 [[close]]
 === close

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -35,7 +35,7 @@ from PyQt5.QtWidgets import QApplication
 from PyQt5.QtWebKit import QWebSettings
 from PyQt5.QtGui import QDesktopServices, QPixmap, QIcon, QCursor, QWindow
 from PyQt5.QtCore import (pyqtSlot, qInstallMessageHandler, QTimer, QUrl,
-                          QObject, Qt, QEvent)
+                          QObject, Qt, QEvent, pyqtSignal)
 try:
     import hunter
 except ImportError:
@@ -741,6 +741,8 @@ class Application(QApplication):
     Attributes:
         _args: ArgumentParser instance.
     """
+
+    new_window = pyqtSignal(mainwindow.MainWindow)
 
     def __init__(self, args):
         """Constructor.

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -45,6 +45,7 @@ from qutebrowser.utils import (message, usertypes, log, qtutils, urlutils,
                                objreg, utils)
 from qutebrowser.utils.usertypes import KeyMode
 from qutebrowser.misc import editor, guiprocess
+from qutebrowser.completion.models import instances, sortfilter
 
 
 class CommandDispatcher:
@@ -833,6 +834,60 @@ class CommandDispatcher:
             except urlutils.InvalidUrlError as e:
                 raise cmdexc.CommandError(e)
             self._open(url, tab, bg, window)
+
+    @cmdutils.register(instance='command-dispatcher', scope='window',
+                       completion=[usertypes.Completion.tab])
+    def buffer(self, index):
+        """Select tab by index or url/title best match.
+
+        Focuses window if necessary.
+
+        Args:
+            index: The [win_id/]index of the tab to focus. Or a substring
+                   in which case the closest match will be focused.
+        """
+        index_parts = index.split('/', 1)
+
+        try:
+            for part in index_parts:
+                int(part)
+        except ValueError:
+            model = instances.get(usertypes.Completion.tab)
+            sf = sortfilter.CompletionFilterModel(source=model)
+            sf.set_pattern(index)
+            if sf.count() > 0:
+                index = sf.data(sf.first_item())
+                index_parts = index.split('/', 1)
+            else:
+                raise cmdexc.CommandError(
+                    "No matching tab for: {}".format(index))
+
+        if len(index_parts) == 2:
+            win_id = int(index_parts[0])
+            idx = int(index_parts[1])
+        elif len(index_parts) == 1:
+            idx = int(index_parts[0])
+            active_win = objreg.get('app').activeWindow()
+            if active_win is None:
+                # Not sure how you enter a command without an active window...
+                raise cmdexc.CommandError(
+                    "No window specified and couldn't find active window!")
+            win_id = active_win.win_id
+
+        if win_id not in objreg.window_registry:
+            raise cmdexc.CommandError(
+                "There's no window with id {}!".format(win_id))
+
+        tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                    window=win_id)
+        if not 0 < idx <= tabbed_browser.count():
+            raise cmdexc.CommandError(
+                "There's no tab with index {}!".format(idx))
+
+        window = objreg.window_registry[win_id]
+        window.activateWindow()
+        window.raise_()
+        tabbed_browser.setCurrentIndex(idx-1)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        count='count')

--- a/qutebrowser/completion/models/instances.py
+++ b/qutebrowser/completion/models/instances.py
@@ -59,6 +59,14 @@ def _init_url_completion():
         _instances[usertypes.Completion.url] = model
 
 
+def _init_tab_completion():
+    """Initialize the tab completion model."""
+    log.completion.debug("Initializing tab completion.")
+    with debug.log_time(log.completion, 'tab completion init'):
+        model = miscmodels.TabCompletionModel()
+        _instances[usertypes.Completion.tab] = model
+
+
 def _init_setting_completions():
     """Initialize setting completion models."""
     log.completion.debug("Initializing setting completion.")
@@ -115,6 +123,7 @@ INITIALIZERS = {
     usertypes.Completion.command: _init_command_completion,
     usertypes.Completion.helptopic: _init_helptopic_completion,
     usertypes.Completion.url: _init_url_completion,
+    usertypes.Completion.tab: _init_tab_completion,
     usertypes.Completion.section: _init_setting_completions,
     usertypes.Completion.option: _init_setting_completions,
     usertypes.Completion.value: _init_setting_completions,

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -187,6 +187,8 @@ class MainWindow(QWidget):
         #self.tabWidget.setCurrentIndex(0)
         #QtCore.QMetaObject.connectSlotsByName(MainWindow)
 
+        objreg.get("app").new_window.emit(self)
+
     def __repr__(self):
         return utils.get_repr(self)
 

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -237,7 +237,7 @@ KeyMode = enum('KeyMode', ['normal', 'hint', 'command', 'yesno', 'prompt',
 # Available command completions
 Completion = enum('Completion', ['command', 'section', 'option', 'value',
                                  'helptopic', 'quickmark_by_name',
-                                 'bookmark_by_url', 'url', 'sessions'])
+                                 'bookmark_by_url', 'url', 'tab', 'sessions'])
 
 
 # Exit statuses for errors. Needs to be an int for sys.exit.

--- a/tests/integration/features/tabs.feature
+++ b/tests/integration/features/tabs.feature
@@ -709,3 +709,116 @@ Feature: Tab management
             - data/hints/link.html
             - about:blank
             - data/hello.txt (active)
+
+    # :buffer
+
+    Scenario: buffer without args
+        Given I have a fresh instance
+        When I run :buffer
+        Then the error "buffer: The following arguments are required: index" should be shown
+
+    Scenario: buffer one window title present
+        When I open data/title.html
+        And I open data/search.html in a new tab
+        And I open data/scroll.html in a new tab
+        And I run :buffer "Searching text"
+        Then the following tabs should be open:
+            - data/title.html
+            - data/search.html (active)
+            - data/scroll.html
+
+    Scenario: buffer one window title not present
+        When I run :buffer "invalid title"
+        Then the error "No matching tab for: invalid title" should be shown
+
+    Scenario: buffer two window title present
+        When I open data/title.html
+        And I open data/search.html in a new tab
+        And I open data/scroll.html in a new tab
+        And I open data/caret.html in a new window
+        And I open data/paste_primary.html in a new tab
+        And I run :buffer "Scrolling"
+        Then the session should look like:
+            windows:
+            - active: true
+              tabs:
+              - history:
+                - url: about:blank
+                - url: http://localhost:*/data/title.html
+              - history:
+                - url: http://localhost:*/data/search.html
+              - active: true
+                history:
+                - url: http://localhost:*/data/scroll.html
+            - tabs:
+              - history:
+                - url: http://localhost:*/data/caret.html
+              - active: true
+                history:
+                - url: http://localhost:*/data/paste_primary.html
+
+    Scenario: buffer one window index not present
+        When I open data/title.html
+        And I run :buffer "666"
+        Then the error "There's no tab with index 666!" should be shown
+
+    Scenario: buffer one window win not present
+        When I open data/title.html
+        And I run :buffer "2/1"
+        Then the error "There's no window with id 2!" should be shown
+
+    Scenario: buffer two window index present
+        Given I have a fresh instance
+        When I open data/title.html
+        And I open data/search.html in a new tab
+        And I open data/scroll.html in a new tab
+        And I run :open -w http://localhost:(port)/data/caret.html
+        And I open data/paste_primary.html in a new tab
+        And I wait until data/caret.html is loaded
+        And I run :buffer "0/2"
+        Then the session should look like:
+            windows:
+            - active: true
+              tabs:
+              - history:
+                - url: about:blank
+                - url: http://localhost:*/data/title.html
+              - active: true
+                history:
+                - url: http://localhost:*/data/search.html
+              - history:
+                - url: http://localhost:*/data/scroll.html
+            - tabs:
+              - history:
+                - url: http://localhost:*/data/caret.html
+              - active: true
+                history:
+                - url: http://localhost:*/data/paste_primary.html
+
+    Scenario: buffer troubling args 01
+        Given I have a fresh instance
+        When I open data/title.html
+        And I run :buffer "-1"
+        Then the error "There's no tab with index -1!" should be shown
+
+    Scenario: buffer troubling args 02
+        When I open data/title.html
+        And I run :buffer "/"
+        Then the following tabs should be open:
+            - data/title.html (active)
+
+    Scenario: buffer troubling args 03
+        When I open data/title.html
+        And I run :buffer "//"
+        Then the following tabs should be open:
+            - data/title.html (active)
+
+    Scenario: buffer troubling args 04
+        When I open data/title.html
+        And I run :buffer "0/x"
+        Then the error "No matching tab for: 0/x" should be shown
+
+    Scenario: buffer troubling args 05
+        When I open data/title.html
+        And I run :buffer "1/2/3"
+        Then the error "No matching tab for: 1/2/3" should be shown


### PR DESCRIPTION
This is so you can jump between tabs based on tab title or URL instead
of just index just like the `buffer` command in vim. Adds a `b` alias
for `tab-focus` to be more like vim too.

The method of updating the completion model (rebuild the whole thing
every time a tab is created, removed or updated) is inefficient but is
still very fast for even unreasonable numbers of open tabs.

TODO: I did a quick test and it doesn't seem to work with multiple windows.
Probably because of how I am getting the `win_id`. Can anyone tell me how
to get the _current_ `win_id`?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-compiler/qutebrowser/1317)
<!-- Reviewable:end -->
