### PR TITLE
allow downloads to be opened directly

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -47,7 +47,7 @@ from qutebrowser.completion.models import instances as completionmodels
 from qutebrowser.commands import cmdutils, runners, cmdexc
 from qutebrowser.config import style, config, websettings, configexc
 from qutebrowser.browser import urlmarks, adblock
-from qutebrowser.browser.webkit import cookies, cache, history
+from qutebrowser.browser.webkit import cookies, cache, history, downloads
 from qutebrowser.browser.webkit.network import (qutescheme, proxy,
                                                 networkmanager)
 from qutebrowser.mainwindow import mainwindow
@@ -438,6 +438,8 @@ def _init_modules(args, crash_handler):
         os.environ.pop('QT_WAYLAND_DISABLE_WINDOWDECORATION', None)
     _maybe_hide_mouse_cursor()
     objreg.get('config').changed.connect(_maybe_hide_mouse_cursor)
+    temp_downloads = downloads.TempDownloadManager(qApp)
+    objreg.register('temporary-downloads', temp_downloads)
 
 
 def _init_late_modules(args):
@@ -711,6 +713,8 @@ class Quitter:
                 not restart):
             atexit.register(shutil.rmtree, self._args.basedir,
                             ignore_errors=True)
+        # Delete temp download dir
+        objreg.get('temporary-downloads').cleanup()
         # If we don't kill our custom handler here we might get segfaults
         log.destroy.debug("Deactivating message handler...")
         qInstallMessageHandler(None)

--- a/qutebrowser/browser/adblock.py
+++ b/qutebrowser/browser/adblock.py
@@ -210,7 +210,7 @@ class HostBlocker:
             else:
                 fobj = io.BytesIO()
                 fobj.name = 'adblock: ' + url.host()
-                target = usertypes.DownloadTarget.FileObj(fobj)
+                target = usertypes.FileObjDownloadTarget(fobj)
                 download = download_manager.get(url, target=target,
                                                 auto_remove=True)
                 self._in_progress.append(download)

--- a/qutebrowser/browser/adblock.py
+++ b/qutebrowser/browser/adblock.py
@@ -27,7 +27,7 @@ import zipfile
 import fnmatch
 
 from qutebrowser.config import config
-from qutebrowser.utils import objreg, standarddir, log, message
+from qutebrowser.utils import objreg, standarddir, log, message, usertypes
 from qutebrowser.commands import cmdutils, cmdexc
 
 
@@ -210,7 +210,8 @@ class HostBlocker:
             else:
                 fobj = io.BytesIO()
                 fobj.name = 'adblock: ' + url.host()
-                download = download_manager.get(url, fileobj=fobj,
+                target = usertypes.DownloadTarget.FileObj(fobj)
+                download = download_manager.get(url, target=target,
                                                 auto_remove=True)
                 self._in_progress.append(download)
                 download.finished.connect(

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1221,15 +1221,23 @@ class CommandDispatcher:
                                           " as mhtml.")
             url = urlutils.qurl_from_user_input(url)
             urlutils.raise_cmdexc_if_invalid(url)
-            download_manager.get(url, filename=dest)
+            if dest is None:
+                target = None
+            else:
+                target = usertypes.DownloadTarget.File(dest)
+            download_manager.get(url, target=target)
         elif mhtml_:
             self._download_mhtml(dest)
         else:
             # FIXME:qtwebengine have a proper API for this
             tab = self._current_widget()
             page = tab._widget.page()  # pylint: disable=protected-access
+            if dest is None:
+                target = None
+            else:
+                target = usertypes.DownloadTarget.File(dest)
             download_manager.get(self._current_url(), page=page,
-                                 filename=dest)
+                                 target=target)
 
     def _download_mhtml(self, dest=None):
         """Download the current page as an MHTML file, including all assets.

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1224,7 +1224,7 @@ class CommandDispatcher:
             if dest is None:
                 target = None
             else:
-                target = usertypes.DownloadTarget.File(dest)
+                target = usertypes.FileDownloadTarget(dest)
             download_manager.get(url, target=target)
         elif mhtml_:
             self._download_mhtml(dest)
@@ -1235,7 +1235,7 @@ class CommandDispatcher:
             if dest is None:
                 target = None
             else:
-                target = usertypes.DownloadTarget.File(dest)
+                target = usertypes.FileDownloadTarget(dest)
             download_manager.get(self._current_url(), page=page,
                                  target=target)
 

--- a/qutebrowser/browser/webkit/downloads.py
+++ b/qutebrowser/browser/webkit/downloads.py
@@ -795,8 +795,7 @@ class DownloadManager(QAbstractListModel):
         req = QNetworkRequest(url)
         return self.get_request(req, **kwargs)
 
-    def get_request(self, request, *, fileobj=None, filename=None,
-                    prompt_download_directory=None, **kwargs):
+    def get_request(self, request, *, fileobj=None, filename=None, **kwargs):
         """Start a download with a QNetworkRequest.
 
         Args:

