### PR TITLE
Allow {url:pretty} variable in commands

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -974,8 +974,10 @@ class CommandDispatcher:
     def spawn(self, cmdline, userscript=False, verbose=False, detach=False):
         """Spawn a command in a shell.
 
-        Note the {url} variable which gets replaced by the current URL might be
-        useful here.
+        Note the `{url}` and `{url:pretty}` variables might be useful here.
+        `{url}` gets replaced by the URL in fully encoded format and
+        `{url:pretty}` uses a "pretty form" with most percent-encoded
+        characters decoded.
 
         Args:
             userscript: Run the command as a userscript. You can use an

--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -33,24 +33,33 @@ ParseResult = collections.namedtuple('ParseResult', ['cmd', 'args', 'cmdline',
                                                      'count'])
 
 
+def _current_url(tabbed_browser):
+    """Convenience method to get the current url."""
+    try:
+        return tabbed_browser.current_url()
+    except qtutils.QtValueError as e:
+        msg = "Current URL is invalid"
+        if e.reason:
+            msg += " ({})".format(e.reason)
+        msg += "!"
+        raise cmdexc.CommandError(msg)
+
+
 def replace_variables(win_id, arglist):
     """Utility function to replace variables like {url} in a list of args."""
     args = []
     tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                 window=win_id)
     if '{url}' in arglist:
-        try:
-            url = tabbed_browser.current_url().toString(QUrl.FullyEncoded |
-                                                        QUrl.RemovePassword)
-        except qtutils.QtValueError as e:
-            msg = "Current URL is invalid"
-            if e.reason:
-                msg += " ({})".format(e.reason)
-            msg += "!"
-            raise cmdexc.CommandError(msg)
+        url = _current_url(tabbed_browser).toString(QUrl.FullyEncoded |
+                                                    QUrl.RemovePassword)
+    if '{url:pretty}' in arglist:
+        pretty_url = _current_url(tabbed_browser).toString(QUrl.RemovePassword)
     for arg in arglist:
         if arg == '{url}':
             args.append(url)
+        elif arg == '{url:pretty}':
+            args.append(pretty_url)
         else:
             args.append(arg)
     return args

--- a/tests/integration/data/title with spaces.html
+++ b/tests/integration/data/title with spaces.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test title</title>
+    </head>
+    <body>
+        foo
+    </body>
+</html>

--- a/tests/integration/features/conftest.py
+++ b/tests/integration/features/conftest.py
@@ -275,10 +275,12 @@ def expect_message(quteproc, httpbin, category, message):
 
 @bdd.then(bdd.parsers.re(r'(?P<is_regex>regex )?"(?P<pattern>[^"]+)" should '
                          r'be logged'))
-def should_be_logged(quteproc, is_regex, pattern):
+def should_be_logged(quteproc, httpbin, is_regex, pattern):
     """Expect the given pattern on regex in the log."""
     if is_regex:
         pattern = re.compile(pattern)
+    else:
+        pattern = pattern.replace('(port)', str(httpbin.port))
     line = quteproc.wait_for(message=pattern)
     line.expected = True
 

--- a/tests/integration/features/spawn.feature
+++ b/tests/integration/features/spawn.feature
@@ -16,9 +16,20 @@ Feature: :spawn
         When I run :spawn echo {url}
         Then "Executing echo with args ['about:blank'], userscript=False" should be logged
 
+    Scenario: Running :spawn with url variable in fully encoded format
+        When I open data/title with spaces.html
+        And I run :spawn echo {url}
+        Then "Executing echo with args ['http://localhost:(port)/data/title%20with%20spaces.html'], userscript=False" should be logged
+
+    Scenario: Running :spawn with url variable in pretty decoded format
+        When I open data/title with spaces.html
+        And I run :spawn echo {url:pretty}
+        Then "Executing echo with args ['http://localhost:(port)/data/title with spaces.html'], userscript=False" should be logged
+
     @posix
     Scenario: Running :spawn with userscript
-        When I execute the userscript open_current_url
+        When I open about:blank
+        And I execute the userscript open_current_url
         And I wait until about:blank is loaded
         Then the following tabs should be open:
             - about:blank


### PR DESCRIPTION
Related to issue #1372.

I've been trying to add tests like the following but I keep getting "Error while splitting command: No closing quotation" from [here](https://github.com/The-Compiler/qutebrowser/blob/master/qutebrowser/browser/commands.py#L994). Any idea what could be wrong?

```diff
diff --git a/tests/integration/features/spawn.feature b/tests/integration/features/spawn.feature
index 03506c1..9df270e 100644
--- a/tests/integration/features/spawn.feature
+++ b/tests/integration/features/spawn.feature
@@ -16,6 +16,16 @@ Feature: :spawn
         When I run :spawn echo {url}
         Then "Executing echo with args ['about:blank'], userscript=False" should be logged

+    Scenario: Running :spawn with url variable in fully encoded format
+        When I open data/title with spaces.html
+        And I run :spawn echo {url}
+        Then "Executing echo with args ['http://localhost:(port)/data/title%20with%20spaces.html'], userscript=False" should be logged
+
+    Scenario: Running :spawn with url variable in pretty decoded format
+        When I open data/title with spaces.html
+        And I run :spawn echo {url:pretty}
+        Then "Executing echo with args ['http://localhost:(port)/data/title with spaces.html'], userscript=False" should be logged
+
     @posix
     Scenario: Running :spawn with userscript
         When I execute the userscript open_current_url
```