### PR TITLE
fix crash on empty parts[] (#1523)

### DIFF
--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -204,6 +204,8 @@ class Completer(QObject):
         parts, cursor_part = self._filter_cmdline_parts(parts, cursor_part)
         log.completion.debug("After filtering flags: parts {}, cursor_part "
                              "{}".format(parts, cursor_part))
+        if not parts:
+            return None
         if cursor_part == 0:
             # '|' or 'set|'
             model = instances.get(usertypes.Completion.command)

--- a/tests/integration/features/misc.feature
+++ b/tests/integration/features/misc.feature
@@ -431,3 +431,9 @@ Feature: Various utility commands.
         Given I have a fresh instance
         When I run :messages
         Then the page should contain the plaintext "No messages to show."
+
+    ## https://github.com/The-Compiler/qutebrowser/issues/1523
+
+    Scenario: Completing a single option argument
+        When I run :set-cmd-text -s :-- 
+        Then no crash should happen


### PR DESCRIPTION
It doesn't crash, but it also doesn't return a completion model. Is this intended behavior? 