### PR TITLE
Make update_3rdparty.py install correctly when run from any directory

### DIFF
--- a/scripts/dev/update_3rdparty.py
+++ b/scripts/dev/update_3rdparty.py
@@ -26,6 +26,7 @@ import urllib.error
 import shutil
 import json
 import os
+import sys
 
 
 def get_latest_pdfjs_url():
@@ -65,6 +66,7 @@ def update_pdfjs(target_version=None):
         url = ('https://github.com/mozilla/pdf.js/releases/download/'
                'v{0}/pdfjs-{0}-dist.zip').format(target_version)
 
+    os.chdir(os.path.join(os.path.dirname(sys.argv[0]), '..', '..'))
     target_path = os.path.join('qutebrowser', '3rdparty', 'pdfjs')
     print("=> Downloading pdf.js {}".format(version))
     try:


### PR DESCRIPTION
If update_3rdparty.py isn't run in the right directory pdf.js isn't downloaded into the right directory. With this change the script chdirs to the expected directory before downloading.