### PR TITLE
Show keychain completions

### DIFF
--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -1205,7 +1205,7 @@ def data(readonly=False):
              "Text color for the keyhint widget."),
 
             ('keyhint.fg.suffix',
-             SettingValue(typ.QssColor(), '#FFFF00'),
+             SettingValue(typ.CssColor(), '#FFFF00'),
              "Highlight color for keys to complete the current keychain"),
 
             ('keyhint.bg',

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -477,7 +477,7 @@ def data(readonly=False):
              "Timeout for ambiguous key bindings."),
 
             ('partial-timeout',
-             SettingValue(typ.Int(minval=0, maxval=MAXVALS['int']), '1000'),
+             SettingValue(typ.Int(minval=0, maxval=MAXVALS['int']), '2500'),
              "Timeout for partially typed key bindings."),
 
             ('insert-mode-on-plugins',

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -355,6 +355,10 @@ def data(readonly=False):
              "Hide the window decoration when using wayland "
              "(requires restart)"),
 
+            ('show-keyhints',
+             SettingValue(typ.Bool(), 'true'),
+             "Show possible keychains based on the current keystring"),
+
             readonly=readonly
         )),
 
@@ -1196,6 +1200,18 @@ def data(readonly=False):
              "Background color for webpages if unset (or empty to use the "
              "theme's color)"),
 
+            ('keyhint.fg',
+             SettingValue(typ.QssColor(), '#FFFFFF'),
+             "Text color for the keyhint widget."),
+
+            ('keyhint.fg.suffix',
+             SettingValue(typ.QssColor(), '#FFFF00'),
+             "Highlight color for keys to complete the current keychain"),
+
+            ('keyhint.bg',
+             SettingValue(typ.QssColor(), 'rgba(0, 0, 0, 80%)'),
+             "Background color of the keyhint widget."),
+
             readonly=readonly
         )),
 
@@ -1276,6 +1292,10 @@ def data(readonly=False):
              SettingValue(
                  typ.Int(none_ok=True, minval=1, maxval=MAXVALS['int']), ''),
              "The default font size for fixed-pitch text."),
