### PR TITLE
Fix toggle config using capitalised boolean value.

### DIFF
--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -734,7 +734,7 @@ class ConfigManager(QObject):
                     val = self.get(section_, option)
                     layer = 'temp' if temp else 'conf'
                     if isinstance(val, bool):
-                        self.set(layer, section_, option, str(not val))
+                        self.set(layer, section_, option, str(not val).lower())
                     else:
                         raise cmdexc.CommandError(
                             "set: Attempted inversion of non-boolean value.")

--- a/tests/end2end/features/set.feature
+++ b/tests/end2end/features/set.feature
@@ -26,7 +26,7 @@ Feature: Setting settings.
     Scenario: Toggling an option
         When I run :set general auto-save-config false
         And I run :set general auto-save-config!
-        Then general -> auto-save-config should be True
+        Then general -> auto-save-config should be true
 
     Scenario: Toggling a non-bool option
         When I run :set colors statusbar.bg!
@@ -44,7 +44,7 @@ Feature: Setting settings.
     Scenario: Using ! and -p
         When I run :set general auto-save-config false
         And I run :set -p general auto-save-config!
-        Then the message "general auto-save-config = True" should be shown
+        Then the message "general auto-save-config = true" should be shown
 
     Scenario: Setting an invalid value
         When I run :set general auto-save-config blah


### PR DESCRIPTION
It appears that since the introduction of the ability to toggle a config value, the config toggling code sets the specified setting to "True" if it was false and "False" if it was true, although this is not incorrect, it doesn't match the stylistic choice throughout qutebrowser to use lower case "true" and upper case "false" for settings.

This pull request attempts to solve this inconsistency.
