### PR TITLE
Completion model for :bind.

### DIFF
--- a/qutebrowser/commands/command.py
+++ b/qutebrowser/commands/command.py
@@ -503,3 +503,12 @@ class Command:
         log.commands.debug('Calling {}'.format(
             debug_utils.format_call(self.handler, posargs, kwargs)))
         self.handler(*posargs, **kwargs)
+
+    def supports_mode(self, mode):
+        """Return True if the command can execute in the given mode.
+
+        Args:
+            mode: KeyMode enum member to check support for.
+        """
+        return ((self._modes is None or mode in self._modes) and
+                (self._not_modes is None or mode not in self._not_modes))

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -254,3 +254,27 @@ class TabCompletionModel(base.BaseCompletionModel):
         tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                     window=int(win_id))
         tabbed_browser.on_tab_close_requested(int(tab_index) - 1)
+
+
+class KeybindingCompletionModel(base.BaseCompletionModel):
+
+    """A CompletionModel that shows the existing command bound to a key."""
+
+    # https://github.com/The-Compiler/qutebrowser/issues/545
+    # pylint: disable=abstract-method
+
+    def __init__(self, cmdlist, cmd=None, parent=None):
+        """Set up binding completions for a particular key across all modes.
+
+        Args:
+            cmd: The name of the command bound to this key, None if no binding.
+            cmdlist: A list all possible commands.
+        """
+        super().__init__(parent)
+        if cmd is not None:
+            cat = self.new_category("Current", sort=0)
+            self.new_item(cat, cmd)
+
+        cat = self.new_category("Commands", sort=1)
+        for cmd in cmdlist:
+            self.new_item(cat, cmd.name, cmd.desc)

--- a/qutebrowser/config/parsers/keyconf.py
+++ b/qutebrowser/config/parsers/keyconf.py
@@ -27,7 +27,7 @@ from PyQt5.QtCore import pyqtSignal, QObject
 
 from qutebrowser.config import configdata, textwrapper
 from qutebrowser.commands import cmdutils, cmdexc
-from qutebrowser.utils import log, utils, qtutils
+from qutebrowser.utils import log, utils, qtutils, usertypes
 
 
 class KeyConfigError(Exception):
@@ -150,7 +150,9 @@ class KeyConfigParser(QObject):
             data = str(self)
             f.write(data)
 
-    @cmdutils.register(instance='key-config', maxsplit=1, no_cmd_split=True)
+    @cmdutils.register(instance='key-config', maxsplit=1, no_cmd_split=True,
+                       completion=[usertypes.Completion.empty,
+                                   usertypes.Completion.keybinding])
     def bind(self, key, command, *, mode=None, force=False):
         """Bind a key to a command.
 

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -238,7 +238,8 @@ KeyMode = enum('KeyMode', ['normal', 'hint', 'command', 'yesno', 'prompt',
 # Available command completions
 Completion = enum('Completion', ['command', 'section', 'option', 'value',
                                  'helptopic', 'quickmark_by_name',
-                                 'bookmark_by_url', 'url', 'tab', 'sessions'])
+                                 'bookmark_by_url', 'url', 'tab', 'sessions',
+                                 'keybinding', 'empty'])
 
 
 # Exit statuses for errors. Needs to be an int for sys.exit.

--- a/tests/unit/completion/test_column_widths.py
+++ b/tests/unit/completion/test_column_widths.py
@@ -27,7 +27,7 @@ from qutebrowser.completion.models.configmodel import (
     SettingValueCompletionModel)
 from qutebrowser.completion.models.miscmodels import (
     CommandCompletionModel, HelpCompletionModel, QuickmarkCompletionModel,
-    BookmarkCompletionModel, SessionCompletionModel)
+    BookmarkCompletionModel, SessionCompletionModel, KeybindingCompletionModel)
 from qutebrowser.completion.models.urlmodel import UrlCompletionModel
 
 
@@ -40,7 +40,7 @@ class TestColumnWidths:
                SettingValueCompletionModel, CommandCompletionModel,
                HelpCompletionModel, QuickmarkCompletionModel,
                BookmarkCompletionModel, SessionCompletionModel,
-               UrlCompletionModel]
+               UrlCompletionModel, KeybindingCompletionModel]
 
     @pytest.mark.parametrize("model", CLASSES)
     def test_list_size(self, model):


### PR DESCRIPTION
`:bind --mode=mode <key>` will show a completion suggestion for every
command valid in the given mode. The first suggestion will be the key's
current binding in that mode. If `--mode` is ommitted, 'normal' mode is
assumed.

![normal](https://cloud.githubusercontent.com/assets/2496231/14767468/af3f8a38-09f3-11e6-9695-427ddcc26af4.png)

![caret](https://cloud.githubusercontent.com/assets/2496231/14767470/b1d3ef3c-09f3-11e6-8afc-a255d25a12a3.png)
