### PR TITLE
Decode URL in statusbar when hovering over it

### DIFF
--- a/qutebrowser/mainwindow/statusbar/url.py
+++ b/qutebrowser/mainwindow/statusbar/url.py
@@ -153,7 +153,7 @@ class UrlText(textbase.TextBase):
             _text: The text of the hovered link (string)
         """
         if link:
-            self._hover_url = QUrl(link).toString()
+            self._hover_url = QUrl(link).toDisplayString()
         else:
             self._hover_url = None
         self._update_url()

--- a/qutebrowser/mainwindow/statusbar/url.py
+++ b/qutebrowser/mainwindow/statusbar/url.py
@@ -153,7 +153,12 @@ class UrlText(textbase.TextBase):
             _text: The text of the hovered link (string)
         """
         if link:
-            self._hover_url = QUrl(link).toDisplayString()
+            # We assume that `link` is always be given in a form that generates
+            # a valid QUrl. If this proves to be wrong, we should probably
+            # check and fall back to the text version otherwise.
+            qurl = QUrl(link)
+            assert qurl.isValid(), link
+            self._hover_url = qurl.toDisplayString()
         else:
             self._hover_url = None
         self._update_url()

--- a/qutebrowser/mainwindow/statusbar/url.py
+++ b/qutebrowser/mainwindow/statusbar/url.py
@@ -19,7 +19,7 @@
 
 """URL displayed in the statusbar."""
 
-from PyQt5.QtCore import pyqtSlot, pyqtProperty, Qt
+from PyQt5.QtCore import pyqtSlot, pyqtProperty, Qt, QUrl
 
 from qutebrowser.browser import webview
 from qutebrowser.mainwindow.statusbar import textbase
@@ -153,7 +153,7 @@ class UrlText(textbase.TextBase):
             _text: The text of the hovered link (string)
         """
         if link:
-            self._hover_url = link
+            self._hover_url = QUrl(link).toString()
         else:
             self._hover_url = None
         self._update_url()

--- a/tests/unit/mainwindow/statusbar/test_url.py
+++ b/tests/unit/mainwindow/statusbar/test_url.py
@@ -76,7 +76,6 @@ def test_set_url(url_widget, url_text):
 @pytest.mark.parametrize('url_text, title, text', [
     ('http://abc123.com/this/awesome/url.html', 'Awesome site', 'click me!'),
     ('https://supersecret.gov/nsa/files.txt', 'Secret area', None),
-    ('Th1$ i$ n0t @ n0rm@L uRL! P@n1c! <-->', 'Probably spam', 'definitely'),
     (None, None, 'did I break?!')
 ])
 def test_set_hover_url(url_widget, url_text, title, text):
@@ -88,6 +87,19 @@ def test_set_hover_url(url_widget, url_text, title, text):
     else:
         assert url_widget.text() == ''
         assert url_widget._urltype == url.UrlType.normal
+
+
+@pytest.mark.parametrize('url_text, expected', [
+    ('http://test.gr/%CE%B1%CE%B2%CE%B3%CE%B4.txt', 'http://test.gr/αβγδ.txt'),
+    ('http://test.ru/%D0%B0%D0%B1%D0%B2%D0%B3.txt', 'http://test.ru/абвг.txt'),
+    ('http://test.com/s%20p%20a%20c%20e.txt', 'http://test.com/s p a c e.txt'),
+    ('http://test.com/%22quotes%22.html', 'http://test.com/%22quotes%22.html'),
+])
+def test_set_hover_url_encoded(url_widget, url_text, expected):
+    """Test text when hovering over a percent encoded link."""
+    url_widget.set_hover_url(url_text, 'title', 'text')
+    assert url_widget.text() == expected
+    assert url_widget._urltype == url.UrlType.hover
 
 
 @pytest.mark.parametrize('status, expected', [

--- a/tests/unit/mainwindow/statusbar/test_url.py
+++ b/tests/unit/mainwindow/statusbar/test_url.py
@@ -94,6 +94,7 @@ def test_set_hover_url(url_widget, url_text, title, text):
     ('http://test.ru/%D0%B0%D0%B1%D0%B2%D0%B3.txt', 'http://test.ru/абвг.txt'),
     ('http://test.com/s%20p%20a%20c%20e.txt', 'http://test.com/s p a c e.txt'),
     ('http://test.com/%22quotes%22.html', 'http://test.com/%22quotes%22.html'),
+    ('http://username:secret%20password@test.com', 'http://username@test.com')
 ])
 def test_set_hover_url_encoded(url_widget, url_text, expected):
     """Test text when hovering over a percent encoded link."""


### PR DESCRIPTION
Fixes the second part of #1483.

I used `QUrl(link).toString()` for PrettyDecoded format.  Another option was
`QUrl.fromPercentEncoding(bytearray(link.encode()))` that decodes every
possible character (e.g. `<`, `>`, `"`) but I chose the former for consistency
and making sure no ambiguous data is shown.

I also removed the `'Th1$ i$ n0t @ n0rm@L uRL! P@n1c! <-->'` test in
`test_set_hover_url` because now `<` and `>` are shown encoded and it failed.
Without these characters it would work but a decoded argument like this would
never be given to `set_hover_url` by Qt anyway.