### PR TITLE
Alias multi commands

### DIFF
--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -26,7 +26,7 @@ from PyQt5.QtCore import pyqtSlot, QUrl, QObject
 
 from qutebrowser.config import config, configexc
 from qutebrowser.commands import cmdexc, cmdutils
-from qutebrowser.utils import message, log, objreg, qtutils
+from qutebrowser.utils import message, objreg, qtutils
 from qutebrowser.misc import split
 
 
@@ -80,7 +80,7 @@ class CommandRunner(QObject):
         self._partial_match = partial_match
         self._win_id = win_id
 
-    def _get_alias(self, text, default = None):
+    def _get_alias(self, text, default=None):
         """Get an alias from the config.
 
         Args:
@@ -105,7 +105,7 @@ class CommandRunner(QObject):
             new_cmd += ' '
         return new_cmd
 
-    def parse_all(self, text, aliases = True, *args, **kwargs):
+    def parse_all(self, text, aliases=True, *args, **kwargs):
         """Split a command on ;; and parse all parts.
 
         If the first command in the commandline is a non-split one, it only
@@ -119,7 +119,6 @@ class CommandRunner(QObject):
         Yields:
             ParseResult tuples.
         """
-
         if aliases:
             text = self._get_alias(text, text)
 

--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -80,21 +80,23 @@ class CommandRunner(QObject):
         self._partial_match = partial_match
         self._win_id = win_id
 
-    def _get_alias(self, text):
+    def _get_alias(self, text, default = None):
         """Get an alias from the config.
 
         Args:
             text: The text to parse.
+            default : Default value to return when alias was not found. By
+                      default it is set to None.
 
         Return:
-            None if no alias was found.
-            The new command string if an alias was found.
+            The new command string if an alias was found. Default value
+            otherwise.
         """
         parts = text.strip().split(maxsplit=1)
         try:
             alias = config.get('aliases', parts[0])
         except (configexc.NoOptionError, configexc.NoSectionError):
-            return None
+            return default
         try:
             new_cmd = '{} {}'.format(alias, parts[1])
         except IndexError:
@@ -103,7 +105,7 @@ class CommandRunner(QObject):
             new_cmd += ' '
         return new_cmd
 
-    def parse_all(self, text, *args, **kwargs):
+    def parse_all(self, text, aliases = True, *args, **kwargs):
         """Split a command on ;; and parse all parts.
 
         If the first command in the commandline is a non-split one, it only
@@ -111,11 +113,16 @@ class CommandRunner(QObject):
 
         Args:
             text: Text to parse.
