### PR TITLE
fix confirm-quit=downloads with finished downloads

### DIFF
--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -897,8 +897,8 @@ class DownloadManager(QAbstractListModel):
         download.redirected.connect(
             functools.partial(self.on_redirect, download))
         download.basename = suggested_filename
-        idx = len(self.downloads) + 1
-        download.index = idx
+        idx = len(self.downloads)
+        download.index = idx + 1  # "Human readable" index
         self.beginInsertRows(QModelIndex(), idx, idx)
         self.downloads.append(download)
         self.endInsertRows()

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -1238,3 +1238,11 @@ class DownloadManager(QAbstractListModel):
             # We don't have children
             return 0
         return len(self.downloads)
+
+    def running_downloads(self):
+        """Return the amount of still running downloads.
+
+        Return:
+            The number of unfinished downloads.
+        """
+        return len([1 for download in self.downloads if not download.done])

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -1245,4 +1245,4 @@ class DownloadManager(QAbstractListModel):
         Return:
             The number of unfinished downloads.
         """
-        return len([1 for download in self.downloads if not download.done])
+        return sum(1 for download in self.downloads if not download.done)

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -413,7 +413,7 @@ class MainWindow(QWidget):
         tab_count = self.tabbed_browser.count()
         download_manager = objreg.get('download-manager', scope='window',
                                       window=self.win_id)
-        download_count = download_manager.rowCount()
+        download_count = download_manager.running_downloads()
         quit_texts = []
         # Ask if multiple-tabs are open
         if 'multiple-tabs' in confirm_quit and tab_count > 1:


### PR DESCRIPTION
Fixes #846

`.rowCount()` returns all downloads, even the finished ones that have not
yet been removed from the list. For confirming the quit event, we should
only consider downloads that are still running.