### PR TITLE
Open command line urls explicitly.

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -282,7 +282,8 @@ def process_pos_args(args, via_ipc=False, cwd=None, target_arg=None):
                               "{}".format(cmd, e))
             else:
                 background = open_target in ('tab-bg', 'tab-bg-silent')
-                tabbed_browser.tabopen(url, background=background)
+                tabbed_browser.tabopen(url, background=background,
+                                       explicit=True)
 
 
 def _open_startpage(win_id=None):


### PR DESCRIPTION
When a url is opened from the command line, it should probably be opened explicitly. This should address the first part of issue #1272. Maybe this should depend on the value of open_target, though?