+            aliases: Whether to handle aliases.
             *args/**kwargs: Passed to parse().
 
         Yields:
             ParseResult tuples.
         """
+
+        if aliases:
+            text = self._get_alias(text, text)
+
         if ';;' in text:
             # Get the first command and check if it doesn't want to have ;;
             # split.
@@ -159,12 +166,11 @@ class CommandRunner(QObject):
             cmdline = text.split()
         return ParseResult(cmd=None, args=None, cmdline=cmdline, count=count)
 
-    def parse(self, text, *, aliases=True, fallback=False, keep=False):
+    def parse(self, text, *, fallback=False, keep=False):
         """Split the commandline text into command and arguments.
 
         Args:
             text: Text to parse.
-            aliases: Whether to handle aliases.
             fallback: Whether to do a fallback splitting when the command was
                       unknown.
             keep: Whether to keep special chars and whitespace
@@ -177,13 +183,6 @@ class CommandRunner(QObject):
 
         if not cmdstr and not fallback:
             raise cmdexc.NoSuchCommandError("No command given")
-
-        if aliases:
-            new_cmd = self._get_alias(text)
-            if new_cmd is not None:
-                log.commands.debug("Re-parsing with '{}'.".format(new_cmd))
-                return self.parse(new_cmd, aliases=False, fallback=fallback,
-                                  keep=keep)
 
         if self._partial_match:
             cmdstr = self._completion_match(cmdstr)

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -354,7 +354,7 @@ class Completer(QObject):
         if completion.enabled:
             completion.show()
 
-    def split(self, keep=False, aliases=False):
+    def split(self, keep=False):
         """Get the text split up in parts.
 
         Args:
@@ -371,7 +371,7 @@ class Completer(QObject):
             # the whitespace.
             return [text]
         runner = runners.CommandRunner(self._win_id)
-        result = runner.parse(text, fallback=True, aliases=aliases, keep=keep)
+        result = runner.parse(text, fallback=True, keep=keep)
         parts = result.cmdline
         if self._empty_item_idx is not None:
             log.completion.debug("Empty element queued at {}, "

--- a/tests/unit/commands/test_runners.py
+++ b/tests/unit/commands/test_runners.py
@@ -43,6 +43,21 @@ class TestCommandRunner:
             with pytest.raises(cmdexc.NoSuchCommandError):
                 list(cr.parse_all(cmdline_test.cmd, aliases=False))
 
+    def test_parse_all_with_alias(self, cmdline_test, monkeypatch):
+        alias_dict = dict(alias_name = cmdline_test.cmd)
+
+        def mock_get(section, *args, **kwargs):
+            assert section == "aliases"
+            return alias_dict.get(*args, **kwargs)
+        monkeypatch.setattr("qutebrowser.config.config.get", mock_get)
+
+        cr = runners.CommandRunner(0)
+        if cmdline_test.valid:
+            assert len(list(cr.parse_all("alias_name"))) > 0
+        else:
+            with pytest.raises(cmdexc.NoSuchCommandError):
+                list(cr.parse_all("alias_name"))
+
     def test_parse_with_count(self):
         """Test parsing of commands with a count."""
         cr = runners.CommandRunner(0)

--- a/tests/unit/commands/test_runners.py
+++ b/tests/unit/commands/test_runners.py
@@ -44,7 +44,7 @@ class TestCommandRunner:
                 list(cr.parse_all(cmdline_test.cmd, aliases=False))
 
     def test_parse_all_with_alias(self, cmdline_test, monkeypatch):
-        alias_dict = dict(alias_name = cmdline_test.cmd)
+        alias_dict = dict(alias_name=cmdline_test.cmd)
 
         def mock_get(section, *args, **kwargs):
             assert section == "aliases"

--- a/tests/unit/commands/test_runners.py
+++ b/tests/unit/commands/test_runners.py
@@ -43,13 +43,8 @@ class TestCommandRunner:
             with pytest.raises(cmdexc.NoSuchCommandError):
                 list(cr.parse_all(cmdline_test.cmd, aliases=False))
 
-    def test_parse_all_with_alias(self, cmdline_test, monkeypatch):
-        alias_dict = dict(alias_name=cmdline_test.cmd)
-
-        def mock_get(section, *args, **kwargs):
-            assert section == "aliases"
-            return alias_dict.get(*args, **kwargs)
-        monkeypatch.setattr("qutebrowser.config.config.get", mock_get)
+    def test_parse_all_with_alias(self, cmdline_test, config_stub):
+        config_stub.data = {'aliases': {'alias_name': cmdline_test.cmd}}
 
         cr = runners.CommandRunner(0)
         if cmdline_test.valid:

--- a/tests/unit/commands/test_runners.py
+++ b/tests/unit/commands/test_runners.py
@@ -46,7 +46,7 @@ class TestCommandRunner:
     def test_parse_with_count(self):
         """Test parsing of commands with a count."""
         cr = runners.CommandRunner(0)
-        result = cr.parse('20:scroll down', aliases=False)
+        result = cr.parse('20:scroll down')
         assert result.cmd.name == 'scroll'
         assert result.count == 20
         assert result.args == ['down']
@@ -58,5 +58,5 @@ class TestCommandRunner:
         The same with it being disabled is tested by test_parse_all.
         """
         cr = runners.CommandRunner(0, partial_match=True)
-        result = cr.parse('message-i', aliases=False)
+        result = cr.parse('message-i')
         assert result.cmd.name == 'message-info'

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -306,7 +306,7 @@ class TestDefaultConfig:
         runner = runners.CommandRunner(win_id=0)
         for sectname in configdata.KEY_DATA:
             for cmd in conf.get_bindings_for(sectname).values():
-                runner.parse(cmd, aliases=False)
+                runner.parse(cmd)
 
     def test_upgrade_version(self):
         """Fail when the qutebrowser version changed.


### PR DESCRIPTION
This is a fix for #956.

With recent addition of `history-clear` command I feel that it would be extremely useful to have an alias for `history-clear ;; quit`. However above bug prevented that. I fixed that by simply moving a logic of checking if a given command is an alias from `CommandRunner.parse()` to `CommandRunner.parse_all()`.

Please review the changes and tell how you feel about them. Thanks. :)