### PR TITLE
Implement edit-url to craft a url with an editor.

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -20,6 +20,7 @@
 |<<download-open,download-open>>|Open the last/[count]th download.
 |<<download-remove,download-remove>>|Remove the last/[count]th download from the list.
 |<<download-retry,download-retry>>|Retry the first failed/[count]th download.
+|<<edit-url,edit-url>>|Compose a url in an external editor and navigate to it.
 |<<fake-key,fake-key>>|Send a fake keypress or key string to the website or qutebrowser.
 |<<forward,forward>>|Go forward in the history of the current tab.
 |<<fullscreen,fullscreen>>|Toggle fullscreen mode.
@@ -222,6 +223,21 @@ Retry the first failed/[count]th download.
 
 ==== count
 The index of the download to retry.
+
+[[edit-url]]
+=== edit-url
+Syntax: +:edit-url [*--bg*] [*--tab*] [*--window*] ['url']+
+
+Open a URL in an external editor and navigate to it upon closing the editor.
+
+==== optional arguments
+* +'url'+: A URL to pre-populate the editor with; defaults to the current URL.
+* +*-b*+, +*--bg*+: Open in a new background tab.
+* +*-t*+, +*--tab*+: Open in a new tab.
+* +*-w*+, +*--window*+: Open in a new window.
+
+==== count
+The tab index to open the URL in.
 
 [[fake-key]]
 === fake-key

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1862,12 +1862,11 @@ class CommandDispatcher:
             window: Open in a new window.
             count: The tab index to open the URL in, or None.
         """
-        self._editor = editor.ExternalEditor(
-            self._win_id, self._tabbed_browser)
+        ed = editor.ExternalEditor(self._win_id, self._tabbed_browser)
 
         # Passthrough for openurl args (e.g. -t, -b, -w)
-        self._editor.editing_finished.connect(
+        ed.editing_finished.connect(
             functools.partial(self.openurl,
-            bg = bg, tab = tab, window = window, count = count))
+            bg=bg, tab=tab, window=window, count=count))
 
-        self._editor.edit(url or self._current_url().toString())
+        ed.edit(url or self._current_url().toString())

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1847,3 +1847,27 @@ class CommandDispatcher:
         """Clear remembered SSL error answers."""
         nam = self._current_widget().page().networkAccessManager()
         nam.clear_all_ssl_errors()
+
+    @cmdutils.register(instance='command-dispatcher', scope='window')
+    def edit_url(self, url=None, bg=False, tab=False, window=False, count=None):
+        """Navigate to a url formed in an external editor.
+
+        The editor which should be launched can be configured via the
+        `general -> editor` config option.
+
+        Args:
+            url: URL to edit; defaults to the current page url.
+            bg: Open in a new background tab.
+            tab: Open in a new tab.
+            window: Open in a new window.
+            count: The tab index to open the URL in, or None.
+        """
+        self._editor = editor.ExternalEditor(
+            self._win_id, self._tabbed_browser)
+
+        # Passthrough for openurl args (e.g. -t, -b, -w)
+        self._editor.editing_finished.connect(
+            functools.partial(self.openurl,
+            bg = bg, tab = tab, window = window, count = count))
+
+        self._editor.edit(url or self._current_url().toString())


### PR DESCRIPTION
The edit-url command opens a url (by default, the current url) in the
user's external editor and navigates to the result when the editor is
closed. This makes it easy to tweak the current url to navigate within
a site.

`edit-url` accepts the same flags as `open` (e.g. -t will open in a new
tab.

One may provide a url as an argument to create a shortcut to
pre-populate part of a url and allow filling in the rest.

There is no default keybinding.

Resolves #1261.