### PR TITLE
Implement libsecret password backend

### DIFF
--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -273,6 +273,28 @@ pass_backend() {
 }
 # =======================================================
 
+# =======================================================
+# backend: secret
+secret_backend() {
+    init() {
+        return
+    }
+    query_entries() {
+        local domain="$1"
+        while read -r line ; do
+            if [[ "$line" =~ "attribute.username = " ]] ; then
+                files+=("$domain ${line#${BASH_REMATCH[0]}}")
+            fi
+        done < <( secret-tool search --unlock --all domain "$domain" 2>&1 )
+    }
+    open_entry() {
+        local domain="${1%% *}"
+        username="${1#* }"
+        password=$(secret-tool lookup domain "$domain" username "$username")
+    }
+}
+# =======================================================
+
 # load some sane default backend
 reset_backend
 pass_backend


### PR DESCRIPTION
This adds support for for libsecret keyrings (GNOME keyring and others), using `secret-tool`, to the `password_fill` userscript.