### PR TITLE
Handle counts for special keys.

### DIFF
--- a/qutebrowser/keyinput/basekeyparser.py
+++ b/qutebrowser/keyinput/basekeyparser.py
@@ -127,7 +127,9 @@ class BaseKeyParser(QObject):
         except KeyError:
             self._debug_log("No binding found for {}.".format(binding))
             return False
-        self.execute(cmdstr, self.Type.special)
+        count, _ = self._split_count()
+        self.execute(cmdstr, self.Type.special, count)
+        self.clear_keystring()
         return True
 
     def _split_count(self):

--- a/tests/unit/keyinput/test_basekeyparser.py
+++ b/tests/unit/keyinput/test_basekeyparser.py
@@ -183,7 +183,17 @@ class TestSpecialKeys:
         keyparser.handle(fake_keyevent_factory(Qt.Key_A, modifier))
         keyparser.handle(fake_keyevent_factory(Qt.Key_X, modifier))
         keyparser.execute.assert_called_once_with(
-            'ctrla', keyparser.Type.special)
+            'ctrla', keyparser.Type.special, None)
+
+    def test_valid_key_count(self, fake_keyevent_factory, keyparser):
+        if sys.platform == 'darwin':
+            modifier = Qt.MetaModifier
+        else:
+            modifier = Qt.ControlModifier
+        keyparser.handle(fake_keyevent_factory(5, text='5'))
+        keyparser.handle(fake_keyevent_factory(Qt.Key_A, modifier, text='A'))
+        keyparser.execute.assert_called_once_with(
+            'ctrla', keyparser.Type.special, 5)
 
     def test_invalid_key(self, fake_keyevent_factory, keyparser):
         keyparser.handle(fake_keyevent_factory(
@@ -217,7 +227,7 @@ class TestKeyChain:
         keyparser.handle(fake_keyevent_factory(Qt.Key_A, modifier))
         keyparser.handle(fake_keyevent_factory(Qt.Key_X, modifier))
         keyparser.execute.assert_called_once_with(
-            'ctrla', keyparser.Type.special)
+            'ctrla', keyparser.Type.special, None)
         assert keyparser._keystring == ''
 
     def test_invalid_special_key(self, fake_keyevent_factory, keyparser):


### PR DESCRIPTION
Now `3<ctrl-o>` will execute whatever `<ctrl-o>` is mapped to with count=3.

Resolves #57 