+
+            ('keyhint',
+             SettingValue(typ.Font(), DEFAULT_FONT_SIZE + ' ${_monospace}'),
+             "Font used in the keyhint widget."),
 
             readonly=readonly
         )),

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -477,7 +477,7 @@ def data(readonly=False):
              "Timeout for ambiguous key bindings."),
 
             ('partial-timeout',
-             SettingValue(typ.Int(minval=0, maxval=MAXVALS['int']), '2500'),
+             SettingValue(typ.Int(minval=0, maxval=MAXVALS['int']), '5000'),
              "Timeout for partially typed key bindings."),
 
             ('insert-mode-on-plugins',

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -294,11 +294,14 @@ class MainWindow(QWidget):
         # commands
         keyparsers[usertypes.KeyMode.normal].keystring_updated.connect(
             status.keystring.setText)
-        keyparsers[usertypes.KeyMode.normal].keystring_updated.connect(
-            self._keyhint.update_keyhint)
         cmd.got_cmd.connect(self._commandrunner.run_safely)
         cmd.returnPressed.connect(tabs.on_cmd_return_pressed)
         tabs.got_cmd.connect(self._commandrunner.run_safely)
+
+        # key hint popup
+        for mode, parser in keyparsers.items():
+            parser.keystring_updated.connect(functools.partial(
+                self._keyhint.update_keyhint, mode.name))
 
         # config
         for obj in keyparsers.values():

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -35,7 +35,7 @@ from qutebrowser.mainwindow.statusbar import bar
 from qutebrowser.completion import completionwidget
 from qutebrowser.keyinput import modeman
 from qutebrowser.browser import hints, downloads, downloadview, commands
-from qutebrowser.misc import crashsignal
+from qutebrowser.misc import crashsignal, keyhintwidget
 
 
 win_id_gen = itertools.count(0)
@@ -160,6 +160,8 @@ class MainWindow(QWidget):
 
         self._commandrunner = runners.CommandRunner(self.win_id)
 
+        self._keyhint = keyhintwidget.KeyHintView(self.win_id, self)
+
         log.init.debug("Initializing modes...")
         modeman.init(self.win_id, self)
 
@@ -178,6 +180,7 @@ class MainWindow(QWidget):
         # resizing will fail. Therefore, we use singleShot QTimers to make sure
         # we defer this until everything else is initialized.
         QTimer.singleShot(0, self._connect_resize_completion)
+        QTimer.singleShot(0, self._connect_resize_keyhint)
         objreg.get('config').changed.connect(self.on_config_changed)
 
         if config.get('ui', 'hide-mouse-cursor'):
@@ -252,6 +255,11 @@ class MainWindow(QWidget):
         self._completion.resize_completion.connect(self.resize_completion)
         self.resize_completion()
 
+    def _connect_resize_keyhint(self):
+        """Connect the reposition_keyhint signal and resize it once."""
+        self._keyhint.reposition_keyhint.connect(self.reposition_keyhint)
+        self.reposition_keyhint()
+
     def _set_default_geometry(self):
         """Set some sensible default geometry."""
         self.setGeometry(QRect(50, 50, 800, 600))
@@ -286,6 +294,8 @@ class MainWindow(QWidget):
         # commands
         keyparsers[usertypes.KeyMode.normal].keystring_updated.connect(
             status.keystring.setText)
+        keyparsers[usertypes.KeyMode.normal].keystring_updated.connect(
+            self._keyhint.update_keyhint)
         cmd.got_cmd.connect(self._commandrunner.run_safely)
         cmd.returnPressed.connect(tabs.on_cmd_return_pressed)
         tabs.got_cmd.connect(self._commandrunner.run_safely)
@@ -367,6 +377,24 @@ class MainWindow(QWidget):
         if rect.isValid():
             self._completion.setGeometry(rect)
 
+    @pyqtSlot()
+    def reposition_keyhint(self):
+        """Adjust keyhint according to config."""
+        if not self._keyhint.isVisible():
+            return
+        # Shrink the window to the shown text and place it at the bottom left
+        width = self._keyhint.width()
+        height = self._keyhint.height()
+        topleft_y = self.height() - self.status.height() - height
+        topleft_y = qtutils.check_overflow(topleft_y, 'int', fatal=False)
+        topleft = QPoint(0, topleft_y)
+        bottomright = (self.status.geometry().topLeft() +
+                       QPoint(width, 0))
+        rect = QRect(topleft, bottomright)
+        log.misc.debug('keyhint rect: {}'.format(rect))
+        if rect.isValid():
+            self._keyhint.setGeometry(rect)
+
     @cmdutils.register(instance='main-window', scope='window')
     @pyqtSlot()
     def close(self):
@@ -394,6 +422,7 @@ class MainWindow(QWidget):
         """
         super().resizeEvent(e)
         self.resize_completion()
+        self.reposition_keyhint()
         self._downloadview.updateGeometry()
         self.tabbed_browser.tabBar().refresh()
 

--- a/qutebrowser/misc/keyhintwidget.py
+++ b/qutebrowser/misc/keyhintwidget.py
@@ -104,12 +104,19 @@ class KeyHintView(QLabel):
             # for now, special keys can't be part of keychains, so ignore them
             is_special_binding = key.startswith('<') and key.endswith('>')
             if key.startswith(prefix) and not is_special_binding:
-                suffix = "<font color='{}'>{}</font>".format(suffix_color,
-                    html.escape(key[len(prefix):]))
-
-                text += '{}{} {}<br>'.format(html.escape(prefix),
-                                             suffix,
-                                             html.escape(cmd))
+                text += (
+                    "<tr>"
+                    "<td>{}</td>"
+                    "<td style='color: {}'>{}</td>"
+                    "<td style='padding-left: 2ex'>{}</td>"
+                    "</tr>"
+                ).format(
+                    html.escape(prefix),
+                    suffix_color,
+                    html.escape(key[len(prefix):]),
+                    html.escape(cmd)
+                )
+        text = '<table>{}</table>'.format(text)
 
         self.setText(text)
         self.adjustSize()

--- a/qutebrowser/misc/keyhintwidget.py
+++ b/qutebrowser/misc/keyhintwidget.py
@@ -51,7 +51,6 @@ class KeyHintView(QLabel):
             color: {{ color['keyhint.fg'] }};
             background-color: {{ color['keyhint.bg'] }};
             padding: 6px;
-            padding-bottom: -4px;
             border-top-right-radius: 6px;
         }
     """

--- a/qutebrowser/misc/keyhintwidget.py
+++ b/qutebrowser/misc/keyhintwidget.py
@@ -107,9 +107,9 @@ class KeyHintView(QLabel):
                 suffix = "<font color='{}'>{}</font>".format(suffix_color,
                     html.escape(key[len(prefix):]))
 
-                text += '{}{}\t<b>{}</b><br>'.format(html.escape(prefix),
-                                                     suffix,
-                                                     html.escape(cmd))
+                text += '{}{} {}<br>'.format(html.escape(prefix),
+                                             suffix,
+                                             html.escape(cmd))
 
         self.setText(text)
         self.adjustSize()

--- a/qutebrowser/misc/keyhintwidget.py
+++ b/qutebrowser/misc/keyhintwidget.py
@@ -1,0 +1,106 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2016 Ryan Roden-Corrent (rcorre) <ryan@rcorre.net>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Small window that pops up to show hints for possible keystrings.
+
+When a user inputs a key that forms a partial match, this shows a small window
+with each possible completion of that keystring and the corresponding command.
+It is intended to help discoverability of keybindings.
+"""
+
+from PyQt5.QtWidgets import QLabel, QSizePolicy
+from PyQt5.QtCore import pyqtSlot, pyqtSignal
+
+from qutebrowser.config import config, style
+from qutebrowser.utils import objreg, utils
+
+
+class KeyHintView(QLabel):
+
+    """The view showing hints for key bindings based on the current key string.
+
+    Attributes:
+        _win_id: Window ID of parent.
+        _enabled: If False, do not show the window at all
+        _suffix_color: Highlight for completions to the current keychain.
+
+    Signals:
+        reposition_keyhint: Emitted when this widget should be resized.
+    """
+
+    STYLESHEET = """
+        QLabel {
+            font: {{ font['keyhint'] }};
+            color: {{ color['keyhint.fg'] }};
+            background-color: {{ color['keyhint.bg'] }};
+        }
+    """
+
+    reposition_keyhint = pyqtSignal()
+
+    def __init__(self, win_id, parent=None):
+        super().__init__(parent)
+        self._win_id = win_id
+        self.set_enabled()
+        config = objreg.get('config')
+        config.changed.connect(self.set_enabled)
+        self._suffix_color = config.get('colors', 'keyhint.fg.suffix')
+        style.set_register_stylesheet(self)
+        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Minimum)
+        self.setVisible(False)
+
+    def __repr__(self):
+        return utils.get_repr(self)
+
+    @config.change_filter('ui', 'show-keyhints')
+    def set_enabled(self):
+        """Update self._enabled when the config changed."""
+        self._enabled = config.get('ui', 'show-keyhints')
+        if not self._enabled: self.setVisible(False)
+
+    def showEvent(self, e):
+        """Adjust the keyhint size when it's freshly shown."""
+        self.reposition_keyhint.emit()
+        super().showEvent(e)
+
+    @pyqtSlot(str)
+    def update_keyhint(self, prefix):
+        """Show hints for the given prefix (or hide if prefix is empty).
+
+        Args:
+            prefix: The current partial keystring.
+        """
+        if len(prefix) == 0 or not self._enabled:
+            self.setVisible(False)
+            return
+
+        self.setVisible(True)
+
+        text = ''
+        keyconf = objreg.get('key-config')
+        # this is only fired in normal mode
+        for key, cmd in keyconf.get_bindings_for('normal').items():
+            if key.startswith(prefix):
+                suffix = "<font color={}>{}</font>".format(self._suffix_color,
+                                                           key[len(prefix):])
+                text += '{}{}\t<b>{}</b><br>'.format(prefix, suffix, cmd)
+
+        self.setText(text)
+        self.adjustSize()
+        self.reposition_keyhint.emit()

--- a/qutebrowser/misc/keyhintwidget.py
+++ b/qutebrowser/misc/keyhintwidget.py
@@ -80,7 +80,7 @@ class KeyHintView(QLabel):
         super().showEvent(e)
 
     @pyqtSlot(str)
-    def update_keyhint(self, prefix):
+    def update_keyhint(self, modename, prefix):
         """Show hints for the given prefix (or hide if prefix is empty).
 
         Args:
@@ -95,7 +95,7 @@ class KeyHintView(QLabel):
         text = ''
         keyconf = objreg.get('key-config')
         # this is only fired in normal mode
-        for key, cmd in keyconf.get_bindings_for('normal').items():
+        for key, cmd in keyconf.get_bindings_for(modename).items():
             if key.startswith(prefix):
                 suffix = "<font color={}>{}</font>".format(self._suffix_color,
                                                            key[len(prefix):])

--- a/qutebrowser/misc/keyhintwidget.py
+++ b/qutebrowser/misc/keyhintwidget.py
@@ -40,7 +40,6 @@ class KeyHintView(QLabel):
     Attributes:
         _win_id: Window ID of parent.
         _enabled: If False, do not show the window at all
-        _suffix_color: Highlight for completions to the current keychain.
 
     Signals:
         reposition_keyhint: Emitted when this widget should be resized.
@@ -53,7 +52,7 @@ class KeyHintView(QLabel):
             background-color: {{ color['keyhint.bg'] }};
             padding: 6px;
             padding-bottom: -4px;
-            border-radius: 6px;
+            border-top-right-radius: 6px;
         }
     """
 
@@ -102,7 +101,9 @@ class KeyHintView(QLabel):
         keyconf = objreg.get('key-config')
         # this is only fired in normal mode
         for key, cmd in keyconf.get_bindings_for(modename).items():
-            if key.startswith(prefix):
+            # for now, special keys can't be part of keychains, so ignore them
+            is_special_binding = key.startswith('<') and key.endswith('>')
+            if key.startswith(prefix) and not is_special_binding:
                 suffix = "<font color='{}'>{}</font>".format(suffix_color,
                     html.escape(key[len(prefix):]))
 

--- a/scripts/dev/check_coverage.py
+++ b/scripts/dev/check_coverage.py
@@ -136,6 +136,8 @@ PERFECT_FILES = [
         'qutebrowser/utils/jinja.py'),
     ('tests/unit/utils/test_error.py',
         'qutebrowser/utils/error.py'),
+    ('tests/unit/utils/test_keyhints.py',
+        'qutebrowser/misc/keyhintwidget.py'),
 ]
 
 

