### PR TITLE
Tweaks the multi-line heuristic to handle scheme-like text

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -841,6 +841,7 @@ class CommandDispatcher:
             bg: Open in a background tab.
             window: Open in new window.
         """
+        force_search = False
         if sel and utils.supports_selection():
             target = "Primary selection"
         else:
@@ -852,15 +853,16 @@ class CommandDispatcher:
         log.misc.debug("{} contained: {!r}".format(target, text))
         text_urls = [u for u in text.split('\n') if u.strip()]
         if (len(text_urls) > 1 and not urlutils.is_url(text_urls[0]) and
-                urlutils.get_path_if_valid(text_urls[0],
-                                           check_exists=True) is None):
+            urlutils.get_path_if_valid(
+                text_urls[0], check_exists=True) is None):
+            force_search = True
             text_urls = [text]
         for i, text_url in enumerate(text_urls):
             if not window and i > 0:
                 tab = False
                 bg = True
             try:
-                url = urlutils.fuzzy_url(text_url)
+                url = urlutils.fuzzy_url(text_url, force_search=force_search)
             except urlutils.InvalidUrlError as e:
                 raise cmdexc.CommandError(e)
             self._open(url, tab, bg, window)

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -168,7 +168,7 @@ def fuzzy_url(urlstr, cwd=None, relative=False, do_search=True,
         relative: Whether to resolve relative files.
         do_search: Whether to perform a search on non-URLs.
         force_search: Whether to force a search even if the content can be
-                      interpreted as an URL.
+                      interpreted as an URL or a path.
 
     Return:
         A target QUrl to a search page or the original URL.
@@ -177,7 +177,7 @@ def fuzzy_url(urlstr, cwd=None, relative=False, do_search=True,
     path = get_path_if_valid(urlstr, cwd=cwd, relative=relative,
                              check_exists=True)
 
-    if path is not None:
+    if not force_search and path is not None:
         url = QUrl.fromLocalFile(path)
     elif force_search or (do_search and not is_url(urlstr)):
         # probably a search term

--- a/tests/integration/features/yankpaste.feature
+++ b/tests/integration/features/yankpaste.feature
@@ -152,7 +152,8 @@ Feature: Yanking and pasting.
             - data/hello.txt?q=this%20url%3A%0Ahttp%3A//qutebrowser.org%0Ashould%20not%20open (active)
 
     Scenario: Pasting multiline whose first line looks like an URI
-        Given I have a fresh instance
+        Given I open about:blank
+        When I run :tab-only
         When I set searchengines -> DEFAULT to http://localhost:(port)/data/hello.txt?q={}
         And I put the following lines into the clipboard:
             text:

--- a/tests/integration/features/yankpaste.feature
+++ b/tests/integration/features/yankpaste.feature
@@ -151,6 +151,19 @@ Feature: Yanking and pasting.
             - about:blank
             - data/hello.txt?q=this%20url%3A%0Ahttp%3A//qutebrowser.org%0Ashould%20not%20open (active)
 
+    Scenario: Pasting multiline whose first line looks like an URI
+        Given I have a fresh instance
+        When I set searchengines -> DEFAULT to http://localhost:(port)/data/hello.txt?q={}
+        And I put the following lines into the clipboard:
+            text:
+            should open
+            as search
+        And I run :paste -t
+        And I wait until data/hello.txt?q=text%3A%0Ashould%20open%0Aas%20search is loaded
+        Then the following tabs should be open:
+            - about:blank
+            - data/hello.txt?q=text%3A%0Ashould%20open%0Aas%20search (active)
+
     Scenario: Pasting multiple urls in a background tab
         Given I open about:blank
         When I run :tab-only

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -247,7 +247,7 @@ class TestFuzzyUrl:
         """Test the force search option"""
         get_search_url_mock.return_value = QUrl('search_url')
 
-        url = urlutils.fuzzy_url(urlstring, force_search = True)
+        url = urlutils.fuzzy_url(urlstring, force_search=True)
 
         assert url == QUrl('search_url')
 

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -312,6 +312,7 @@ def test_get_search_url_invalid(urlutils_config_stub, url):
     (True, True, False, 'qute::foo'),
     # Invalid URLs
     (False, False, False, ''),
+    (False, True, False, 'onlyscheme:'),
     (False, True, False, 'http:foo:0'),
     # Not URLs
     (False, True, False, 'foo bar'),  # no DNS because of space

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -238,6 +238,19 @@ class TestFuzzyUrl:
         with pytest.raises(urlutils.InvalidUrlError):
             urlutils.fuzzy_url(url, do_search=True)
 
+    @pytest.mark.parametrize('urlstring', [
+        'http://www.qutebrowser.org/',
+        '/foo',
+        'test'
+    ])
+    def test_force_search(self, urlstring, get_search_url_mock):
+        """Test the force search option"""
+        get_search_url_mock.return_value = QUrl('search_url')
+
+        url = urlutils.fuzzy_url(urlstring, force_search = True)
+
+        assert url == QUrl('search_url')
+
     @pytest.mark.parametrize('path, check_exists', [
         ('/foo', False),
         ('/bar', True),

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -244,7 +244,7 @@ class TestFuzzyUrl:
         'test'
     ])
     def test_force_search(self, urlstring, get_search_url_mock):
-        """Test the force search option"""
+        """Test the force search option."""
         get_search_url_mock.return_value = QUrl('search_url')
 
         url = urlutils.fuzzy_url(urlstring, force_search=True)


### PR DESCRIPTION
Adds some options to implement a way to treat multiline text that starts
with a scheme-like line as text instead as an URL.