### PR TITLE
Allow hint --rapid in normal mode.

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -846,7 +846,7 @@ class HintManager(QObject):
         if rapid:
             if target in [Target.tab_bg, Target.window, Target.run,
                           Target.hover, Target.userscript, Target.spawn,
-                          Target.download]:
+                          Target.download, Target.normal, Target.current]:
                 pass
             elif (target == Target.tab and
                   config.get('tabs', 'background-tabs')):

--- a/tests/end2end/data/hints/buttons.html
+++ b/tests/end2end/data/hints/buttons.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Rapid hinting with buttons</title>
+    </head>
+    <body>
+        <input type="text" id="number" value="0"/>
+        <button onclick="console.log('beep!')">beep!</button>
+        <button onclick="console.log('bop!')">bop!</button>
+        <button onclick="console.log('boop!')">boop!</button>
+    </body>
+</html>

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -97,6 +97,16 @@ Feature: Using hints
         And I run :follow-hint a
         Then the clipboard should contain "http://localhost:(port)/data/hello.txt"
 
+    Scenario: Using hint --rapid to hit multiple buttons
+        When I open data/hints/buttons.html
+        And I run :hint --rapid
+        And I run :follow-hint s
+        And I run :follow-hint d
+        And I run :follow-hint f
+        Then the javascript message "beep!" should be logged
+        And the javascript message "bop!" should be logged
+        And the javascript message "boop!" should be logged
+
     ### iframes
     ### FIXME currenly skipped, see https://github.com/The-Compiler/qutebrowser/issues/1525
 


### PR DESCRIPTION
This was disallowed by an assertion, but has a legitimate use case for
clicking multiple buttons or ticking multiple checkboxes.

Resolves #1541.