### PR TITLE
Allow flexible whitespace in color strings.

### DIFF
--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -742,11 +742,13 @@ class QssColor(CssColor):
         color_func_regexes: Valid function regexes.
     """
 
+    num = r'[0-9]{1,3}%?'
+
     color_func_regexes = [
-        r'rgb\([0-9]{1,3}%?, [0-9]{1,3}%?, [0-9]{1,3}%?\)',
-        r'rgba\([0-9]{1,3}%?, [0-9]{1,3}%?, [0-9]{1,3}%?, [0-9]{1,3}%?\)',
-        r'hsv\([0-9]{1,3}%?, [0-9]{1,3}%?, [0-9]{1,3}%?\)',
-        r'hsva\([0-9]{1,3}%?, [0-9]{1,3}%?, [0-9]{1,3}%?, [0-9]{1,3}%?\)',
+        r'rgb\({},\s*{},\s*{}\)'.format(num, num, num),
+        r'rgba\({},\s*{},\s*{},\s*{}\)'.format(num, num, num, num),
+        r'hsv\({},\s*{},\s*{}\)'.format(num, num, num),
+        r'hsva\({},\s*{},\s*{},\s*{}\)'.format(num, num, num, num),
         r'qlineargradient\(.*\)',
         r'qradialgradient\(.*\)',
         r'qconicalgradient\(.*\)',

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -913,12 +913,15 @@ class ColorTests:
         ('foo(1, 2, 3)', []),
 
         ('rgb(0, 0, 0)', [configtypes.QssColor]),
+        ('rgb(0,0,0)', [configtypes.QssColor]),
         ('-foobar(42)', [configtypes.CssColor]),
 
         ('rgba(255, 255, 255, 255)', [configtypes.QssColor]),
+        ('rgba(255,255,255,255)', [configtypes.QssColor]),
         ('hsv(359, 255, 255)', [configtypes.QssColor]),
         ('hsva(359, 255, 255, 255)', [configtypes.QssColor]),
         ('hsv(10%, 10%, 10%)', [configtypes.QssColor]),
+        ('hsv(10%,10%,10%)', [configtypes.QssColor]),
         ('qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 white, '
          'stop: 0.4 gray, stop:1 green)', [configtypes.QssColor]),
         ('qconicalgradient(cx:0.5, cy:0.5, angle:30, stop:0 white, '


### PR DESCRIPTION
Allow a variable amount of whitespace for rgb, rgba, hsv, and hsva
strings in the config.
Previously only 'rgb(0, 0, 0)' was allowed. Now things like
'rgb(0,0,0)' are permitted.
The repeated 3-digit segments of the regexes were separated out to
reduce repetition and line length.