### PR TITLE
tests: un-xfail some iframe tests (#1525)

### DIFF
--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -136,6 +136,7 @@ Feature: Using hints
         When I open data/hints/iframe_target.html
         And I run :hint links tab
         And I run :follow-hint a
+        And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
             - data/hints/iframe_target.html
             - data/hello.txt (active)

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -108,15 +108,14 @@ Feature: Using hints
         And the javascript message "boop!" should be logged
 
     ### iframes
-    ### FIXME currenly skipped, see https://github.com/The-Compiler/qutebrowser/issues/1525
 
-    @xfail_norun
     Scenario: Using :follow-hint inside an iframe
         When I open data/hints/iframe.html
         And I run :hint links normal
         And I run :follow-hint a
         Then "acceptNavigationRequest, url http://localhost:*/data/hello.txt, type NavigationTypeLinkClicked, *" should be logged
 
+    ### FIXME currenly skipped, see https://github.com/The-Compiler/qutebrowser/issues/1525
     @xfail_norun
     Scenario: Using :follow-hint inside a scrolled iframe
         When I open data/hints/iframe_scroll.html
@@ -127,14 +126,12 @@ Feature: Using hints
         And I run :follow-hint a
         Then "acceptNavigationRequest, url http://localhost:*/data/hello2.txt, type NavigationTypeLinkClicked, *" should be logged
 
-    @xfail_norun
     Scenario: Opening a link inside a specific iframe
         When I open data/hints/iframe_target.html
         And I run :hint links normal
         And I run :follow-hint a
         Then "acceptNavigationRequest, url http://localhost:*/data/hello.txt, type NavigationTypeLinkClicked, *" should be logged
 
-    @xfail_norun
     Scenario: Opening a link with specific target frame in a new tab
         When I open data/hints/iframe_target.html
         And I run :hint links tab


### PR DESCRIPTION
After ee8247525e0a9894730fa5981bcdb3546b2d52a9, the given reason (clicking an iframe to get a focus) applies to only one test, the others are either stable or flaky for a different reason.

Letting Travis to take a look at it...