--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -385,8 +385,14 @@ class KeyConfigStub:
 
     """Stub for the key-config object."""
 
-    def get_bindings_for(self, _section):
-        return {}
+    def __init__(self):
+        self.bindings = {}
+
+    def get_bindings_for(self, section):
+        return self.bindings.get(section)
+
+    def set_bindings_for(self, section, bindings):
+        self.bindings[section] = bindings
 
 
 class HostBlockerStub:

--- a/tests/unit/misc/test_keyhints.py
+++ b/tests/unit/misc/test_keyhints.py
@@ -1,0 +1,96 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2016 Ryan Roden-Corrent (rcorre) <ryan@rcorre.net>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test the keyhint widget."""
+
+from collections import OrderedDict
+from unittest import mock
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QApplication
+import pytest
+
+from qutebrowser.misc.keyhintwidget import KeyHintView
+
+
+class TestKeyHintView:
+    """Tests for KeyHintView widget."""
+
+    @pytest.fixture
+    def keyhint(self, qtbot, config_stub, key_config_stub):
+        """Fixture to initialize a KeyHintView."""
+        config_stub.data = {
+            'colors': {
+                'keyhint.fg': 'white',
+                'keyhint.fg.suffix': 'yellow',
+                'keyhint.bg': 'black'
+            },
+            'fonts': {'keyhint': 'Comic Sans'},
+            'ui': {'show-keyhints': True},
+        }
+        keyhint = KeyHintView(0, None)
+        #qtbot.add_widget(keyhint)
+        assert keyhint.text() == ''
+        return keyhint
+
+    def test_suggestions(self, qtbot, keyhint, key_config_stub):
+        """Test cursor position based on the prompt."""
+        # we want the dict to return sorted items() for reliable testing
+        key_config_stub.set_bindings_for('normal', OrderedDict([
+            ('aa', 'cmd-aa'),
+            ('ab', 'cmd-ab'),
+            ('aba', 'cmd-aba'),
+            ('abb', 'cmd-abb'),
+            ('xd', 'cmd-xd'),
+            ('xe', 'cmd-xe')]))
+
+        keyhint.update_keyhint('normal', 'a')
+        line = "a<font color='{}'>{}</font>\t<b>{}</b><br>"
+        assert keyhint.text() == (line.format('yellow', 'a', 'cmd-aa') +
+                                  line.format('yellow', 'b', 'cmd-ab') +
+                                  line.format('yellow', 'ba', 'cmd-aba') +
+                                  line.format('yellow', 'bb', 'cmd-abb'))
+
+    def test_special_bindings(self, qtbot, keyhint, key_config_stub):
+        """Ensure the a prefix of '<' doesn't suggest special keys"""
+        # we want the dict to return sorted items() for reliable testing
+        key_config_stub.set_bindings_for('normal', OrderedDict([
+            ('<a', 'cmd-aa'),
+            ('<b', 'cmd-ab'),
+            ('<ctrl-a>', 'cmd-aba')]))
+
+        keyhint.update_keyhint('normal', '<')
+        line = "&lt;<font color='{}'>{}</font>\t<b>{}</b><br>"
+        assert keyhint.text() == (line.format('yellow', 'a', 'cmd-aa') +
+                                  line.format('yellow', 'b', 'cmd-ab'))
+
+    def test_disable(self, qtbot, keyhint, config_stub):
+        """Ensure the a prefix of '<' doesn't suggest special keys"""
+        config_stub.set('ui', 'show-keyhints', False)
+        keyhint.update_keyhint('normal', 'a')
+        assert not keyhint.text()
+        assert not keyhint.isVisible()
+
+    def test_color_switch(self, qtbot, keyhint, config_stub, key_config_stub):
+        """Ensure the the keyhint suffix color can be updated at runtime."""
+        config_stub.set('colors', 'keyhint.fg.suffix', '#ABCDEF')
+        key_config_stub.set_bindings_for('normal', OrderedDict([
+            ('aa', 'cmd-aa')]))
+        keyhint.update_keyhint('normal', 'a')
+        expected = "a<font color='#ABCDEF'>a</font>\t<b>cmd-aa</b><br>"
+        assert keyhint.text() == expected

