### PR TITLE
cache: fix crash when cache_dir is None

### DIFF
--- a/qutebrowser/browser/cache.py
+++ b/qutebrowser/browser/cache.py
@@ -32,16 +32,23 @@ class DiskCache(QNetworkDiskCache):
 
     """Disk cache which sets correct cache dir and size.
 
+    If the cache is deactivated via the command line argument --cachedir="",
+    both attributes _cache_dir and _http_cache_dir are set to None.
+
     Attributes:
         _activated: Whether the cache should be used.
-        _cache_dir: The base directory for cache files (standarddir.cache())
-        _http_cache_dir: the HTTP subfolder in _cache_dir.
+        _cache_dir: The base directory for cache files (standarddir.cache()) or
+                    None.
+        _http_cache_dir: the HTTP subfolder in _cache_dir or None.
     """
 
     def __init__(self, cache_dir, parent=None):
         super().__init__(parent)
         self._cache_dir = cache_dir
-        self._http_cache_dir = os.path.join(cache_dir, 'http')
+        if cache_dir is None:
+            self._http_cache_dir = None
+        else:
+            self._http_cache_dir = os.path.join(cache_dir, 'http')
         self._maybe_activate()
         objreg.get('config').changed.connect(self.on_config_changed)
 

--- a/tests/integration/test_invocations.py
+++ b/tests/integration/test_invocations.py
@@ -54,6 +54,37 @@ def test_no_config(tmpdir, quteproc_new):
 
 
 @pytest.mark.linux
+def test_no_cache(tmpdir, quteproc_new):
+    """Test starting with --cachedir="".
+
+    We can't run --basedir or --temp-basedir to reproduce this, so we mess with
+    XDG_*_DIR to get things relocated.
+    """
+    data_dir = tmpdir / 'data'
+    config_dir = tmpdir / 'config'
+    runtime_dir = tmpdir / 'runtime'
+    cache_dir = tmpdir / 'cache'
+
+    runtime_dir.ensure(dir=True)
+    runtime_dir.chmod(0o700)
+
+    (data_dir / 'qutebrowser' / 'state').write_text(
+        '[general]\nquickstart-done = 1', encoding='utf-8', ensure=True)
+
+    env = {
+        'XDG_DATA_HOME': str(data_dir),
+        'XDG_CONFIG_HOME': str(config_dir),
+        'XDG_RUNTIME_DIR': str(runtime_dir),
+        'XDG_CACHE_HOME': str(cache_dir),
+    }
+
+    args = ['--debug', '--no-err-windows', '--cachedir=""', 'about:blank']
+    quteproc_new.start(args, env=env)
+    quteproc_new.send_cmd(':quit')
+    quteproc_new.wait_for_quit()
+
+
+@pytest.mark.linux
 def test_ascii_locale(httpbin, tmpdir, quteproc_new):
     """Test downloads with LC_ALL=C set.
 

--- a/tests/integration/test_invocations.py
+++ b/tests/integration/test_invocations.py
@@ -61,7 +61,7 @@ def test_no_config(temp_basedir_env, quteproc_new):
 @pytest.mark.linux
 def test_no_cache(temp_basedir_env, quteproc_new):
     """Test starting with --cachedir=""."""
-    args = ['--debug', '--no-err-windows', '--cachedir=""', 'about:blank']
+    args = ['--debug', '--no-err-windows', '--cachedir=', 'about:blank']
     quteproc_new.start(args, env=temp_basedir_env)
     quteproc_new.send_cmd(':quit')
     quteproc_new.wait_for_quit()

--- a/tests/integration/test_invocations.py
+++ b/tests/integration/test_invocations.py
@@ -22,11 +22,11 @@
 import pytest
 
 
-@pytest.mark.linux
-def test_no_config(tmpdir, quteproc_new):
-    """Test starting with -c "".
+@pytest.fixture
+def temp_basedir_env(tmpdir):
+    """Return a dict of environment variables that fakes --temp-basedir.
 
-    We can't run --basedir or --temp-basedir to reproduce this, so we mess with
+    We can't run --basedir or --temp-basedir for some tests, so we mess with
     XDG_*_DIR to get things relocated.
     """
     data_dir = tmpdir / 'data'
@@ -46,40 +46,23 @@ def test_no_config(tmpdir, quteproc_new):
         'XDG_RUNTIME_DIR': str(runtime_dir),
         'XDG_CACHE_HOME': str(cache_dir),
     }
+    return env
 
+
+@pytest.mark.linux
+def test_no_config(temp_basedir_env, quteproc_new):
+    """Test starting with -c ""."""
     args = ['--debug', '--no-err-windows', '-c', '', 'about:blank']
-    quteproc_new.start(args, env=env)
+    quteproc_new.start(args, env=temp_basedir_env)
     quteproc_new.send_cmd(':quit')
     quteproc_new.wait_for_quit()
 
 
 @pytest.mark.linux
-def test_no_cache(tmpdir, quteproc_new):
-    """Test starting with --cachedir="".
-
-    We can't run --basedir or --temp-basedir to reproduce this, so we mess with
-    XDG_*_DIR to get things relocated.
-    """
-    data_dir = tmpdir / 'data'
-    config_dir = tmpdir / 'config'
-    runtime_dir = tmpdir / 'runtime'
-    cache_dir = tmpdir / 'cache'
-
-    runtime_dir.ensure(dir=True)
-    runtime_dir.chmod(0o700)
-
-    (data_dir / 'qutebrowser' / 'state').write_text(
-        '[general]\nquickstart-done = 1', encoding='utf-8', ensure=True)
-
-    env = {
-        'XDG_DATA_HOME': str(data_dir),
-        'XDG_CONFIG_HOME': str(config_dir),
-        'XDG_RUNTIME_DIR': str(runtime_dir),
-        'XDG_CACHE_HOME': str(cache_dir),
-    }
-
+def test_no_cache(temp_basedir_env, quteproc_new):
+    """Test starting with --cachedir=""."""
     args = ['--debug', '--no-err-windows', '--cachedir=""', 'about:blank']
-    quteproc_new.start(args, env=env)
+    quteproc_new.start(args, env=temp_basedir_env)
     quteproc_new.send_cmd(':quit')
     quteproc_new.wait_for_quit()
 

--- a/tests/unit/browser/test_cache.py
+++ b/tests/unit/browser/test_cache.py
@@ -113,6 +113,16 @@ def test_cache_size_deactivated(config_stub, tmpdir):
     assert disk_cache.cacheSize() == 0
 
 
+def test_cache_no_cache_dir(config_stub):
+    """Confirm that the cache is deactivated when cache_dir is None."""
+    config_stub.data = {
+        'storage': {'cache-size': 1024},
+        'general': {'private-browsing': False},
+    }
+    disk_cache = cache.DiskCache(None)
+    assert disk_cache.cacheSize() == 0
+
+
 def test_cache_existing_metadata_file(config_stub, tmpdir):
     """Test querying existing meta data file from activated cache."""
     config_stub.data = {


### PR DESCRIPTION
Issue #1412

When passing `--cachedir=""` on the command line, `standarddir.cache()`
returns `None`, which stands for "deactivate cache" and has to be
properly handled in `DiskCache.__init__()` (i.e. don't pass it to
`os.path.join`)