### PR TITLE
Strip the url before processing it

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -604,7 +604,7 @@ class HintManager(QObject):
         """
         for attr in ('href', 'src'):
             if attr in elem:
-                text = elem[attr]
+                text = elem[attr].strip()
                 break
         else:
             return None

--- a/tests/end2end/data/hints/html/with_spaces.html
+++ b/tests/end2end/data/hints/html/with_spaces.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+
+<!-- target: hello.txt -->
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Simple link</title>
+    </head>
+    <body>
+        <a href="
+				 /data/hello.txt">Follow me!</a>
+    </body>
+</html>


### PR DESCRIPTION
This won't hurt and will help with some poorly formatted sites
including blank spaces around the url (e.g. the Previous link in a
dashboard make with CDash 2.0.2).