### PR TITLE
Add background-tabs and new-tab-position feature tests

### DIFF
--- a/tests/integration/features/tabs.feature
+++ b/tests/integration/features/tabs.feature
@@ -644,3 +644,61 @@ Feature: Tab management
         And I run :tab-only
         And I run :tab-close
         Then qutebrowser should quit
+
+    # tab settings
+
+    Scenario: opening links with tabs->background-tabs true
+        When I set tabs -> background-tabs to true
+        And I open data/hints/link.html
+        And I run :hint all tab
+        And I run :follow-hint a
+        Then the following tabs should be open:
+            - data/hints/link.html (active)
+            - data/hello.txt
+
+    Scenario: opening tab with tabs->new-tab-position left
+        When I set tabs -> new-tab-position to left
+        And I set tabs -> background-tabs to false
+        And I open about:blank
+        And I open data/hints/link.html in a new tab
+        And I run :hint all tab
+        And I run :follow-hint a
+        Then the following tabs should be open:
+            - about:blank
+            - data/hello.txt (active)
+            - data/hints/link.html
+
+    Scenario: opening tab with tabs->new-tab-position right
+        When I set tabs -> new-tab-position to right
+        And I set tabs -> background-tabs to false
+        And I open about:blank
+        And I open data/hints/link.html in a new tab
+        And I run :hint all tab
+        And I run :follow-hint a
+        Then the following tabs should be open:
+            - about:blank
+            - data/hints/link.html
+            - data/hello.txt (active)
+
+    Scenario: opening tab with tabs->new-tab-position first
+        When I set tabs -> new-tab-position to first
+        And I open about:blank
+        And I open data/hints/link.html in a new tab
+        And I run :hint all tab
+        And I run :follow-hint a
+        Then the following tabs should be open:
+            - data/hello.txt (active)
+            - about:blank
+            - data/hints/link.html
+
+    Scenario: opening tab with tabs->new-tab-position last
+        When I set tabs -> new-tab-position to last
+        And I open data/hints/link.html
+        And I open about:blank in a new tab
+        And I run :tab-focus last
+        And I run :hint all tab
+        And I run :follow-hint a
+        Then the following tabs should be open:
+            - data/hints/link.html
+            - about:blank
+            - data/hello.txt (active)

--- a/tests/integration/features/tabs.feature
+++ b/tests/integration/features/tabs.feature
@@ -652,6 +652,7 @@ Feature: Tab management
         And I open data/hints/link.html
         And I run :hint all tab
         And I run :follow-hint a
+        And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
             - data/hints/link.html (active)
             - data/hello.txt

--- a/tests/integration/features/tabs.feature
+++ b/tests/integration/features/tabs.feature
@@ -663,6 +663,7 @@ Feature: Tab management
         And I open data/hints/link.html in a new tab
         And I run :hint all tab
         And I run :follow-hint a
+        And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
             - about:blank
             - data/hello.txt (active)
@@ -675,6 +676,7 @@ Feature: Tab management
         And I open data/hints/link.html in a new tab
         And I run :hint all tab
         And I run :follow-hint a
+        And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
             - about:blank
             - data/hints/link.html
@@ -687,6 +689,7 @@ Feature: Tab management
         And I open data/hints/link.html in a new tab
         And I run :hint all tab
         And I run :follow-hint a
+        And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
             - data/hello.txt (active)
             - about:blank
@@ -700,6 +703,7 @@ Feature: Tab management
         And I run :tab-focus last
         And I run :hint all tab
         And I run :follow-hint a
+        And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
             - data/hints/link.html
             - about:blank

--- a/tests/integration/features/tabs.feature
+++ b/tests/integration/features/tabs.feature
@@ -682,6 +682,7 @@ Feature: Tab management
 
     Scenario: opening tab with tabs->new-tab-position first
         When I set tabs -> new-tab-position to first
+        And I set tabs -> background-tabs to false
         And I open about:blank
         And I open data/hints/link.html in a new tab
         And I run :hint all tab
@@ -693,6 +694,7 @@ Feature: Tab management
 
     Scenario: opening tab with tabs->new-tab-position last
         When I set tabs -> new-tab-position to last
+        And I set tabs -> background-tabs to false
         And I open data/hints/link.html
         And I open about:blank in a new tab
         And I run :tab-focus last


### PR DESCRIPTION
This adds feature tests for the `background-tabs` and `new-tab-position` settings.

I'm using hints to select and open the link. Not sure if there is a more concise way to achieve the same result.

Issue-Link: https://github.com/The-Compiler/qutebrowser/issues/999

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/the-compiler/qutebrowser/1361)
<!-- Reviewable:end -->
