### PR TITLE
Remove _new target in links

### DIFF
--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -293,7 +293,7 @@ class WebElementWrapper(collections.abc.MutableMapping):
                 break
             tag = elem.tagName().lower()
             if tag == 'a' or tag == 'area':
-                if elem.attribute('target') == '_blank':
+                if elem.attribute('target') in ('_blank', '_new'):
                     elem.setAttribute('target', '_top')
                 break
             elem = elem.parent()

--- a/tests/unit/browser/test_webelem.py
+++ b/tests/unit/browser/test_webelem.py
@@ -344,14 +344,16 @@ class TestRemoveBlankTarget:
         assert 'target' not in elem
 
     @pytest.mark.parametrize('tagname', ['a', 'area'])
-    def test_blank_target(self, tagname):
-        elem = get_webelem(tagname=tagname, attributes={'target': '_blank'})
+    @pytest.mark.parametrize('target', ['_blank', '_new'])
+    def test_blank_target(self, tagname, target):
+        elem = get_webelem(tagname=tagname, attributes={'target': target})
         elem.remove_blank_target()
         assert elem['target'] == '_top'
 
     @pytest.mark.parametrize('tagname', ['a', 'area'])
-    def test_ancestor_blank_target(self, tagname):
-        elem = get_webelem(tagname=tagname, attributes={'target': '_blank'})
+    @pytest.mark.parametrize('target', ['_blank', '_new'])
+    def test_ancestor_blank_target(self, tagname, target):
+        elem = get_webelem(tagname=tagname, attributes={'target': target})
         elem_child = get_webelem(tagname='img', parent=elem._elem)
         elem_child._elem.encloseWith(elem._elem)
         elem_child.remove_blank_target()


### PR DESCRIPTION
WebKit, and I guess WebEngine, supports the non-standard target="_new". As it has (always?) the same effect as _blank, we should handle it the same.