### PR TITLE
Show currently bound keys in command completion.

### DIFF
--- a/qutebrowser/completion/models/instances.py
+++ b/qutebrowser/completion/models/instances.py
@@ -186,3 +186,7 @@ def init():
     history = objreg.get('web-history')
     history.async_read_done.connect(
         functools.partial(update, [usertypes.Completion.url]))
+
+    keyconf = objreg.get('key-config')
+    keyconf.changed.connect(
+        functools.partial(update, [usertypes.Completion.command]))

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -33,10 +33,10 @@ class CommandCompletionModel(base.BaseCompletionModel):
 
     """A CompletionModel filled with all commands and descriptions."""
 
-    COLUMN_WIDTHS = (20, 60, 20)
-
     # https://github.com/The-Compiler/qutebrowser/issues/545
     # pylint: disable=abstract-method
+
+    COLUMN_WIDTHS = (20, 60, 20)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -54,11 +54,11 @@ class CommandCompletionModel(base.BaseCompletionModel):
 
         # map each command to its bound keys and show these in the misc column
         keyconf = objreg.get('key-config')
-        cmd_to_keys = defaultdict(lambda: [])
+        cmd_to_keys = defaultdict(list)
         for key, cmd in keyconf.get_bindings_for('normal').items():
             cmd_to_keys[cmd].append(key)
         for (name, desc) in sorted(cmdlist):
-            self.new_item(cat, name, desc, str.join(',', cmd_to_keys[name]))
+            self.new_item(cat, name, desc, str.join(', ', cmd_to_keys[name]))
 
 
 class HelpCompletionModel(base.BaseCompletionModel):

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -19,6 +19,7 @@
 
 """Misc. CompletionModels."""
 
+from collections import defaultdict
 from PyQt5.QtCore import Qt, QTimer, pyqtSlot
 
 from qutebrowser.browser import webview
@@ -31,6 +32,8 @@ from qutebrowser.completion.models import base
 class CommandCompletionModel(base.BaseCompletionModel):
 
     """A CompletionModel filled with all commands and descriptions."""
+
+    COLUMN_WIDTHS = (20, 60, 20)
 
     # https://github.com/The-Compiler/qutebrowser/issues/545
     # pylint: disable=abstract-method
@@ -48,8 +51,14 @@ class CommandCompletionModel(base.BaseCompletionModel):
         for name, cmd in config.section('aliases').items():
             cmdlist.append((name, "Alias for '{}'".format(cmd)))
         cat = self.new_category("Commands")
+
+        # map each command to its bound keys and show these in the misc column
+        keyconf = objreg.get('key-config')
+        cmd_to_keys = defaultdict(lambda: [])
+        for key, cmd in keyconf.get_bindings_for('normal').items():
+            cmd_to_keys[cmd].append(key)
         for (name, desc) in sorted(cmdlist):
-            self.new_item(cat, name, desc)
+            self.new_item(cat, name, desc, str.join(',', cmd_to_keys[name]))
 
 
 class HelpCompletionModel(base.BaseCompletionModel):

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -56,7 +56,11 @@ class CommandCompletionModel(base.BaseCompletionModel):
         keyconf = objreg.get('key-config')
         cmd_to_keys = defaultdict(list)
         for key, cmd in keyconf.get_bindings_for('normal').items():
-            cmd_to_keys[cmd].append(key)
+            # put special bindings last
+            if key.startswith('<') and key.endswith('>'):
+                cmd_to_keys[cmd].append(key)
+            else:
+                cmd_to_keys[cmd].insert(0, key)
         for (name, desc) in sorted(cmdlist):
             self.new_item(cat, name, desc, str.join(', ', cmd_to_keys[name]))
 

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -62,7 +62,7 @@ class CommandCompletionModel(base.BaseCompletionModel):
             else:
                 cmd_to_keys[cmd].insert(0, key)
         for (name, desc) in sorted(cmdlist):
-            self.new_item(cat, name, desc, str.join(', ', cmd_to_keys[name]))
+            self.new_item(cat, name, desc, ', '.join(cmd_to_keys[name]))
 
 
 class HelpCompletionModel(base.BaseCompletionModel):


### PR DESCRIPTION
The command completion menu now uses the misc colum to show a
comma-separated list of normal-mode keybindings for each command.

Continuing the trend of increasing discoverability...

![pic](https://cloud.githubusercontent.com/assets/2496231/15343760/cc6a9fee-1c6d-11e6-9f0b-30ca79d2afd8.png)


Resolves #45.