### PR TITLE
link_pyqt: fix crash with spaces in pypath

### DIFF
--- a/scripts/link_pyqt.py
+++ b/scripts/link_pyqt.py
@@ -191,7 +191,7 @@ def get_tox_syspython(tox_path):
     path = os.path.join(tox_path, '.tox-config1')
     with open(path, encoding='ascii') as f:
         line = f.readline()
-    _md5, sys_python = line.rstrip().split(' ')
+    _md5, sys_python = line.rstrip().split(' ', 1)
     return sys_python
 
 


### PR DESCRIPTION
This fixes a bug where `link_pyqt` crashes when the path to the python
interpreter contains a space.