### PR TITLE
#1512 Update behaviour of rl_unix_word_rubout

### DIFF
--- a/qutebrowser/misc/readline.py
+++ b/qutebrowser/misc/readline.py
@@ -166,12 +166,12 @@ class ReadlineBridge:
         is_word_boundary = True
         while is_word_boundary and target_position > 0:
             is_word_boundary = text[target_position - 1] == " "
-            target_position-=1
+            target_position -= 1
 
         is_word_boundary = False
         while not is_word_boundary and target_position > 0:
             is_word_boundary = text[target_position - 1] == " "
-            target_position-=1
+            target_position -= 1
 
         moveby = cursor_position - target_position - 1
         widget.cursorBackward(True, moveby)
@@ -227,4 +227,3 @@ class ReadlineBridge:
         if widget is None:
             return
         widget.backspace()
-

--- a/qutebrowser/misc/readline.py
+++ b/qutebrowser/misc/readline.py
@@ -158,7 +158,23 @@ class ReadlineBridge:
         widget = self._widget()
         if widget is None:
             return
-        widget.cursorWordBackward(True)
+        cursor_position = widget.cursorPosition()
+        text = widget.text()
+
+        target_position = cursor_position
+
+        is_word_boundary = True
+        while is_word_boundary and target_position > 0:
+            is_word_boundary = text[target_position - 1] == " "
+            target_position-=1
+
+        is_word_boundary = False
+        while not is_word_boundary and target_position > 0:
+            is_word_boundary = text[target_position - 1] == " "
+            target_position-=1
+
+        moveby = cursor_position - target_position - 1
+        widget.cursorBackward(True, moveby)
         self._deleted[widget] = widget.selectedText()
         widget.del_()
 
@@ -211,3 +227,4 @@ class ReadlineBridge:
         if widget is None:
             return
         widget.backspace()
+

--- a/tests/unit/misc/test_readline.py
+++ b/tests/unit/misc/test_readline.py
@@ -234,6 +234,8 @@ def test_rl_kill_line(lineedit, bridge, text, deleted, rest):
 @pytest.mark.parametrize('text, deleted, rest', [
     ('test delete|foobar', 'delete', 'test |foobar'),
     ('test delete |foobar', 'delete ', 'test |foobar'),
+    ('open -t github.com/foo/bar  |', 'github.com/foo/bar  ', 'open -t |'),
+    ('open -t |github.com/foo/bar', '-t ', 'open |github.com/foo/bar'),
     fixme(('test del<ete>foobar', 'delete', 'test |foobar')),
     ('test del<ete >foobar', 'del', 'test |ete foobar'),  # wrong
 ])


### PR DESCRIPTION
Closes #1512 
 
Now, unix_word_rubout behaves like in bash, eg it deletes the last word in the command line.

For example , if you type 

`:open -t https://github.com/The-Compiler/qutebrowser/`

and your cursor is at the end of the line, hitting c-w will bring you to `:open -t `.

If you liked the previous behaviour, you can use `Ctrl-Backspace`