### PR TITLE
downloads: fix filename for data: links

### DIFF
--- a/tests/integration/data/downloads/issue1214.html
+++ b/tests/integration/data/downloads/issue1214.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Wrong filename when using data: links</title>
+    </head>
+    <body>
+        <a href="data:;base64,cXV0ZWJyb3dzZXI=">download</a>
+    </body>
+</html>

--- a/tests/integration/features/downloads.feature
+++ b/tests/integration/features/downloads.feature
@@ -34,6 +34,16 @@ Feature: Downloading things from a website.
         And I run :leave-mode
         Then no crash should happen
 
+    Scenario: Downloading a data: link (issue 1214)
+        When I set completion -> download-path-suggestion to filename
+        And I set storage -> prompt-download-directory to true
+        And I open data/downloads/issue1214.html
+        And I run :hint links download
+        And I run :follow-hint a
+        And I wait for "Asking question <qutebrowser.utils.usertypes.Question default='binary blob' mode=<PromptMode.text: 2> text='Save file to:'>, *" in the log
+        And I run :leave-mode
+        Then no crash should happen
+
     Scenario: Retrying a failed download
         When I run :download http://localhost:(port)/does-not-exist
         And I wait for the error "Download error: * - server replied: NOT FOUND"

--- a/tests/integration/features/misc.feature
+++ b/tests/integration/features/misc.feature
@@ -295,7 +295,7 @@ Feature: Various utility commands.
         # WORKAROUND to prevent the "Painter ended with 2 saved states" warning
         # Might be related to https://bugreports.qt.io/browse/QTBUG-13524 and
         # a weird interaction with the previous test.
-        When I wait 0.5s
+        When I wait 1s
         And I set content -> enable-pdfjs to true
         And I set completion -> download-path-suggestion to filename
         And I set storage -> prompt-download-directory to true

--- a/tests/integration/features/misc.feature
+++ b/tests/integration/features/misc.feature
@@ -290,6 +290,18 @@ Feature: Various utility commands.
         And I open data/misc/test.pdf
         Then "Download finished" should be logged
 
+    Scenario: Downloading a pdf via pdf.js button (issue 1214)
+        Given pdfjs is available
+        When I set content -> enable-pdfjs to true
+        And I set completion -> download-path-suggestion to filename
+        And I set storage -> prompt-download-directory to true
+        And I open data/misc/test.pdf
+        And I wait for "[qute://pdfjs/*] PDF * (PDF.js: *)" in the log
+        And I run :jseval document.getElementById("download").click()
+        And I wait for "Asking question <qutebrowser.utils.usertypes.Question default='test.pdf' mode=<PromptMode.text: 2> text='Save file to:'>, *" in the log
+        And I run :leave-mode
+        Then no crash should happen
+
     # :print
 
     # Disabled because it causes weird segfaults and QPainter warnings in Qt...

--- a/tests/integration/features/misc.feature
+++ b/tests/integration/features/misc.feature
@@ -292,7 +292,11 @@ Feature: Various utility commands.
 
     Scenario: Downloading a pdf via pdf.js button (issue 1214)
         Given pdfjs is available
-        When I set content -> enable-pdfjs to true
+        # WORKAROUND to prevent the "Painter ended with 2 saved states" warning
+        # Might be related to https://bugreports.qt.io/browse/QTBUG-13524 and
+        # a weird interaction with the previous test.
+        When I wait 0.5s
+        And I set content -> enable-pdfjs to true
         And I set completion -> download-path-suggestion to filename
         And I set storage -> prompt-download-directory to true
         And I open data/misc/test.pdf


### PR DESCRIPTION
Issue #1214

Now uses a sensible filename for `data:` links instead of the whole base64 content. For PDF.js, it even uses the correct pdf filename.

The "pdf.js test" is still a work in progess, as it constantly fails due to a Qt warning:

It produces a "QPainter::end: Painter ended with ? saved states"  (*emoji unintended*) warning while running the "Downloading a pdf via pdf.js button" test here, tested with

```
Arch Linux (32 and 64 bit)
CPython: 3.5.1
Qt: 5.5.1, runtime: 5.5.1
PyQt: 5.5.1
```

and

```
Ubuntu 15.10 32 bit
CPython: 3.4.3
Qt: 5.4.2, runtime: 5.4.2
PyQt: 5.4.2
```

Normally, the message says "2 saved states", but I could also get "4 saved states" when running with `--qute-delay=50`. When running with `--qute-delay=100` or higher, the tests seem to pass fine.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-compiler/qutebrowser/1321)
<!-- Reviewable:end -->
