### PR TITLE
Fix downloading a page with SSL errors (#1413)

### DIFF
--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -412,6 +412,8 @@ class DownloadItem(QObject):
         self.reply = None
         self.done = True
         self.data_changed.emit()
+        if self.fileobj is not None:
+            self.fileobj.close()
 
     def init_reply(self, reply):
         """Set a new reply and connect its signals.

--- a/qutebrowser/browser/network/networkmanager.py
+++ b/qutebrowser/browser/network/networkmanager.py
@@ -226,9 +226,13 @@ class NetworkManager(QNetworkAccessManager):
         self.shutting_down.connect(q.abort)
         if owner is not None:
             owner.destroyed.connect(q.abort)
-        webview = objreg.get('webview', scope='tab', window=self._win_id,
-                             tab=self._tab_id)
-        webview.loadStarted.connect(q.abort)
+
+        # This might be a generic network manager, e.g. one belonging to a
+        # DownloadManager. In this case, just skip the webview thing.
+        if self._tab_id is not None:
+            webview = objreg.get('webview', scope='tab', window=self._win_id,
+                                 tab=self._tab_id)
+            webview.loadStarted.connect(q.abort)
         bridge = objreg.get('message-bridge', scope='window',
                             window=self._win_id)
         bridge.ask(q, blocking=True)

--- a/tests/integration/features/downloads.feature
+++ b/tests/integration/features/downloads.feature
@@ -44,6 +44,14 @@ Feature: Downloading things from a website.
         And I run :leave-mode
         Then no crash should happen
 
+    Scenario: Downloading with SSL errors (issue 1413)
+        When I run :debug-clear-ssl-errors
+        And I set network -> ssl-strict to ask
+        And I download a SSL page
+        And I wait for "Entering mode KeyMode.* (reason: question asked)" in the log
+        And I run :prompt-accept
+        Then the error "Download error: SSL handshake failed" should be shown
+
     Scenario: Retrying a failed download
         When I run :download http://localhost:(port)/does-not-exist
         And I wait for the error "Download error: * - server replied: NOT FOUND"
@@ -162,7 +170,7 @@ Feature: Downloading things from a website.
         When I run :download http://localhost:(port)/drip?numbytes=128&duration=5
         And I run :download-open with count 1
         Then the error "Download 1 is not done!" should be shown
-        
+
     ## completion -> download-path-suggestion
 
     Scenario: completion -> download-path-suggestion = path

--- a/tests/integration/features/test_downloads.py
+++ b/tests/integration/features/test_downloads.py
@@ -41,6 +41,12 @@ def wait_for_download_finished(quteproc):
     quteproc.wait_for(category='downloads', message='Download finished')
 
 
+@bdd.when("I download a SSL page")
+def download_ssl_page(quteproc, ssl_server):
+    quteproc.send_cmd(':download https://localhost:{}/'
+                      .format(ssl_server.port))
+
+
 @bdd.then(bdd.parsers.parse("The downloaded file {filename} should not exist"))
 def download_should_not_exist(filename, tmpdir):
     path = tmpdir / filename


### PR DESCRIPTION
Issue #1413

This happens when the networkmanager is used by something that has no
tab_id, like the generic DownloadManager. In this case, we should just
skip the webview connection (as it makes no sense) instead of crashing
(which is the last thing we want to do).

**The test is still flaky (it somehow produces a unclosed resource warning), I will need to look into this some more** - but the main test works.