### PR TITLE
Add a userscript to integrate with taskwarrior.

### DIFF
--- a/misc/userscripts/taskadd
+++ b/misc/userscripts/taskadd
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Behavior:
+#   Userscript for qutebrowser which adds a task to taskwarrior.
+#   If run as a command (:spawn --userscript taskadd), it creates a new task
+#   with the description equal to the current page title and annotates it with
+#   the current page url. Additional arguments are passed along so you can add
+#   mods to the task (e.g. priority, due date, tags).
+#
+#   Example:
+#       :spawn --userscript taskadd due:eod pri:H
+#
+#   To enable passing along extra args, I suggest using a mapping like:
+#       :bind <somekey> set-cmd-text -s :spawn --userscript taskadd
+#
+#   If run from hint mode, it uses the selected hint text as the description
+#   and the selected hint url as the annotation.
+#
+# Ryan Roden-Corrent (rcorre), 2016
+# Any feedback is welcome!
+#
+# For more info on Taskwarrior, see http://taskwarrior.org/
+
+# use either the current page title or the hint text as the task description
+[[ $QUTE_MODE == 'hints' ]] && title=$QUTE_SELECTED_TEXT || title=$QUTE_TITLE
+
+# try to add the task and grab the output
+msg="$(task add $title $@ 2>&1)"
+
+if [[ $? == 0 ]]; then
+    # scan the output for the new task number
+    num=$(echo $msg | sed -r 's/Created task ([0-9]+)\./\1/')
+
+    # annotate the new task with the url, send the output back to the browser
+    task $num annotate "$QUTE_URL"
+    echo "message-info '$msg'" >> $QUTE_FIFO
+else
+    echo "message-error '$msg'" >> $QUTE_FIFO
+fi

--- a/misc/userscripts/taskadd
+++ b/misc/userscripts/taskadd
@@ -28,11 +28,8 @@
 msg="$(task add $title $@ 2>&1)"
 
 if [[ $? == 0 ]]; then
-    # scan the output for the new task number
-    num=$(echo $msg | sed -r 's/Created task ([0-9]+)\./\1/')
-
     # annotate the new task with the url, send the output back to the browser
-    task $num annotate "$QUTE_URL"
+    task +LATEST annotate "$QUTE_URL"
     echo "message-info '$msg'" >> $QUTE_FIFO
 else
     echo "message-error '$msg'" >> $QUTE_FIFO


### PR DESCRIPTION
The `taskadd` userscript adds a task based on the current title and URL.
It passes additional arguments along to `task`.

For example:
    :spawn --userscript taskadd due:eod pri:H
will add a task with high priority due at the end of the day.
The description will be the current page title and it will be annotated
with the current page url.

If used with hints, the hint text is used as the description.

Unfortunately, there is currently no way to use :hint fill and maintain
the hint text, which limits the ability to provide additional args in
hint mode.