### PR TITLE
Don't crash when undoing twice on default page.

### DIFF
--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -305,6 +305,7 @@ class TabbedBrowser(tabwidget.TabWidget):
         """Undo removing of a tab."""
         # Remove unused tab which may be created after the last tab is closed
         last_close = config.get('tabs', 'last-close')
+        use_current_tab = False
         if last_close in ['blank', 'startpage', 'default-page']:
             only_one_tab_open = self.count() == 1
             no_history = self.widget(0).history().count() == 1
@@ -317,12 +318,17 @@ class TabbedBrowser(tabwidget.TabWidget):
             last_close_urlstr = urls[last_close].toString().rstrip('/')
             first_tab_urlstr = first_tab_url.toString().rstrip('/')
             last_close_url_used = first_tab_urlstr == last_close_urlstr
-
-            if only_one_tab_open and no_history and last_close_url_used:
-                self.removeTab(0)
+            use_current_tab = (only_one_tab_open and no_history and
+                               last_close_url_used)
 
         url, history_data = self._undo_stack.pop()
-        newtab = self.tabopen(url, background=False)
+
+        if use_current_tab:
+            self.openurl(url, newtab=False)
+            newtab = self.widget(0)
+        else:
+            newtab = self.tabopen(url, background=False)
+
         qtutils.deserialize(history_data, newtab.history())
 
     @pyqtSlot('QUrl', bool)

--- a/tests/integration/features/tabs.feature
+++ b/tests/integration/features/tabs.feature
@@ -641,9 +641,9 @@ Feature: Tab management
         And I set tabs -> last-close to default-page
         And I set general -> default-page to about:blank
         And I run :undo
+        And I run :undo
         Then the error "Nothing to undo!" should be shown
-        And the following tabs should be open:
-            - about:blank (active)
+        And the error "Nothing to undo!" should be shown
 
     # last-close
 

--- a/tests/integration/features/tabs.feature
+++ b/tests/integration/features/tabs.feature
@@ -635,6 +635,16 @@ Feature: Tab management
         Then the following tabs should be open:
             - data/hello.txt (active)
 
+    Scenario: Double-undo with single tab on last-close default page
+        Given I have a fresh instance
+        When I open about:blank
+        And I set tabs -> last-close to default-page
+        And I set general -> default-page to about:blank
+        And I run :undo
+        Then the error "Nothing to undo!" should be shown
+        And the following tabs should be open:
+            - about:blank (active)
+
     # last-close
 
     Scenario: last-close = blank


### PR DESCRIPTION
Avoid a crash when undoing twice on the default page with last-close set to
default-page.
This was caused by logic to reuse the current tab if it is on the default page
and has no history. The fix is using openurl rather than removeTab/tabopen.

Resolves #1423 