### PR TITLE
[WIP] force link to open in current tab

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -164,6 +164,7 @@ Contributors, sorted by the number of commits in descending order:
 * Nathan Isom
 * Thorsten Wißmann
 * Austin Anderson
+* Kevin Velghe
 * Alexey "Averrin" Nabrodov
 * ZDarian
 * Milan Svoboda
@@ -215,7 +216,6 @@ Contributors, sorted by the number of commits in descending order:
 * Samuel Loury
 * Matthias Lisin
 * Marcel Schilling
-* Kevin Velghe
 * Jean-Christophe Petkovich
 * Helen Sherwood-Taylor
 * HalosGhost

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -275,7 +275,8 @@ Start hinting.
 
 * +'target'+: What to do with the selected element. 
 
- - `normal`: Open the link in the current tab.
+ - `normal`: Open the link.
+ - `current`: Open the link in the current tab.
  - `tab`: Open the link in a new tab (honoring the
  background-tabs setting).
  - `tab-fg`: Open the link in a new foreground tab.

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -463,6 +463,7 @@ class HintManager(QObject):
                 QMouseEvent(QEvent.MouseButtonRelease, pos, Qt.LeftButton,
                             Qt.NoButton, modifiers),
             ]
+        elem.remove_target()
         for evt in events:
             self.mouse_event.emit(evt)
         if elem.is_text_input() and elem.is_editable():

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -71,7 +71,8 @@ class HintContext:
         elems: A mapping from key strings to (elem, label) namedtuples.
         baseurl: The URL of the current page.
         target: What to do with the opened links.
-                normal/current/tab/tab_fg/tab_bg/window: Get passed to BrowserTab.
+                normal/current/tab/tab_fg/tab_bg/window: Get passed to
+                                                         BrowserTab.
                 yank/yank_primary: Yank to clipboard/primary selection.
                 run: Run a command.
                 fill: Fill commandline with link.

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -42,10 +42,10 @@ from qutebrowser.misc import guiprocess
 ElemTuple = collections.namedtuple('ElemTuple', ['elem', 'label'])
 
 
-Target = usertypes.enum('Target', ['normal', 'tab', 'tab_fg', 'tab_bg',
-                                   'window', 'yank', 'yank_primary', 'run',
-                                   'fill', 'hover', 'download', 'userscript',
-                                   'spawn'])
+Target = usertypes.enum('Target', ['normal', 'current', 'tab', 'tab_fg',
+                                   'tab_bg', 'window', 'yank', 'yank_primary',
+                                   'run', 'fill', 'hover', 'download',
+                                   'userscript', 'spawn'])
 
 
 class WordHintingError(Exception):
@@ -71,7 +71,7 @@ class HintContext:
         elems: A mapping from key strings to (elem, label) namedtuples.
         baseurl: The URL of the current page.
         target: What to do with the opened links.
-                normal/tab/tab_fg/tab_bg/window: Get passed to BrowserTab.
+                normal/current/tab/tab_fg/tab_bg/window: Get passed to BrowserTab.
                 yank/yank_primary: Yank to clipboard/primary selection.
                 run: Run a command.
                 fill: Fill commandline with link.