--- a/qutebrowser/browser/webkit/downloads.py
+++ b/qutebrowser/browser/webkit/downloads.py
@@ -1295,7 +1295,7 @@ class TempDownloadManager(QObject):
             self._tmpdir.cleanup()
             self._tmpdir = None
 
-    def get_tmpdir(self):
+    def _get_tmpdir(self):
         """Return the temporary directory that is used for downloads.
 
         The directory is created lazily on first access.
@@ -1321,7 +1321,7 @@ class TempDownloadManager(QObject):
         Return:
             A tempfile.NamedTemporaryFile that should be used to save the file.
         """
-        tmpdir = self.get_tmpdir()
+        tmpdir = self._get_tmpdir()
         fobj = tempfile.NamedTemporaryFile(dir=tmpdir.name, delete=False,
                                            suffix=suggested_name)
         self.files.append(fobj)

--- a/qutebrowser/browser/webkit/downloads.py
+++ b/qutebrowser/browser/webkit/downloads.py
@@ -784,10 +784,7 @@ class DownloadManager(QAbstractListModel):
             **kwargs: passed to get_request().
 
         Return:
-            If the download could start immediately, (target given),
-            the created DownloadItem.
-
-            If not, None.
+            The created DownloadItem.
         """
         if not url.isValid():
             urlutils.invalid_url_error(self._win_id, url, "start download")
@@ -804,10 +801,7 @@ class DownloadManager(QAbstractListModel):
             **kwargs: Passed to fetch_request.
 
         Return:
-            If the download could start immediately, (target given),
-            the created DownloadItem.
-
-            If not, None.
+            The created DownloadItem.
         """
         # WORKAROUND for Qt corrupting data loaded from cache:
         # https://bugreports.qt.io/browse/QTBUG-42757

--- a/qutebrowser/browser/webkit/downloads.py
+++ b/qutebrowser/browser/webkit/downloads.py
@@ -802,9 +802,6 @@ class DownloadManager(QAbstractListModel):
             request: The QNetworkRequest to download.
             fileobj: The file object to write the answer to.
             filename: A path to write the data to.
-            prompt_download_directory: Whether to prompt for the download dir
-                                       or automatically download. If None, the
-                                       config is used.
             **kwargs: Passed to fetch_request.
 
         Return:

--- a/qutebrowser/browser/webkit/downloads.py
+++ b/qutebrowser/browser/webkit/downloads.py
@@ -874,9 +874,9 @@ class DownloadManager(QAbstractListModel):
             The created DownloadItem.
         """
         if not suggested_filename:
-            if isinstance(target, usertypes.DownloadTarget.File):
+            if isinstance(target, usertypes.FileDownloadTarget):
                 suggested_filename = os.path.basename(target.filename)
-            elif (isinstance(target, usertypes.DownloadTarget.FileObj) and
+            elif (isinstance(target, usertypes.FileObjDownloadTarget) and
                   getattr(target.fileobj, 'name', None)):
                 suggested_filename = target.fileobj.name
             else:
@@ -922,7 +922,7 @@ class DownloadManager(QAbstractListModel):
 
         # User doesn't want to be asked, so just use the download_dir
         if filename is not None:
-            target = usertypes.DownloadTarget.File(filename)
+            target = usertypes.FileDownloadTarget(filename)
             self._set_download_target(download, suggested_filename, target)
             return download
 
@@ -946,12 +946,12 @@ class DownloadManager(QAbstractListModel):
             suggested_filename: The suggested filename.
             target: The usertypes.DownloadTarget for this download.
         """
