### PR TITLE
Make tab-focus count from end with negative index

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -719,7 +719,7 @@ Select the tab given as argument/[count].
 If neither count nor index are given, it behaves like tab-next.
 
 ==== positional arguments
-* +'index'+: The tab index to focus, starting with 1. The special value `last` focuses the last focused tab.
+* +'index'+: The tab index to focus, starting with 1. Negative values counts from the end, such that -1 will focus the last tab. The special value `last` focuses the last focused tab.
 
 
 ==== count

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -900,7 +900,8 @@ class CommandDispatcher:
 
         Args:
             index: The tab index to focus, starting with 1. The special value
-                   `last` focuses the last focused tab.
+                   `last` focuses the last focused tab. Negative indexes
+                   counts from the end, such that -1 is the last tab.
             count: The tab index to focus, starting with 1.
         """
         if index == 'last':
@@ -909,6 +910,8 @@ class CommandDispatcher:
         if index is None and count is None:
             self.tab_next()
             return
+        if index is not None and index < 0:
+            index = self._count() + index + 1
         try:
             idx = cmdutils.arg_or_count(index, count, default=1,
                                         countzero=self._count())

--- a/tests/integration/features/tabs.feature
+++ b/tests/integration/features/tabs.feature
@@ -228,6 +228,34 @@ Feature: Tab management
             - data/numbers/2.txt
             - data/numbers/3.txt
 
+    Scenario: :tab-focus with -1
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I open data/numbers/3.txt in a new tab
+        And I run :tab-focus 1
+        And I run :tab-focus -1
+        Then the following tabs should be open:
+            - data/numbers/1.txt
+            - data/numbers/2.txt
+            - data/numbers/3.txt (active)
+
+    Scenario: :tab-focus negative index
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I open data/numbers/3.txt in a new tab
+        And I run :tab-focus -2
+        Then the following tabs should be open:
+            - data/numbers/1.txt
+            - data/numbers/2.txt (active)
+            - data/numbers/3.txt
+
+    Scenario: :tab-focus with invalid negative index
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I open data/numbers/3.txt in a new tab
+        And I run :tab-focus -5
+        Then the error "There's no tab with index -1!" should be shown
+
     Scenario: :tab-focus last with no last focused tab
         Given I have a fresh instance
         And I run :tab-focus last


### PR DESCRIPTION
This makes it possible to jump to the very last tab, as opposed to the
last focused tab, by using -1 as the index. Generally negative indexes
are counted from the end.

Solves issue #1166 