--- a/tests/unit/misc/test_keyhints.py
+++ b/tests/unit/misc/test_keyhints.py
@@ -60,7 +60,7 @@ class TestKeyHintView:
             ('xe', 'cmd-xe')]))
 
         keyhint.update_keyhint('normal', 'a')
-        line = "a<font color='{}'>{}</font>\t<b>{}</b><br>"
+        line = "a<font color='{}'>{}</font> {}<br>"
         assert keyhint.text() == (line.format('yellow', 'a', 'cmd-aa') +
                                   line.format('yellow', 'b', 'cmd-ab') +
                                   line.format('yellow', 'ba', 'cmd-aba') +
@@ -75,12 +75,12 @@ class TestKeyHintView:
             ('<ctrl-a>', 'cmd-aba')]))
 
         keyhint.update_keyhint('normal', '<')
-        line = "&lt;<font color='{}'>{}</font>\t<b>{}</b><br>"
+        line = "&lt;<font color='{}'>{}</font> {}<br>"
         assert keyhint.text() == (line.format('yellow', 'a', 'cmd-aa') +
                                   line.format('yellow', 'b', 'cmd-ab'))
 
     def test_disable(self, qtbot, keyhint, config_stub):
-        """Ensure the a prefix of '<' doesn't suggest special keys"""
+        """Ensure the widget isn't visible if disabled."""
         config_stub.set('ui', 'show-keyhints', False)
         keyhint.update_keyhint('normal', 'a')
         assert not keyhint.text()
@@ -92,5 +92,5 @@ class TestKeyHintView:
         key_config_stub.set_bindings_for('normal', OrderedDict([
             ('aa', 'cmd-aa')]))
         keyhint.update_keyhint('normal', 'a')
-        expected = "a<font color='#ABCDEF'>a</font>\t<b>cmd-aa</b><br>"
+        expected = "a<font color='#ABCDEF'>a</font> cmd-aa<br>"
         assert keyhint.text() == expected


### PR DESCRIPTION
Pop up a small window during a partial match to show possible keychain completions.
Resolves #209 

I remember really liking this in dwb, so I initially went dwb-style, showing completions horizontally in the status bar. However, there wasn't nearly enough room for something like `;`. I guess we just have longer command names than `dwb` did?

So instead I went with a separate semi-transparent window:

![hints](https://cloud.githubusercontent.com/assets/2496231/15268131/ab6320c8-19a2-11e6-9587-3e66e6f407e3.png)
