### PR TITLE
Complete url's in openfeeds userscript

### DIFF
--- a/misc/userscripts/openfeeds
+++ b/misc/userscripts/openfeeds
@@ -30,9 +30,10 @@ import os
 import re
 
 from bs4 import BeautifulSoup
+from urllib.parse import urljoin
 
 with open(os.environ['QUTE_HTML'], 'r') as f:
     soup = BeautifulSoup(f)
 with open(os.environ['QUTE_FIFO'], 'w') as f:
     for link in soup.find_all('link', rel='alternate', type=re.compile(r'application/((rss|rdf|atom)\+)?xml|text/xml')):
-        f.write('open -t %s\n' % link.get('href'))
+        f.write('open -t %s\n' % urljoin(os.environ['QUTE_URL'], link.get('href')))


### PR DESCRIPTION
Currently, the openfeeds userscript only works when a complete url is given. When an url such as:
 - /feeds
 - //hello.world/feeds
 - ../feeds
is given, qutebrowser will search, or (try to) open a file. This fixes this.