### PR TITLE
Add ':o' alias for open and ':e' alias for session-load

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -226,7 +226,7 @@ class CommandDispatcher:
             self._tabbed_browser.close_tab(tab)
             tabbar.setSelectionBehaviorOnRemove(old_selection_behavior)
 
-    @cmdutils.register(instance='command-dispatcher', name='open',
+    @cmdutils.register(instance='command-dispatcher', name=['open', 'o'],
                        maxsplit=0, scope='window', count='count',
                        completion=[usertypes.Completion.url])
     def openurl(self, url=None, bg=False, tab=False, window=False, count=None):

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -354,7 +354,8 @@ class SessionManager(QObject):
                 sessions.append(base)
         return sessions
 
-    @cmdutils.register(completion=[usertypes.Completion.sessions],
+    @cmdutils.register(name=['session-load', 'e'],
+                       completion=[usertypes.Completion.sessions],
                        instance='session-manager')
     def session_load(self, name, clear=False, temp=False, force=False):
         """Load a session.


### PR DESCRIPTION
In this PR I added aliases for `:open` and `:session-load`

I added `:e` as the alias for loading sessions as it lines up with the current `:w` alias for writing sessions.

`:o` is a present alias in many other plugins, and it's a very frequently used command, so it makes sense to have a short alias.

I also added an [editorconfig](http://editorconfig.org/) file to set style options for who aren't running vim (and can't use the `:vim` headers) but have the editorconfig plugin.

Let me know if there are any isses and I'll go ahead and fix them!