### PR TITLE
Allow the user to specify the bookmark directory

### DIFF
--- a/qutebrowser/browser/urlmarks.py
+++ b/qutebrowser/browser/urlmarks.py
@@ -243,18 +243,23 @@ class BookmarkManager(UrlMarkManager):
           second argument.
         - removed gets emitted with the URL as argument.
     """
+    @property
+    def _bookmarks_directory(self):
+        return os.environ.get(
+            "QUTE_BOOKMARK_DIRECTORY",
+            os.path.join(standarddir.config(), 'bookmarks')
+        )
 
     def _init_lineparser(self):
-        bookmarks_directory = os.path.join(standarddir.config(), 'bookmarks')
+        bookmarks_directory = self._bookmarks_directory
         if not os.path.isdir(bookmarks_directory):
             os.makedirs(bookmarks_directory)
 
-        bookmarks_subdir = os.path.join('bookmarks', 'urls')
         self._lineparser = lineparser.LineParser(
-            standarddir.config(), bookmarks_subdir, parent=self)
+            bookmarks_directory, "urls", parent=self)
 
     def _init_savemanager(self, save_manager):
-        filename = os.path.join(standarddir.config(), 'bookmarks', 'urls')
+        filename = os.path.join(self._bookmarks_directory, "urls")
         save_manager.add_saveable('bookmark-manager', self.save, self.changed,
                                   filename=filename)
 


### PR DESCRIPTION
I define configuration files as static files deciding the behavior of the application. 

IMHO, bookmarks are more dynamic files and don't impact the behavior of the application, they are more related to data.

Moreover, I like to version [my configuration files](https://github.com/Konubinix/Devel/blob/master/config/qutebrowser/qutebrowser.conf). But for obvious reasons, I don't want to version my bookmarks.

I don't propose to change the default value of bookmarks so as to avoid disturbing people that are now used of this current behavior. Instead, I proposed to let the user overwrite this value using the environment variables.

Personnaly, I set the location of bookmarks to the XDG_DATA_HOME/qutebrowser directory, IMHO a more suited one.