### PR TITLE
mhtml: don't crash when user cancels a download

### DIFF
--- a/qutebrowser/browser/mhtml.py
+++ b/qutebrowser/browser/mhtml.py
@@ -345,7 +345,7 @@ class _Downloader:
         self.pending_downloads.add((url, item))
         item.finished.connect(functools.partial(self._finished, url, item))
         item.error.connect(functools.partial(self._error, url, item))
-        item.cancelled.connect(functools.partial(self._error, url, item))
+        item.cancelled.connect(functools.partial(self._cancelled, url, item))
 
     def _finished(self, url, item):
         """Callback when a single asset is downloaded.
@@ -417,6 +417,20 @@ class _Downloader:
         if self.pending_downloads:
             return
         self._finish_file()
+
+    def _cancelled(self, url, item):
+        """Callback when a download is cancelled by the user.
+
+        Args:
+            url: The original url of the asset as QUrl.
+            item: The DownloadItem given by the DownloadManager.
+        """
+        # This callback is called before _finished, so there's no need to
+        # remove the item or close the fileobject.
+        log.downloads.debug("MHTML download cancelled by used: {}".format(url))
+        # Write an empty file instead
+        item.fileobj.seek(0)
+        item.fileobj.truncate()
 
     def _finish_file(self):
         """Save the file to the filename given in __init__."""

--- a/qutebrowser/browser/mhtml.py
+++ b/qutebrowser/browser/mhtml.py
@@ -427,7 +427,7 @@ class _Downloader:
         """
         # This callback is called before _finished, so there's no need to
         # remove the item or close the fileobject.
-        log.downloads.debug("MHTML download cancelled by used: {}".format(url))
+        log.downloads.debug("MHTML download cancelled by user: {}".format(url))
         # Write an empty file instead
         item.fileobj.seek(0)
         item.fileobj.truncate()

--- a/tests/end2end/data/downloads/issue1535.html
+++ b/tests/end2end/data/downloads/issue1535.html
@@ -1,0 +1,14 @@
+<html>
+    <head>
+        <title>test case for issue 1535</title>
+    </head>
+    <body>
+        <p>Cancelling a download that belongs to a mhtml download.</p>
+        <p>See also <a href="https://github.com/The-Compiler/qutebrowser/issues/1535">GitHub</a></p>
+        <!--
+            Use drip so we have a chance to cancel the download before
+            it finishes
+        -->
+        <img src="/drip?numbytes=128&duration=2">
+    </body>
+</html>

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -130,7 +130,6 @@ Feature: Downloading things from a website.
     Scenario: Cancelling a MHTML download (issue 1535)
         When I open data/downloads/issue1535.html
         And I run :download --mhtml
-        And I wait 1s
         And I run :download-cancel
         Then no crash should happen
 

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -126,6 +126,14 @@ Feature: Downloading things from a website.
         Then "cancelled" should be logged
         And "cancelled" should be logged
 
+    # https://github.com/The-Compiler/qutebrowser/issues/1535
+    Scenario: Cancelling a MHTML download (issue 1535)
+        When I open data/downloads/issue1535.html
+        And I run :download --mhtml
+        And I wait 1s
+        And I run :download-cancel
+        Then no crash should happen
+
     ## :download-delete
 
     Scenario: Deleting a download


### PR DESCRIPTION
Fixes #1535

The browser crashed because both callbacks were called (finished and
error), trying to remove the item twice from the list of downloads.

I've tried to write a test for this, but it seems like the download from localhost is just too fast, even no delay doesn't work (error on `:download-cancel` because there is no download) (or I'm just missing something here)