### PR TITLE
Fix Dvorak hint chars

### DIFF
--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -888,7 +888,7 @@ def data(readonly=False):
             ('chars',
              SettingValue(typ.UniqueCharString(minlen=2, completions=[
                  ('asdfghjkl', "Home row"),
-                 ('dhtnaoeu', "Home row (Dvorak)"),
+                 ('aoeuidnths', "Home row (Dvorak)"),
                  ('abcdefghijklmnopqrstuvwxyz', "All letters"),
              ]), 'asdfghjkl'),
              "Chars used for hint strings."),


### PR DESCRIPTION
  - Use the whole home-row
  - Produce easier chords
    - 2-key chords alternate hands first (f-[aoeui]-[dhtns])


This is indeed a poor patch for easier chords as it should work on
 every home-row, but there are not that much home-rows around.