### PR TITLE
Handle special keystrings case-insensitively.

### DIFF
--- a/qutebrowser/config/parsers/keyconf.py
+++ b/qutebrowser/config/parsers/keyconf.py
@@ -165,6 +165,10 @@ class KeyConfigParser(QObject):
                   (default: `normal`).
             force: Rebind the key if it is already bound.
         """
+        if utils.is_special_key(key):
+            # <Ctrl-t>, <ctrl-T>, and <ctrl-t> should be considered equivalent
+            key = key.lower()
+
         if mode is None:
             mode = 'normal'
 
@@ -206,6 +210,10 @@ class KeyConfigParser(QObject):
             mode: A comma-separated list of modes to unbind the key in
                   (default: `normal`).
         """
+        if utils.is_special_key(key):
+            # <Ctrl-t>, <ctrl-T>, and <ctrl-t> should be considered equivalent
+            key = key.lower()
+
         if mode is None:
             mode = 'normal'
         mode = self._normalize_sectname(mode)
@@ -377,6 +385,9 @@ class KeyConfigParser(QObject):
 
     def _add_binding(self, sectname, keychain, command, *, force=False):
         """Add a new binding from keychain to command in section sectname."""
+        if utils.is_special_key(keychain):
+            # <Ctrl-t>, <ctrl-T>, and <ctrl-t> should be considered equivalent
+            keychain = keychain.lower()
         log.keyboard.vdebug("Adding binding {} -> {} in mode {}.".format(
             keychain, command, sectname))
         if sectname not in self.keybindings:

--- a/qutebrowser/config/parsers/keyconf.py
+++ b/qutebrowser/config/parsers/keyconf.py
@@ -154,7 +154,7 @@ class KeyConfigParser(QObject):
     @cmdutils.argument('win_id', win_id=True)
     @cmdutils.argument('key', completion=usertypes.Completion.empty)
     @cmdutils.argument('command', completion=usertypes.Completion.command)
-    def bind(self, key, win_id, command=None, *, mode=None, force=False):
+    def bind(self, key, win_id, command=None, *, mode='normal', force=False):
         """Bind a key to a command.
 
         Args:
@@ -168,9 +168,6 @@ class KeyConfigParser(QObject):
         if utils.is_special_key(key):
             # <Ctrl-t>, <ctrl-T>, and <ctrl-t> should be considered equivalent
             key = key.lower()
-
-        if mode is None:
-            mode = 'normal'
 
         if command is None:
             cmd = self.get_bindings_for(mode).get(key, None)
@@ -202,7 +199,7 @@ class KeyConfigParser(QObject):
             self._mark_config_dirty()
 
     @cmdutils.register(instance='key-config')
-    def unbind(self, key, mode=None):
+    def unbind(self, key, mode='normal'):
         """Unbind a keychain.
 
         Args:
@@ -214,8 +211,6 @@ class KeyConfigParser(QObject):
             # <Ctrl-t>, <ctrl-T>, and <ctrl-t> should be considered equivalent
             key = key.lower()
 
-        if mode is None:
-            mode = 'normal'
         mode = self._normalize_sectname(mode)
         for m in mode.split(','):
             if m not in configdata.KEY_DATA:

--- a/tests/end2end/features/keyinput.feature
+++ b/tests/end2end/features/keyinput.feature
@@ -45,6 +45,22 @@ Feature: Keyboard input
         And I run :bind --mode=caret test08
         Then the message "test08 is bound to 'message-info bar' in caret mode" should be shown
 
+    Scenario: Binding special keys with differing case (issue 1544)
+        When I run :bind <ctrl-test21> message-info test01
+        And I run :bind <Ctrl-Test21> message-info test01
+        Then the error "Duplicate keychain <ctrl-test21> - use --force to override!" should be shown
+
+    Scenario: Print a special binding with differing case (issue 1544)
+        When I run :bind <Ctrl-Test22> message-info foo
+        And I run :bind <ctrl-test22>
+        Then the message "<ctrl-test22> is bound to 'message-info foo' in normal mode" should be shown
+
+    Scenario: Overriding a special binding with differing case (issue 816)
+        When I run :bind <ctrl-test23> message-info foo
+        And I run :bind --force <Ctrl-Test23> message-info bar
+        And I run :bind <ctrl-test23>
+        Then the message "<ctrl-test23> is bound to 'message-info bar' in normal mode" should be shown
+
     # :unbind
 
     Scenario: Binding and unbinding a keychain
@@ -66,6 +82,12 @@ Feature: Keyboard input
         And I press the key "o"
         Then "No binding found for o." should be logged
         # maybe check it's unbound in the config?
+
+    Scenario: Binding and unbinding a special keychain with differing case (issue 1544)
+        When I run :bind <ctrl-test24> message-error test09
+        And I run :unbind <Ctrl-Test24>
+        When I run :bind <ctrl-test24>
+        Then the message "<ctrl-test24> is unbound in normal mode" should be shown
 
     # :clear-keychain
 


### PR DESCRIPTION
Load all special keystrings (e.g. <ctrl-a>) into memory as lowercase,
and automatically lowercase any special keystring given to bind/unbind.
This prevents <ctrl-a> and <Ctrl-A> from being treated differently.

Resolves #1544, where `:bind <ctrl-t>` would not complain even though
`<Ctrl-T>` was bound.