### PR TITLE
downloads: handle relative XDG_DOWNLOAD_DIR

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -51,6 +51,7 @@ Fixed
 - Fixed crashes when opening an empty URL (e.g. via pasting).
 - Fixed validation of duplicate values in `hints -> chars`.
 - Fixed crash when PDF.js was partially installed.
+- Fixed crash when XDG_DOWNLOAD_DIR was not an absolute path.
 
 v0.5.1
 ------

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -543,8 +543,8 @@ class DownloadItem(QObject):
             message.error(
                 self._win_id,
                 "XDG_DOWNLOAD_DIR points to a relative path - please check"
-                " your ~/.config/user-dirs.dirs. The download is saved in your "
-                "home directory.",
+                " your ~/.config/user-dirs.dirs. The download is saved in"
+                " your home directory.",
             )
             # fall back to $HOME as download_dir
             self._filename = create_full_filename(

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -534,6 +534,22 @@ class DownloadItem(QObject):
             self._filename = create_full_filename(
                 self.basename, os.path.join(download_dir(), filename))
 
+        # At this point, we have a misconfigured XDG_DOWNLOAd_DIR, as
+        # download_dir() + filename is still no absolute path.
+        # The config value is checked for "absoluteness", but
+        # ~/.config/user-dirs.dirs may be misconfigured and a non-absolute path
+        # may be set for XDG_DOWNLOAD_DIR
+        if self._filename is None:
+            message.error(
+                self._win_id,
+                "XDG_DOWNLOAD_DIR points to a relative path - please check"
+                " your ~/.config/user-dirs.dirs. The download is saved in your "
+                "home directory.",
+            )
+            # fall back to $HOME as download_dir
+            self._filename = create_full_filename(
+                self.basename, os.path.expanduser(os.path.join('~', filename)))
+
         self.basename = os.path.basename(self._filename)
         last_used_directory = os.path.dirname(self._filename)
 


### PR DESCRIPTION
Issues #1269, probably #866

qutebrowser would crash when `XDG_DOWNLOAD_DIR` was set to some
non-absolute value (which should not happen, but it can) and
`storage -> download-dir` was empty, since when the user didn't give an
absolute filename, even the joined path of `download_dir()` (i.e.
`XDG_DOWNLOAD_DIR` in this case) and the filename was not absolute either.

Since the path was not absolute, `create_full_filename` returned `None`,
which meant that `os.path.basename(self._filename)` raised an exception.

Now we display an error message and fall back to $HOME.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/the-compiler/qutebrowser/1323)
<!-- Reviewable:end -->
