### PR TITLE
allow {0} in search engine specification strings

### DIFF
--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1196,7 +1196,7 @@ class SearchEngineUrl(BaseType):
         self._basic_validation(value)
         if not value:
             return
-        elif '{}' not in value:
+        elif not ('{}' in value or '{0}' in value):
             raise configexc.ValidationError(value, "must contain \"{}\"")
         try:
             value.format("")

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -1726,6 +1726,8 @@ class TestSearchEngineUrl:
 
     @pytest.mark.parametrize('val', [
         'http://example.com/?q={}',
+        'http://example.com/?q={0}',
+        'http://example.com/?q={0}&a={0}',
         '',  # empty value with none_ok
     ])
     def test_validate_valid(self, klass, val):


### PR DESCRIPTION
allow {0} in search engine specification strings to allow multiple instances of the search term in the url.
also includes changes to accommodate this in the unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-compiler/qutebrowser/1348)
<!-- Reviewable:end -->