-        if isinstance(target, usertypes.DownloadTarget.FileObj):
+        if isinstance(target, usertypes.FileObjDownloadTarget):
             download.set_fileobj(target.fileobj)
             download.autoclose = False
-        elif isinstance(target, usertypes.DownloadTarget.File):
+        elif isinstance(target, usertypes.FileDownloadTarget):
             download.set_filename(target.filename)
-        elif isinstance(target, usertypes.DownloadTarget.OpenDownload):
+        elif isinstance(target, usertypes.OpenFileDownloadTarget):
             tmp_manager = objreg.get('temporary-downloads')
             fobj = tmp_manager.get_tmpfile(suggested_filename)
             download.finished.connect(download.open_file)

--- a/qutebrowser/browser/webkit/mhtml.py
+++ b/qutebrowser/browser/webkit/mhtml.py
@@ -35,7 +35,8 @@ import email.message
 from PyQt5.QtCore import QUrl
 
 from qutebrowser.browser.webkit import webelem, downloads
-from qutebrowser.utils import log, objreg, message, usertypes, utils, urlutils
+from qutebrowser.utils import (log, objreg, message, usertypes, utils,
+                               urlutils, usertypes)
 
 try:
     import cssutils
@@ -343,7 +344,8 @@ class _Downloader:
 
         download_manager = objreg.get('download-manager', scope='window',
                                       window=self._win_id)
