### PR TITLE
Allow searching system-wide data path on Linux for userscripts

### DIFF
--- a/qutebrowser/commands/userscripts.py
+++ b/qutebrowser/commands/userscripts.py
@@ -344,13 +344,17 @@ def run(cmd, *args, win_id, env, verbose=False):
     user_agent = config.get('network', 'user-agent')
     if user_agent is not None:
         env['QUTE_USER_AGENT'] = user_agent
-    cmd = os.path.expanduser(cmd)
+    cmd_path = os.path.expanduser(cmd)
 
     # if cmd is not given as an absolute path, look it up
     # ~/.local/share/qutebrowser/userscripts (or $XDG_DATA_DIR)
-    if not os.path.isabs(cmd):
-        log.misc.debug("{} is no absolute path".format(cmd))
-        cmd = os.path.join(standarddir.data(), "userscripts", cmd)
+    if not os.path.isabs(cmd_path):
+        log.misc.debug("{} is no absolute path".format(cmd_path))
+        cmd_path = os.path.join(standarddir.data(), "userscripts", cmd)
+        if not os.path.exists(cmd_path):
+            cmd_path = os.path.join(standarddir.system_data(),
+                                    "userscripts", cmd)
+    log.misc.debug("Userscript to run: {}".format(cmd_path))
 
     runner.run(cmd, *args, env=env, verbose=verbose)
     runner.finished.connect(commandrunner.deleteLater)

--- a/qutebrowser/commands/userscripts.py
+++ b/qutebrowser/commands/userscripts.py
@@ -356,6 +356,6 @@ def run(cmd, *args, win_id, env, verbose=False):
                                     "userscripts", cmd)
     log.misc.debug("Userscript to run: {}".format(cmd_path))
 
-    runner.run(cmd, *args, env=env, verbose=verbose)
+    runner.run(cmd_path, *args, env=env, verbose=verbose)
     runner.finished.connect(commandrunner.deleteLater)
     runner.finished.connect(runner.deleteLater)

--- a/qutebrowser/utils/standarddir.py
+++ b/qutebrowser/utils/standarddir.py
@@ -65,6 +65,17 @@ def data():
     return path
 
 
+def system_data():
+    """Get a location for system-wide data. This path may be read-only."""
+    if sys.platform.startswith('linux'):
+        path = "/usr/share/qutebrowser"
+        if not os.path.exists(path):
+            path = data()
+    else:
+        path = data()
+    return path
+
+
 def cache():
     """Get a location for the cache."""
     typ = QStandardPaths.CacheLocation

--- a/tests/unit/utils/test_standarddir.py
+++ b/tests/unit/utils/test_standarddir.py
@@ -313,3 +313,25 @@ class TestCreatingDir:
 
         func = getattr(standarddir, typ)
         func()
+
+
+class TestSystemData:
+
+    """Test system data path."""
+
+    def test_system_datadir_exist_linux(self, monkeypatch):
+        """Test that /usr/share/qutebrowser is used if path exists."""
+        monkeypatch.setattr('sys.platform', "linux")
+        monkeypatch.setattr(os.path, 'exists', lambda path: True)
+        assert standarddir.system_data() == "/usr/share/qutebrowser"
+
+    @pytest.mark.linux
+    def test_system_datadir_not_exist_linux(self, monkeypatch):
+        """Test that system-wide path isn't used on linux if path not exist."""
+        monkeypatch.setattr(os.path, 'exists', lambda path: False)
+        assert standarddir.system_data() == standarddir.data()
+
+    def test_system_datadir_unsupportedos(self, monkeypatch):
+        """Test that system-wide path is not used on non-Linux OS."""
+        monkeypatch.setattr('sys.platform', "potato")
+        assert standarddir.system_data() == standarddir.data()


### PR DESCRIPTION
This implements a system-wide data location (/usr/share/qutebrowser) when running on Linux, and the userscript command has been modified to search in this location if it cannot find a script in the user-specific path that the standarddir.data() returns.
For non-Linux systems and Linux systems where nothing was installed to /usr/share/qutebrowser, the system_data() function defaults to calling data() for the user-specific path. This insures that there is always _something_ usable returned by this function, even if the path is not system-wide. 

Packagers would need to create this path (/usr/share/qutebrowser) on Linux systems, and install the userscripts directory to this location. In the future, other files could be placed here (global qutebrowser.conf, anyone? :P)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-compiler/qutebrowser/1356)
<!-- Reviewable:end -->
