### PR TITLE
Add basic editorconfig for enforcing style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+max_line_length = 79
+
+indent_style = space
+indent_size = 4
+
+[*.yml]
+indent_size = 2
+
+[*.feature]
+max_line_length = 9999
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -25,6 +25,7 @@ recursive-exclude doc *.asciidoc
 include doc/qutebrowser.1.asciidoc
 prune tests
 prune qutebrowser/3rdparty
+exclude .editorconfig
 exclude pytest.ini
 exclude qutebrowser.rcc
 exclude .coveragerc


### PR DESCRIPTION
Here is my [editorconfig](http://editorconfig.org/) file from the other PR. These are the settings I could infer, but if anything is wrong let me know! With editorconfig it's also possible to have different configs for different files (ex: size 2 spaces for yml and size 4 spaces for .py). If there are any other special cases like that, I can write them in, but this seems to match what I see so far. 