### PR TITLE
Hints positioning

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -351,7 +351,7 @@ class HintManager(QObject):
             ('display', 'inline !important'),
             ('z-index', '{} !important'.format(int(2 ** 32 / 2 - 1))),
             ('pointer-events', 'none !important'),
-            ('position', 'absolute !important'),
+            ('position', 'fixed !important'),
             ('color', config.get('colors', 'hints.fg') + ' !important'),
             ('background', config.get('colors', 'hints.bg') + ' !important'),
             ('font', config.get('fonts', 'hints') + ' !important'),
@@ -377,15 +377,11 @@ class HintManager(QObject):
             elem: The QWebElement to set the style attributes for.
             label: The label QWebElement.
         """
-        rect = elem.geometry()
+        rect = self._get_first_rectangle(elem)
         left = rect.x()
         top = rect.y()
-        zoom = elem.webFrame().zoomFactor()
-        if not config.get('ui', 'zoom-text-only'):
-            left /= zoom
-            top /= zoom
-        log.hints.vdebug("Drawing label '{!r}' at {}/{} for element '{!r}', "
-                         "zoom level {}".format(label, left, top, elem, zoom))
+        log.hints.vdebug("Drawing label '{!r}' at {}/{} for element '{!r}'"
+                         .format(label, left, top, elem))
         label.setStyleProperty('left', '{}px !important'.format(left))
         label.setStyleProperty('top', '{}px !important'.format(top))
 
@@ -438,7 +434,7 @@ class HintManager(QObject):
             elem: The QWebElement of interest.
         """
         rects = elem.evaluateJavaScript("this.getClientRects()")
-        log.hints.debug("Client rectangles of element '{}': {}"
+        log.hints.vdebug("Client rectangles of element '{}': {}"
                 .format(elem.debug_text(), rects))
         for i in range(int(rects.get("length", 0))):
             rect = rects[str(i)]

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -482,11 +482,15 @@ class HintManager(QObject):
         else:
             target_mapping[Target.tab] = usertypes.ClickTarget.tab
 
-        # FIXME Instead of clicking the center, we could have nicer heuristics.
-        # e.g. parse (-webkit-)border-radius correctly and click text fields at
-        # the bottom right, and everything else on the top left or so.
-        # https://github.com/The-Compiler/qutebrowser/issues/70
+        # Click the center of the largest square fitting into the top/left
+        # corner of the rectangle, this will help if part of the <a> element
+        # is hidden behind other elements
+        # https://github.com/The-Compiler/qutebrowser/issues/1005
         rect = self._get_first_rectangle(elem)
+        if rect.width() > rect.height():
+            rect.setWidth(rect.height())
+        else:
+            rect.setHeight(rect.width())
         pos = rect.center()
 
         action = "Hovering" if context.target == Target.hover else "Clicking"

--- a/tests/integration/features/hints.feature
+++ b/tests/integration/features/hints.feature
@@ -63,8 +63,6 @@ Feature: Using hints
 
     Scenario: Using :follow-hint inside an iframe
         When I open data/hints/iframe.html
-        And I run :hint all normal
-        And I run :follow-hint a
         And I run :hint links normal
         And I run :follow-hint a
         Then "acceptNavigationRequest, url http://localhost:*/data/hello.txt, type NavigationTypeLinkClicked, *" should be logged


### PR DESCRIPTION
Continuing #1311 and making sure that this is not lost. Only the last two commits are relevant:

- [The first](https://github.com/The-Compiler/qutebrowser/commit/ac2c5439dc963229fef50a5afb7f9a6bed1ddea4) moves the click position from the center of the element near the top-left corner, which should help if the element is overlayed with another one (see e.g. #1005).
- [The second](https://github.com/The-Compiler/qutebrowser/commit/5ce3c42d807c85b62db7a9b26ebc497281d6e59a) uses the `getClientRects()` method (introduced in #1311) also for positioning the hint label, which is visually more pleasing but also considerably slower on pages with many links, so I'm not sure if it should be used by default. It should solve at least https://github.com/The-Compiler/qutebrowser/issues/824#issuecomment-208859886.