-        item = download_manager.get(url, fileobj=_NoCloseBytesIO(),
+        target = usertypes.DownloadTarget.FileObj(_NoCloseBytesIO())
+        item = download_manager.get(url, target=target,
                                     auto_remove=True)
         self.pending_downloads.add((url, item))
         item.finished.connect(functools.partial(self._finished, url, item))

--- a/qutebrowser/browser/webkit/mhtml.py
+++ b/qutebrowser/browser/webkit/mhtml.py
@@ -35,8 +35,7 @@ import email.message
 from PyQt5.QtCore import QUrl
 
 from qutebrowser.browser.webkit import webelem, downloads
-from qutebrowser.utils import (log, objreg, message, usertypes, utils,
-                               urlutils, usertypes)
+from qutebrowser.utils import log, objreg, message, usertypes, utils, urlutils
 
 try:
     import cssutils

--- a/qutebrowser/browser/webkit/mhtml.py
+++ b/qutebrowser/browser/webkit/mhtml.py
@@ -343,7 +343,7 @@ class _Downloader:
 
         download_manager = objreg.get('download-manager', scope='window',
                                       window=self._win_id)
-        target = usertypes.DownloadTarget.FileObj(_NoCloseBytesIO())
+        target = usertypes.FileObjDownloadTarget(_NoCloseBytesIO())
         item = download_manager.get(url, target=target,
                                     auto_remove=True)
         self.pending_downloads.add((url, item))

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -1575,6 +1575,7 @@ KEY_DATA = collections.OrderedDict([
         ('prompt-accept', RETURN_KEYS),
         ('prompt-yes', ['y']),
         ('prompt-no', ['n']),
+        ('prompt-open-download', ['<Ctrl-X>']),
     ])),
 
     ('command,prompt', collections.OrderedDict([

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -452,6 +452,7 @@ class MainWindow(QWidget):
         self._save_geometry()
         log.destroy.debug("Closing window {}".format(self.win_id))
         self.tabbed_browser.shutdown()
+        self._get_object('download-manager').cleanup()
 
     def closeEvent(self, e):
         """Override closeEvent to display a confirmation if needed."""

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -452,7 +452,6 @@ class MainWindow(QWidget):
         self._save_geometry()
         log.destroy.debug("Closing window {}".format(self.win_id))
         self.tabbed_browser.shutdown()
-        self._get_object('download-manager').cleanup()
 
     def closeEvent(self, e):
         """Override closeEvent to display a confirmation if needed."""

--- a/qutebrowser/mainwindow/statusbar/prompter.py
+++ b/qutebrowser/mainwindow/statusbar/prompter.py
@@ -248,7 +248,7 @@ class Prompter(QObject):
             self._question.done()
         elif self._question.mode == usertypes.PromptMode.download:
             # User just entered a path for a download.
-            target = usertypes.DownloadTarget.File(prompt.lineedit.text())
+            target = usertypes.FileDownloadTarget(prompt.lineedit.text())
             self._question.answer = target
             modeman.maybe_leave(self._win_id, usertypes.KeyMode.prompt,
                                 'prompt accept')
@@ -299,7 +299,7 @@ class Prompter(QObject):
         if self._question.mode != usertypes.PromptMode.download:
             # We just ignore this if we don't have a download question.
             return
-        self._question.answer = usertypes.DownloadTarget.OpenDownload()
+        self._question.answer = usertypes.OpenFileDownloadTarget()
         modeman.maybe_leave(self._win_id, usertypes.KeyMode.prompt,
                             'download open')
         self._question.done()

--- a/qutebrowser/mainwindow/statusbar/prompter.py
+++ b/qutebrowser/mainwindow/statusbar/prompter.py
@@ -80,6 +80,7 @@ class Prompter(QObject):
         usertypes.PromptMode.text: usertypes.KeyMode.prompt,
         usertypes.PromptMode.user_pwd: usertypes.KeyMode.prompt,
         usertypes.PromptMode.alert: usertypes.KeyMode.prompt,
+        usertypes.PromptMode.download: usertypes.KeyMode.prompt,
     }
 
     show_prompt = pyqtSignal()
@@ -164,12 +165,9 @@ class Prompter(QObject):
                 suffix = " (no)"
             prompt.txt.setText(self._question.text + suffix)
             prompt.lineedit.hide()
-        elif self._question.mode == usertypes.PromptMode.text:
-            prompt.txt.setText(self._question.text)
-            if self._question.default:
-                prompt.lineedit.setText(self._question.default)
-            prompt.lineedit.show()
-        elif self._question.mode == usertypes.PromptMode.user_pwd:
+        elif self._question.mode in {usertypes.PromptMode.text,
+                                     usertypes.PromptMode.user_pwd,
+                                     usertypes.PromptMode.download}:
             prompt.txt.setText(self._question.text)
             if self._question.default:
                 prompt.lineedit.setText(self._question.default)
@@ -248,6 +246,12 @@ class Prompter(QObject):
             modeman.maybe_leave(self._win_id, usertypes.KeyMode.prompt,
                                 'prompt accept')
             self._question.done()
+        elif self._question.mode == usertypes.PromptMode.download:
+            # User just entered a path for a download.
+            self._question.answer = prompt.lineedit.text()
+            modeman.maybe_leave(self._win_id, usertypes.KeyMode.prompt,
+                                'prompt accept')
+            self._question.done()
         elif self._question.mode == usertypes.PromptMode.yesno:
             # User wants to accept the default of a yes/no question.
             self._question.answer = self._question.default
@@ -285,6 +289,18 @@ class Prompter(QObject):
         self._question.answer = False
         modeman.maybe_leave(self._win_id, usertypes.KeyMode.yesno,
                             'prompt accept')
+        self._question.done()
+
+    @cmdutils.register(instance='prompter', hide=True, scope='window',
+                       modes=[usertypes.KeyMode.prompt])
+    def prompt_open_download(self):
+        """Immediately open a download."""
+        if self._question.mode != usertypes.PromptMode.download:
+            # We just ignore this if we don't have a download question.
+            return
+        self._question.answer = usertypes.OPEN_DOWNLOAD
+        modeman.maybe_leave(self._win_id, usertypes.KeyMode.prompt,
+                            'download open')
         self._question.done()
 
     @pyqtSlot(usertypes.Question, bool)

--- a/qutebrowser/mainwindow/statusbar/prompter.py
+++ b/qutebrowser/mainwindow/statusbar/prompter.py
@@ -165,9 +165,9 @@ class Prompter(QObject):
                 suffix = " (no)"
             prompt.txt.setText(self._question.text + suffix)
             prompt.lineedit.hide()
-        elif self._question.mode in {usertypes.PromptMode.text,
+        elif self._question.mode in [usertypes.PromptMode.text,
                                      usertypes.PromptMode.user_pwd,
-                                     usertypes.PromptMode.download}:
+                                     usertypes.PromptMode.download]:
             prompt.txt.setText(self._question.text)
             if self._question.default:
                 prompt.lineedit.setText(self._question.default)

--- a/qutebrowser/mainwindow/statusbar/prompter.py
+++ b/qutebrowser/mainwindow/statusbar/prompter.py
@@ -248,7 +248,8 @@ class Prompter(QObject):
             self._question.done()
         elif self._question.mode == usertypes.PromptMode.download:
             # User just entered a path for a download.
-            self._question.answer = prompt.lineedit.text()
+            target = usertypes.DownloadTarget.File(prompt.lineedit.text())
+            self._question.answer = target
             modeman.maybe_leave(self._win_id, usertypes.KeyMode.prompt,
                                 'prompt accept')
             self._question.done()
@@ -298,7 +299,7 @@ class Prompter(QObject):
         if self._question.mode != usertypes.PromptMode.download:
             # We just ignore this if we don't have a download question.
             return
-        self._question.answer = usertypes.OPEN_DOWNLOAD
+        self._question.answer = usertypes.DownloadTarget.OpenDownload()
         modeman.maybe_leave(self._win_id, usertypes.KeyMode.prompt,
                             'download open')
         self._question.done()

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -33,6 +33,7 @@ from qutebrowser.utils import log, qtutils, utils
 
 
 _UNSET = object()
+OPEN_DOWNLOAD = object()
 
 
 def enum(name, items, start=1, is_int=False):
@@ -221,7 +222,8 @@ class NeighborList(collections.abc.Sequence):
 
 
 # The mode of a Question.
-PromptMode = enum('PromptMode', ['yesno', 'text', 'user_pwd', 'alert'])
+PromptMode = enum('PromptMode', ['yesno', 'text', 'user_pwd', 'alert',
+                                 'download'])
 
 
 # Where to open a clicked link.

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -274,6 +274,7 @@ class FileDownloadTarget(DownloadTarget):
     """
 
     def __init__(self, filename):
+        # pylint: disable=super-init-not-called
         self.filename = filename
 
 
@@ -286,6 +287,7 @@ class FileObjDownloadTarget(DownloadTarget):
     """
 
     def __init__(self, fileobj):
+        # pylint: disable=super-init-not-called
         self.fileobj = fileobj
 
 
@@ -294,6 +296,7 @@ class OpenFileDownloadTarget(DownloadTarget):
     """Save the download in a temp dir and directly open it."""
 
     def __init__(self):
+        # pylint: disable=super-init-not-called
         pass
 
 

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -33,7 +33,6 @@ from qutebrowser.utils import log, qtutils, utils
 
 
 _UNSET = object()
-OPEN_DOWNLOAD = object()
 
 
 def enum(name, items, start=1, is_int=False):
@@ -255,6 +254,52 @@ LoadStatus = enum('LoadStatus', ['none', 'success', 'success_https', 'error',
 
 # Backend of a tab
 Backend = enum('Backend', ['QtWebKit', 'QtWebEngine'])
+
+
+# Where a download should be saved
+class DownloadTarget:
+
+    """Augmented enum that directs how a download should be saved.
+
+    Objects of this class cannot be instantiated directly, use the "subclasses"
+    instead.
+    """
+
+    def __init__(self):
+        raise NotImplementedError
+
+    # Due to technical limitations, these can't be actual subclasses without a
+    # workaround. But they should still be part of DownloadTarget to get the
+    # enum-like access (usertypes.DownloadTarget.File, like
+    # usertypes.PromptMode.download).
+
+    class File:
+
+        """Save the download to the given file.
+
+        Attributes:
+            filename: Filename where the download should be saved.
+        """
+
+        def __init__(self, filename):
+            self.filename = filename
+
+    class FileObj:
+
+        """Save the download to the given file-like object.
+
+        Attributes:
+            fileobj: File-like object where the download should be written to.
+        """
+
+        def __init__(self, fileobj):
+            self.fileobj = fileobj
+
+    class OpenDownload:
+
+        """Save the download in a temp dir and directly open it."""
+
+        pass
 
 
 class Question(QObject):

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -259,46 +259,41 @@ Backend = enum('Backend', ['QtWebKit', 'QtWebEngine'])
 # Where a download should be saved
 class DownloadTarget:
 
-    """Augmented enum that directs how a download should be saved.
-
-    Objects of this class cannot be instantiated directly, use the "subclasses"
-    instead.
-    """
+    """Abstract base class for different download targets."""
 
     def __init__(self):
         raise NotImplementedError
 
-    # Due to technical limitations, these can't be actual subclasses without a
-    # workaround. But they should still be part of DownloadTarget to get the
-    # enum-like access (usertypes.DownloadTarget.File, like
-    # usertypes.PromptMode.download).
 
-    class File:
+class FileDownloadTarget(DownloadTarget):
 
-        """Save the download to the given file.
+    """Save the download to the given file.
 
-        Attributes:
-            filename: Filename where the download should be saved.
-        """
+    Attributes:
+        filename: Filename where the download should be saved.
+    """
 
-        def __init__(self, filename):
-            self.filename = filename
+    def __init__(self, filename):
+        self.filename = filename
 
-    class FileObj:
 
-        """Save the download to the given file-like object.
+class FileObjDownloadTarget(DownloadTarget):
 
-        Attributes:
-            fileobj: File-like object where the download should be written to.
-        """
+    """Save the download to the given file-like object.
 
-        def __init__(self, fileobj):
-            self.fileobj = fileobj
+    Attributes:
+        fileobj: File-like object where the download should be written to.
+    """
 
-    class OpenDownload:
+    def __init__(self, fileobj):
+        self.fileobj = fileobj
 
-        """Save the download in a temp dir and directly open it."""
 
+class OpenFileDownloadTarget(DownloadTarget):
+
+    """Save the download in a temp dir and directly open it."""
+
+    def __init__(self):
         pass
 
 

--- a/scripts/dev/misc_checks.py
+++ b/scripts/dev/misc_checks.py
@@ -81,14 +81,14 @@ def check_spelling():
     """Check commonly misspelled words."""
     # Words which I often misspell
     words = {'[Bb]ehaviour', '[Qq]uitted', 'Ll]ikelyhood', '[Ss]ucessfully',
-             '[Oo]ccur[^r .]', '[Ss]eperator', '[Ee]xplicitely', '[Rr]esetted',
+             '[Oo]ccur[^rs .]', '[Ss]eperator', '[Ee]xplicitely',
              '[Aa]uxillary', '[Aa]ccidentaly', '[Aa]mbigious', '[Ll]oosly',
              '[Ii]nitialis', '[Cc]onvienence', '[Ss]imiliar', '[Uu]ncommited',
              '[Rr]eproducable', '[Aa]n [Uu]ser', '[Cc]onvienience',
              '[Ww]ether', '[Pp]rogramatically', '[Ss]plitted', '[Ee]xitted',
              '[Mm]ininum', '[Rr]esett?ed', '[Rr]ecieved', '[Rr]egularily',
              '[Uu]nderlaying', '[Ii]nexistant', '[Ee]lipsis', 'commiting',
-             'existant'}
+             'existant', '[Rr]esetted'}
 
     # Words which look better when splitted, but might need some fine tuning.
     words |= {'[Ww]ebelements', '[Mm]ouseevent', '[Kk]eysequence',

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -30,7 +30,7 @@ Feature: Downloading things from a website.
         And I open data/downloads/issue1243.html
         And I run :hint links download
         And I run :follow-hint a
-        And I wait for "Asking question <qutebrowser.utils.usertypes.Question default='qutebrowser-download' mode=<PromptMode.text: 2> text='Save file to:'>, *" in the log
+        And I wait for "Asking question <qutebrowser.utils.usertypes.Question default='qutebrowser-download' mode=<PromptMode.download: 5> text='Save file to:'>, *" in the log
         And I run :leave-mode
         Then no crash should happen
 
@@ -40,7 +40,7 @@ Feature: Downloading things from a website.
         And I open data/downloads/issue1214.html
         And I run :hint links download
         And I run :follow-hint a
-        And I wait for "Asking question <qutebrowser.utils.usertypes.Question default='binary blob' mode=<PromptMode.text: 2> text='Save file to:'>, *" in the log
+        And I wait for "Asking question <qutebrowser.utils.usertypes.Question default='binary blob' mode=<PromptMode.download: 5> text='Save file to:'>, *" in the log
         And I run :leave-mode
         Then no crash should happen
 

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -31,8 +31,7 @@ Feature: Downloading things from a website.
         And I run :hint links download
         And I run :follow-hint a
         And I wait for "Asking question <qutebrowser.utils.usertypes.Question default='qutebrowser-download' mode=<PromptMode.download: 5> text='Save file to:'>, *" in the log
-        And I run :leave-mode
-        Then no crash should happen
+        Then the error "Download error: No handler found for qute://!" should be shown
 
     Scenario: Downloading a data: link (issue 1214)
         When I set completion -> download-path-suggestion to filename

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -312,7 +312,7 @@ Feature: Various utility commands.
         And I open data/misc/test.pdf
         And I wait for "[qute://pdfjs/*] PDF * (PDF.js: *)" in the log
         And I run :jseval document.getElementById("download").click()
-        And I wait for "Asking question <qutebrowser.utils.usertypes.Question default='test.pdf' mode=<PromptMode.text: 2> text='Save file to:'>, *" in the log
+        And I wait for "Asking question <qutebrowser.utils.usertypes.Question default='test.pdf' mode=<PromptMode.download: 5> text='Save file to:'>, *" in the log
         And I run :leave-mode
         Then no crash should happen
 

--- a/tests/end2end/features/test_downloads_bdd.py
+++ b/tests/end2end/features/test_downloads_bdd.py
@@ -64,7 +64,7 @@ def download_should_exist(filename, tmpdir):
 def download_prompt(tmpdir, quteproc, path):
     full_path = path.replace('{downloaddir}', str(tmpdir)).replace('/', os.sep)
     msg = ("Asking question <qutebrowser.utils.usertypes.Question "
-           "default={full_path!r} mode=<PromptMode.text: 2> "
+           "default={full_path!r} mode=<PromptMode.download: 5> "
            "text='Save file to:'>, *".format(full_path=full_path))
     quteproc.wait_for(message=msg)
     quteproc.send_cmd(':leave-mode')

--- a/tests/unit/browser/test_adblock.py
+++ b/tests/unit/browser/test_adblock.py
@@ -92,12 +92,12 @@ class FakeDownloadManager:
 
     """Mock browser.downloads.DownloadManager."""
 
-    def get(self, url, fileobj, **kwargs):
+    def get(self, url, target, **kwargs):
         """Return a FakeDownloadItem instance with a fileobj.
 
         The content is copied from the file the given url links to.
         """
-        download_item = FakeDownloadItem(fileobj, name=url.path())
+        download_item = FakeDownloadItem(target.fileobj, name=url.path())
         with open(url.path(), 'rb') as fake_url_file:
             shutil.copyfileobj(fake_url_file, download_item.fileobj)
         return download_item

--- a/tests/unit/utils/usertypes/test_downloadtarget.py
+++ b/tests/unit/utils/usertypes/test_downloadtarget.py
@@ -1,0 +1,54 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2016 Daniel Schadt
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the DownloadTarget class."""
+
+from qutebrowser.utils import usertypes
+
+import pytest
+
+
+def test_base():
+    with pytest.raises(NotImplementedError):
+        usertypes.DownloadTarget()
+
+
+def test_filename():
+    target = usertypes.FileDownloadTarget("/foo/bar")
+    assert target.filename == "/foo/bar"
+
+
+def test_fileobj():
+    fobj = object()
+    target = usertypes.FileObjDownloadTarget(fobj)
+    assert target.fileobj is fobj
+
+
+def test_openfile():
+    # Just make sure no error is raised, that should be enough.
+    usertypes.OpenFileDownloadTarget()
+
+
+@pytest.mark.parametrize('obj', [
+    usertypes.FileDownloadTarget('foobar'),
+    usertypes.FileObjDownloadTarget(None),
+    usertypes.OpenFileDownloadTarget(),
+])
+def test_class_hierarchy(obj):
+    assert isinstance(obj, usertypes.DownloadTarget)


### PR DESCRIPTION
Fixes #39.

The file is saved in a temporary directory, which is cleaned up when the
window is closed.

Bind `prompt-open-download` to a key combination (e.g. `:bind --mode prompt <ctrl-o> prompt-open-download`) and press it during the filename prompt to download the file to a temporary location and automatically open it after it has finished downloading.

Todo:
- [x] Use one directory per instance, not per window
- [x] Clean up at program end, not on window close
- [x] Code cleanup (probably shouldn't reuse filename for everything)
- [x] Add default keybinding (`Ctrl-x`)
- [x] Find some unrelated race condition that (may) lead(s) to bugs.