### PR TITLE
Switch browsing history away from QWebHistoryInterface and add titles.

### DIFF
--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -173,7 +173,11 @@ class WebHistory(QWebHistoryInterface):
         self._lineparser.save()
         self._saved_count = len(self._new_history)
 
-    def addHistoryEntry(self, url_string, title=""):
+    def addHistoryEntry(self, url_string):
+        """Required for a QWebHistoryInterface impl, obseleted by add_url."""
+        pass
+
+    def add_url(self, url_string, title=""):
         """Called by WebKit when an URL should be added to the history.
 
         Args:
@@ -212,3 +216,4 @@ def init(parent=None):
     """
     history = WebHistory(parent)
     objreg.register('web-history', history)
+    QWebHistoryInterface.setDefaultInterface(history)

--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -212,4 +212,3 @@ def init(parent=None):
     """
     history = WebHistory(parent)
     objreg.register('web-history', history)
-    QWebHistoryInterface.setDefaultInterface(history)

--- a/qutebrowser/browser/webview.py
+++ b/qutebrowser/browser/webview.py
@@ -145,6 +145,12 @@ class WebView(QWebView):
         self.loadProgress.connect(lambda p: setattr(self, 'progress', p))
         objreg.get('config').changed.connect(self.on_config_changed)
 
+    @pyqtSlot()
+    def on_initial_layout_complete(self):
+        """Add url to history now that we have displayed something."""
+        objreg.get('web-history').addHistoryEntry(
+            self.url().toDisplayString(), self.title())
+
     def _init_page(self):
         """Initialize the QWebPage used by this view."""
         page = webpage.BrowserPage(self.win_id, self.tab_id, self)
@@ -152,6 +158,8 @@ class WebView(QWebView):
         page.linkHovered.connect(self.linkHovered)
         page.mainFrame().loadStarted.connect(self.on_load_started)
         page.mainFrame().loadFinished.connect(self.on_load_finished)
+        page.mainFrame().initialLayoutCompleted.connect(
+            self.on_initial_layout_complete)
         page.statusBarMessage.connect(
             lambda msg: setattr(self, 'statusbar_message', msg))
         page.networkAccessManager().sslErrors.connect(

--- a/qutebrowser/browser/webview.py
+++ b/qutebrowser/browser/webview.py
@@ -146,9 +146,9 @@ class WebView(QWebView):
         objreg.get('config').changed.connect(self.on_config_changed)
 
     @pyqtSlot()
-    def on_initial_layout_complete(self):
+    def on_initial_layout_completed(self):
         """Add url to history now that we have displayed something."""
-        objreg.get('web-history').addHistoryEntry(
+        objreg.get('web-history').add_url(
             self.url().toDisplayString(), self.title())
 
     def _init_page(self):
@@ -159,7 +159,7 @@ class WebView(QWebView):
         page.mainFrame().loadStarted.connect(self.on_load_started)
         page.mainFrame().loadFinished.connect(self.on_load_finished)
         page.mainFrame().initialLayoutCompleted.connect(
-            self.on_initial_layout_complete)
+            self.on_initial_layout_completed)
         page.statusBarMessage.connect(
             lambda msg: setattr(self, 'statusbar_message', msg))
         page.networkAccessManager().sslErrors.connect(

--- a/qutebrowser/completion/models/urlmodel.py
+++ b/qutebrowser/completion/models/urlmodel.py
@@ -99,7 +99,8 @@ class UrlCompletionModel(base.BaseCompletionModel):
 
     def _add_history_entry(self, entry):
         """Add a new history entry to the completion."""
-        self.new_item(self._history_cat, entry.url.toDisplayString(), "",
+        self.new_item(self._history_cat, entry.url.toDisplayString(),
+                      entry.title,
                       self._fmt_atime(entry.atime), sort=int(entry.atime),
                       userdata=entry.url)
 
@@ -122,9 +123,11 @@ class UrlCompletionModel(base.BaseCompletionModel):
         for i in range(self._history_cat.rowCount()):
             url_item = self._history_cat.child(i, self.URL_COLUMN)
             atime_item = self._history_cat.child(i, self.TIME_COLUMN)
+            title_item = self._history_cat.child(i, self.TEXT_COLUMN)
             url = url_item.data(base.Role.userdata)
             if url == entry.url:
                 atime_item.setText(self._fmt_atime(entry.atime))
+                title_item.setText(entry.title)
                 url_item.setData(int(entry.atime), base.Role.sort)
                 break
         else:


### PR DESCRIPTION
Changes history items to be added when initialLayoutCompleted is fired as opposed to when navigation is initiated. Regarding #1345 this method saves the final url after redirects and doesn't save the url of the redirect.

There are some things I am unsure about:
* Encoding. I haven't tested the serialization with unicode titles (and urls) on windows.
* Testing. I was looking at the history behavior for redirects and errors and was wondering if this was worth adding to the test suite and how.

Here is some comparisons with dwb and otter:

Otter (for the qtwebkit backend at least) calls handleHistory() at a few
places but calls after the first one update an entry instead of adding a new
one. It gets called on title changed, navigate (load started I think) and load
finished. Due to events that would update current url and title not firing for
redirect urls otter saves the originally requested url as url and title into
history so if there is a chain of redirects all but the first will be saved
wrong.

dwb and QupZilla use load finished. They only save the final page on
redirects.

This method, the old method, dwb and otter all save the requested url to
history on DNS and 404 errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-compiler/qutebrowser/1350)
<!-- Reviewable:end -->
