### PR TITLE
Fix importer script to output bookmarks in the right format for qutebrowser to use

### DIFF
--- a/qutebrowser/commands/userscripts.py
+++ b/qutebrowser/commands/userscripts.py
@@ -344,13 +344,17 @@ def run(cmd, *args, win_id, env, verbose=False):
     user_agent = config.get('network', 'user-agent')
     if user_agent is not None:
         env['QUTE_USER_AGENT'] = user_agent
-    cmd = os.path.expanduser(cmd)
+    cmd_path = os.path.expanduser(cmd)
 
     # if cmd is not given as an absolute path, look it up
     # ~/.local/share/qutebrowser/userscripts (or $XDG_DATA_DIR)
-    if not os.path.isabs(cmd):
-        log.misc.debug("{} is no absolute path".format(cmd))
-        cmd = os.path.join(standarddir.data(), "userscripts", cmd)
+    if not os.path.isabs(cmd_path):
+        log.misc.debug("{} is no absolute path".format(cmd_path))
+        cmd_path = os.path.join(standarddir.data(), "userscripts", cmd)
+        if not os.path.exists(cmd_path):
+            cmd_path = os.path.join(standarddir.system_data(),
+                                    "userscripts", cmd)
+    log.misc.debug("Userscript to run: {}".format(cmd_path))
 
     runner.run(cmd, *args, env=env, verbose=verbose)
     runner.finished.connect(commandrunner.deleteLater)

--- a/qutebrowser/commands/userscripts.py
+++ b/qutebrowser/commands/userscripts.py
@@ -356,6 +356,6 @@ def run(cmd, *args, win_id, env, verbose=False):
                                     "userscripts", cmd)
     log.misc.debug("Userscript to run: {}".format(cmd_path))
 
-    runner.run(cmd, *args, env=env, verbose=verbose)
+    runner.run(cmd_path, *args, env=env, verbose=verbose)
     runner.finished.connect(commandrunner.deleteLater)
     runner.finished.connect(runner.deleteLater)

--- a/qutebrowser/utils/standarddir.py
+++ b/qutebrowser/utils/standarddir.py
@@ -65,6 +65,17 @@ def data():
     return path
 
 
+def system_data():
+    """Get a location for system-wide data. This path may be read-only."""
+    if sys.platform.startswith('linux'):
+        path = "/usr/share/qutebrowser"
+        if not os.path.exists(path):
+            path = data()
+    else:
+        path = data()
+    return path
+
+
 def cache():
     """Get a location for the cache."""
     typ = QStandardPaths.CacheLocation

--- a/scripts/importer.py
+++ b/scripts/importer.py
@@ -61,7 +61,7 @@ def import_netscape_bookmarks(bookmarks_file):
     bookmarks = []
     for tag in html_tags:
         if tag['href'] not in bookmarks:
-            bookmarks.append('{tag.string} {tag[href]}'.format(tag=tag))
+            bookmarks.append('{tag[href]} {tag.string}'.format(tag=tag))
 
     for bookmark in bookmarks:
         print(bookmark)

--- a/tests/unit/utils/test_standarddir.py
+++ b/tests/unit/utils/test_standarddir.py
@@ -313,3 +313,25 @@ class TestCreatingDir:
 
         func = getattr(standarddir, typ)
         func()
+
+
+class TestSystemData:
+
+    """Test system data path."""
+
+    def test_system_datadir_exist_linux(self, monkeypatch):
+        """Test that /usr/share/qutebrowser is used if path exists."""
+        monkeypatch.setattr('sys.platform', "linux")
+        monkeypatch.setattr(os.path, 'exists', lambda path: True)
+        assert standarddir.system_data() == "/usr/share/qutebrowser"
+
+    @pytest.mark.linux
+    def test_system_datadir_not_exist_linux(self, monkeypatch):
+        """Test that system-wide path isn't used on linux if path not exist."""
+        monkeypatch.setattr(os.path, 'exists', lambda path: False)
+        assert standarddir.system_data() == standarddir.data()
+
+    def test_system_datadir_unsupportedos(self, monkeypatch):
+        """Test that system-wide path is not used on non-Linux OS."""
+        monkeypatch.setattr('sys.platform', "potato")
+        assert standarddir.system_data() == standarddir.data()


### PR DESCRIPTION
This prints each bookmark it reads from html in the format "<url> <title>". Previously, if you tried to select a bookmark, qutebrowser would search for the bookmark's title using your search engine of choice rather than visit the url.