@@ -128,6 +128,7 @@ class HintManager(QObject):
 
     HINT_TEXTS = {
         Target.normal: "Follow hint",
+        Target.current: "Follow hint in current tab",
         Target.tab: "Follow hint in new tab",
         Target.tab_fg: "Follow hint in foreground tab",
         Target.tab_bg: "Follow hint in background tab",
@@ -429,6 +430,7 @@ class HintManager(QObject):
         """
         target_mapping = {
             Target.normal: usertypes.ClickTarget.normal,
+            Target.current: usertypes.ClickTarget.normal,
             Target.tab_fg: usertypes.ClickTarget.tab,
             Target.tab_bg: usertypes.ClickTarget.tab_bg,
             Target.window: usertypes.ClickTarget.window,
@@ -463,7 +465,8 @@ class HintManager(QObject):
                 QMouseEvent(QEvent.MouseButtonRelease, pos, Qt.LeftButton,
                             Qt.NoButton, modifiers),
             ]
-        elem.remove_target()
+        if context.target == Target.current:
+            elem.remove_target()
         for evt in events:
             self.mouse_event.emit(evt)
         if elem.is_text_input() and elem.is_editable():
@@ -742,7 +745,8 @@ class HintManager(QObject):
 
             target: What to do with the selected element.
 
-                - `normal`: Open the link in the current tab.
+                - `normal`: Open the link.
+                - `current`: Open the link in the current tab.
                 - `tab`: Open the link in a new tab (honoring the
                          background-tabs setting).
                 - `tab-fg`: Open the link in a new foreground tab.
@@ -892,6 +896,7 @@ class HintManager(QObject):
         # Handlers which take a QWebElement
         elem_handlers = {
             Target.normal: self._click,
+            Target.current: self._click,
             Target.tab: self._click,
             Target.tab_fg: self._click,
             Target.tab_bg: self._click,

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -466,7 +466,7 @@ class HintManager(QObject):
                             Qt.NoButton, modifiers),
             ]
         if context.target == Target.current:
-            elem.remove_target()
+            elem.remove_blank_target()
         for evt in events:
             self.mouse_event.emit(evt)
         if elem.is_text_input() and elem.is_editable():

--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -288,8 +288,11 @@ class WebElementWrapper(collections.abc.MutableMapping):
     def remove_blank_target(self):
         """Remove target from link."""
         elem = self._elem
-        while elem is not None:
-            if elem.tagName().lower() == 'a':
+        for i in range(5):
+            if elem is None:
+                break
+            tag = elem.tagName().lower()
+            if tag == 'a' or tag == 'area':
                 if elem.attribute('target') == '_blank':
                     elem.setAttribute('target', '_top')
                 break

--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -286,7 +286,7 @@ class WebElementWrapper(collections.abc.MutableMapping):
         return self.get('role', None) in roles or tag in ('input', 'textarea')
 
     def remove_target(self):
-        """Remove target from link"""
+        """Remove target from link."""
         if self._elem.tagName().lower() == 'a':
             self._elem.removeAttribute('target')
         elif self.parent().tagName().lower() == 'a':

--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -285,12 +285,13 @@ class WebElementWrapper(collections.abc.MutableMapping):
         tag = self._elem.tagName().lower()
         return self.get('role', None) in roles or tag in ('input', 'textarea')
 
-    def remove_target(self):
+    def remove_blank_target(self):
         """Remove target from link."""
-        if self._elem.tagName().lower() == 'a':
-            self._elem.removeAttribute('target')
-        elif self.parent().tagName().lower() == 'a':
-            self.parent().removeAttribute('target')
+        for elem in [self._elem, self.parent()]:
+            if elem.tagName().lower() == 'a':
+                if elem.attribute('target') == '_blank':
+                    elem.setAttribute('target', '_top')
+                break
 
     def debug_text(self):
         """Get a text based on an element suitable for debug output."""

--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -287,11 +287,13 @@ class WebElementWrapper(collections.abc.MutableMapping):
 
     def remove_blank_target(self):
         """Remove target from link."""
-        for elem in [self._elem, self.parent()]:
+        elem = self._elem
+        while elem is not None:
             if elem.tagName().lower() == 'a':
                 if elem.attribute('target') == '_blank':
                     elem.setAttribute('target', '_top')
                 break
+            elem = elem.parent()
 
     def debug_text(self):
         """Get a text based on an element suitable for debug output."""

--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -285,6 +285,13 @@ class WebElementWrapper(collections.abc.MutableMapping):
         tag = self._elem.tagName().lower()
         return self.get('role', None) in roles or tag in ('input', 'textarea')
 
+    def remove_target(self):
+        """Remove target from link"""
+        if self._elem.tagName().lower() == 'a':
+            self._elem.removeAttribute('target')
+        elif self.parent().tagName().lower() == 'a':
+            self.parent().removeAttribute('target')
+
     def debug_text(self):
         """Get a text based on an element suitable for debug output."""
         self._check_vanished()

--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -288,7 +288,7 @@ class WebElementWrapper(collections.abc.MutableMapping):
     def remove_blank_target(self):
         """Remove target from link."""
         elem = self._elem
-        for i in range(5):
+        for _ in range(5):
             if elem is None:
                 break
             tag = elem.tagName().lower()

--- a/tests/integration/data/hints/link_blank.html
+++ b/tests/integration/data/hints/link_blank.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>A link to use hints on</title>
+    </head>
+    <body>
+        <a href="/data/hello.txt" target="_blank">Follow me!</a>
+    </body>
+</html>

--- a/tests/integration/data/hints/link_span.html
+++ b/tests/integration/data/hints/link_span.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>A link to use hints on</title>
+    </head>
+    <body>
+        <a href="/data/hello.txt" target="_blank"><span style="font-size: large">Follow me!</span></a>
+    </body>
+</html>

--- a/tests/integration/features/hints.feature
+++ b/tests/integration/features/hints.feature
@@ -20,7 +20,7 @@ Feature: Using hints
         Then the error "No hint xyz!" should be shown
 
     Scenario: Following a hint and force to open in current tab.
-        When I open data/hints/link.html
+        When I open data/hints/link_blank.html
         And I run :hint links current
         And I run :follow-hint a
         And I wait until data/hello.txt is loaded
@@ -34,4 +34,13 @@ Feature: Using hints
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
             - data/hints/link_blank.html
+            - data/hello.txt (active)
+
+    Scenario: Following a hint to link with sub-element and force to open in current tab.
+        When I open data/hints/link_span.html
+        And I run :tab-close
+        And I run :hint links current
+        And I run :follow-hint a
+        And I wait until data/hello.txt is loaded
+        Then the following tabs should be open:
             - data/hello.txt (active)

--- a/tests/integration/features/hints.feature
+++ b/tests/integration/features/hints.feature
@@ -18,3 +18,20 @@ Feature: Using hints
         And I run :hint links normal
         And I run :follow-hint xyz
         Then the error "No hint xyz!" should be shown
+
+    Scenario: Following a hint and force to open in current tab.
+        When I open data/hints/link.html
+        And I run :hint links current
+        And I run :follow-hint a
+        And I wait until data/hello.txt is loaded
+        Then the following tabs should be open:
+            - data/hello.txt (active)
+
+    Scenario: Following a hint and allow to open in new tab.
+        When I open data/hints/link_blank.html
+        And I run :hint links normal
+        And I run :follow-hint a
+        And I wait until data/hello.txt is loaded
+        Then the following tabs should be open:
+            - data/hints/link_blank.html
+            - data/hello.txt (active)

--- a/tests/unit/browser/test_webelem.py
+++ b/tests/unit/browser/test_webelem.py
@@ -347,11 +347,16 @@ class TestWebElementWrapper:
         elem_child.remove_blank_target()
         assert elem._elem.attribute('target') == '_top'
 
-        elem = get_webelem(tagname='button')
-        elem_child = get_webelem(tagname='div', parent=elem._elem)
-        elem_child._elem.encloseWith(elem._elem)
-        elem_child.remove_blank_target()
-        assert 'target' not in elem_child
+        elem[0] = get_webelem(tagname='div')
+        for i in range(1, 5):
+            elem[i] = get_webelem(tagname='div', parent=elem[i-1])
+            elem[i]._elem.encloseWith(elem[i-1]._elem)
+        elem[4].remove_blank_target()
+        for i in range(5):
+            assert 'target' not in elem[i]
+
+        elem = get_webelem(tagname='div')
+        elem.remove_blank_target()
         assert 'target' not in elem
 
 

--- a/tests/unit/browser/test_webelem.py
+++ b/tests/unit/browser/test_webelem.py
@@ -339,13 +339,20 @@ class TestWebElementWrapper:
 
         elem = get_webelem(tagname='a')
         elem.remove_blank_target()
-        assert elem._elem.attribute('target') == ''
+        assert 'target' not in elem
 
         elem = get_webelem(tagname='a', attributes={'target': '_blank'})
         elem_child = get_webelem(tagname='img', parent=elem._elem)
         elem_child._elem.encloseWith(elem._elem)
         elem_child.remove_blank_target()
         assert elem._elem.attribute('target') == '_top'
+
+        elem = get_webelem(tagname='button')
+        elem_child = get_webelem(tagname='div', parent=elem._elem)
+        elem_child._elem.encloseWith(elem._elem)
+        elem_child.remove_blank_target()
+        assert 'target' not in elem_child
+        assert 'target' not in elem
 
 
 class TestIsVisible:

--- a/tests/unit/browser/test_webelem.py
+++ b/tests/unit/browser/test_webelem.py
@@ -342,7 +342,7 @@ class TestWebElementWrapper:
         assert elem._elem.attribute('target') == ''
 
         elem = get_webelem(tagname='a', attributes={'target': '_blank'})
-        elem_child = get_webelem(tagname='img', attributes={'src':'test'}, parent=elem._elem)
+        elem_child = get_webelem(tagname='img', parent=elem._elem)
         elem_child._elem.encloseWith(elem._elem)
         elem_child.remove_blank_target()
         assert elem._elem.attribute('target') == '_top'


### PR DESCRIPTION
Fix for #676

It removes the target of the link, like VimFX, as to prevent the website to overrule the user. Thanks to @The-Compiler to point me to QWebElement. I guess one of the following things should be done:
 - add setting to enable/disable this behaviour
 - add "hint all current"

I'm not sure what you would prefer, so I'll wait for some comments.
