### PR TITLE
Stop creating qute_test!

### DIFF
--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -432,3 +432,14 @@ def data_tmpdir(monkeypatch, tmpdir):
     os.mkdir(path)
     monkeypatch.setattr('qutebrowser.utils.standarddir.data', lambda: path)
     return tmpdir
+
+
+@pytest.fixture
+def redirect_xdg_data(data_tmpdir):
+    """Set XDG_DATA_HOME to a temp location.
+
+    While data_tmpdir covers most cases by redirecting standarddir.data(), this
+    is not enough for places Qt references the data dir internally. For these,
+    we need to set the environment variable to redirect data access.
+    """
+    os.putenv('XDG_DATA_HOME', str(data_tmpdir))

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -30,6 +30,7 @@ import itertools
 import textwrap
 import unittest.mock
 import types
+import os
 
 import pytest
 
@@ -405,3 +406,29 @@ def mode_manager(win_registry, config_stub, qapp):
     objreg.register('mode-manager', mm, scope='window', window=0)
     yield mm
     objreg.delete('mode-manager', scope='window', window=0)
+
+
+@pytest.fixture
+def config_tmpdir(monkeypatch, tmpdir):
+    """Set tmpdir/config as the configdir.
+
+    Use this to avoid creating a 'real' config dir (~/.config/qute_test).
+    """
+    tmpdir = tmpdir / 'config'
+    path = str(tmpdir)
+    os.mkdir(path)
+    monkeypatch.setattr('qutebrowser.utils.standarddir.config', lambda: path)
+    return tmpdir
+
+
+@pytest.fixture
+def data_tmpdir(monkeypatch, tmpdir):
+    """Set tmpdir/data as the datadir.
+
+    Use this to avoid creating a 'real' data dir (~/.local/share/qute_test).
+    """
+    tmpdir = tmpdir / 'data'
+    path = str(tmpdir)
+    os.mkdir(path)
+    monkeypatch.setattr('qutebrowser.utils.standarddir.data', lambda: path)
+    return tmpdir

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -435,11 +435,11 @@ def data_tmpdir(monkeypatch, tmpdir):
 
 
 @pytest.fixture
-def redirect_xdg_data(data_tmpdir):
+def redirect_xdg_data(data_tmpdir, monkeypatch):
     """Set XDG_DATA_HOME to a temp location.
 
     While data_tmpdir covers most cases by redirecting standarddir.data(), this
     is not enough for places Qt references the data dir internally. For these,
     we need to set the environment variable to redirect data access.
     """
-    os.putenv('XDG_DATA_HOME', str(data_tmpdir))
+    monkeypatch.setenv('XDG_DATA_HOME', str(data_tmpdir))

--- a/tests/unit/browser/test_adblock.py
+++ b/tests/unit/browser/test_adblock.py
@@ -30,7 +30,7 @@ from qutebrowser.browser import adblock
 from qutebrowser.utils import objreg
 from qutebrowser.commands import cmdexc
 
-pytestmark = pytest.mark.usefixtures('qapp')
+pytestmark = pytest.mark.usefixtures('qapp', 'config_tmpdir')
 
 # TODO See ../utils/test_standarddirutils for OSError and caplog assertion
 
@@ -52,13 +52,6 @@ URLS_TO_CHECK = ('http://localhost',
                  'http://goodhost.gov',
                  'ftp://verygoodhost.com',
                  'http://qutebrowser.org')
-
-
-@pytest.fixture
-def data_tmpdir(monkeypatch, tmpdir):
-    """Set tmpdir as datadir."""
-    tmpdir = str(tmpdir)
-    monkeypatch.setattr('qutebrowser.utils.standarddir.data', lambda: tmpdir)
 
 
 class BaseDirStub:
@@ -348,7 +341,7 @@ def test_blocking_with_whitelist(config_stub, basedir, download_stub,
     # by creating a file named blocked-hosts,
     # Exclude localhost from it, since localhost is in HostBlocker.WHITELISTED
     filtered_blocked_hosts = BLOCKLIST_HOSTS[1:]
-    blocklist = create_blocklist(tmpdir,
+    blocklist = create_blocklist(data_tmpdir,
                                  blocked_hosts=filtered_blocked_hosts,
                                  name='blocked-hosts',
                                  line_format='one_per_line')

--- a/tests/unit/browser/test_tab.py
+++ b/tests/unit/browser/test_tab.py
@@ -25,6 +25,8 @@ from qutebrowser.browser import browsertab
 from qutebrowser.keyinput import modeman
 from qutebrowser.utils import objreg
 
+pytestmark = pytest.mark.usefixtures('redirect_xdg_data')
+
 try:
     from PyQt5.QtWebKitWidgets import QWebView
 

--- a/tests/unit/browser/webkit/test_cookies.py
+++ b/tests/unit/browser/webkit/test_cookies.py
@@ -24,6 +24,8 @@ import pytest
 from qutebrowser.browser.webkit import cookies
 from qutebrowser.misc import lineparser
 
+pytestmark = pytest.mark.usefixtures('data_tmpdir')
+
 CONFIG_ALL_COOKIES = {'content': {'cookies-accept': 'all'}}
 CONFIG_NEVER_COOKIES = {'content': {'cookies-accept': 'never'}}
 CONFIG_COOKIES_ENABLED = {'content': {'cookies-store': True}}

--- a/tests/unit/browser/webkit/test_qt_javascript.py
+++ b/tests/unit/browser/webkit/test_qt_javascript.py
@@ -21,7 +21,6 @@
 
 
 import pytest
-import os
 
 from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5.QtWebKit import QWebSettings
@@ -65,18 +64,14 @@ def test_element_js_webkit(webview, js_enabled, expected):
     assert result == expected
 
 
+@pytest.mark.usefixtures('redirect_xdg_data')
 @pytest.mark.parametrize('js_enabled, expected', [(True, 2.0), (False, 2.0)])
-def test_simple_js_webengine(qtbot, webengineview, js_enabled, expected,
-                             data_tmpdir):
+def test_simple_js_webengine(qtbot, webengineview, js_enabled, expected):
     """With QtWebEngine, runJavaScript works even when JS is off."""
     # pylint: disable=no-name-in-module,useless-suppression
     # If we get there (because of the webengineview fixture) we can be certain
     # QtWebEngine is available
     from PyQt5.QtWebEngineWidgets import QWebEngineSettings
-    # runJavaScript will write to the data directory. As the path is determined
-    # by Qt and bypasses standarddir.data(), the data_tmpdir fixture is not
-    # enough -- we need to set XDG_DATA_HOME as well
-    os.putenv('XDG_DATA_HOME', str(data_tmpdir))
     webengineview.settings().setAttribute(QWebEngineSettings.JavascriptEnabled,
                                           js_enabled)
 

--- a/tests/unit/browser/webkit/test_qt_javascript.py
+++ b/tests/unit/browser/webkit/test_qt_javascript.py
@@ -21,6 +21,7 @@
 
 
 import pytest
+import os
 
 from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5.QtWebKit import QWebSettings
@@ -65,12 +66,17 @@ def test_element_js_webkit(webview, js_enabled, expected):
 
 
 @pytest.mark.parametrize('js_enabled, expected', [(True, 2.0), (False, 2.0)])
-def test_simple_js_webengine(qtbot, webengineview, js_enabled, expected):
+def test_simple_js_webengine(qtbot, webengineview, js_enabled, expected,
+                             data_tmpdir):
     """With QtWebEngine, runJavaScript works even when JS is off."""
     # pylint: disable=no-name-in-module,useless-suppression
     # If we get there (because of the webengineview fixture) we can be certain
     # QtWebEngine is available
     from PyQt5.QtWebEngineWidgets import QWebEngineSettings
+    # runJavaScript will write to the data directory. As the path is determined
+    # by Qt and bypasses standarddir.data(), the data_tmpdir fixture is not
+    # enough -- we need to set XDG_DATA_HOME as well
+    os.putenv('XDG_DATA_HOME', str(data_tmpdir))
     webengineview.settings().setAttribute(QWebEngineSettings.JavascriptEnabled,
                                           js_enabled)
 

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -35,8 +35,6 @@ from qutebrowser.config.parsers import keyconf
 from qutebrowser.commands import runners
 from qutebrowser.utils import objreg, standarddir
 
-pytestmark = pytest.mark.usefixtures('config_tmpdir')
-
 
 class TestConfigParser:
 
@@ -297,6 +295,7 @@ class TestKeyConfigParser:
         assert new == new_expected
 
 
+@pytest.mark.usefixtures('config_tmpdir')
 @pytest.mark.integration
 class TestDefaultConfig:
 

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -35,6 +35,8 @@ from qutebrowser.config.parsers import keyconf
 from qutebrowser.commands import runners
 from qutebrowser.utils import objreg, standarddir
 
+pytestmark = pytest.mark.usefixtures('config_tmpdir')
+
 
 class TestConfigParser:
 

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -33,8 +33,6 @@ from PyQt5.QtNetwork import QNetworkProxy
 from qutebrowser.config import configtypes, configexc
 from qutebrowser.utils import debug, utils
 
-pytestmark = pytest.mark.usefixtures('config_tmpdir')
-
 
 class Font(QFont):
 
@@ -1284,6 +1282,7 @@ def unrequired_class(**kwargs):
 
 
 @pytest.mark.usefixtures('qapp')
+@pytest.mark.usefixtures('config_tmpdir')
 class TestFileAndUserStyleSheet:
 
     """Test File/UserStyleSheet."""

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -33,6 +33,8 @@ from PyQt5.QtNetwork import QNetworkProxy
 from qutebrowser.config import configtypes, configexc
 from qutebrowser.utils import debug, utils
 
+pytestmark = pytest.mark.usefixtures('config_tmpdir')
+
 
 class Font(QFont):
 

--- a/tests/unit/config/test_configtypes_hypothesis.py
+++ b/tests/unit/config/test_configtypes_hypothesis.py
@@ -42,7 +42,7 @@ def gen_classes():
             yield member
 
 
-@pytest.mark.usefixtures('qapp')
+@pytest.mark.usefixtures('qapp', 'config_tmpdir')
 @pytest.mark.parametrize('klass', gen_classes())
 @hypothesis.given(strategies.text())
 @hypothesis.example('\x00')

--- a/tests/unit/utils/test_standarddir.py
+++ b/tests/unit/utils/test_standarddir.py
@@ -287,7 +287,6 @@ class TestCreatingDir:
         basedir = tmpdir / 'basedir'
         assert not basedir.exists()
         args = types.SimpleNamespace(basedir=str(basedir))
-        standarddir.init(None)
         standarddir.init(args)
 
         func = getattr(standarddir, typ)

--- a/tests/unit/utils/test_standarddir.py
+++ b/tests/unit/utils/test_standarddir.py
@@ -195,8 +195,10 @@ class TestArguments:
         standarddir.init(args)
         assert standarddir.data() == testcase.expected
 
-    def test_confdir_none(self):
+    def test_confdir_none(self, mocker):
         """Test --confdir with None given."""
+        # patch makedirs to a noop so we don't really create a directory
+        mocker.patch('qutebrowser.utils.standarddir.os.makedirs')
         args = types.SimpleNamespace(confdir=None, cachedir=None, datadir=None,
                                      basedir=None)
         standarddir.init(args)
@@ -326,12 +328,16 @@ class TestSystemData:
         assert standarddir.system_data() == "/usr/share/qutebrowser"
 
     @pytest.mark.linux
-    def test_system_datadir_not_exist_linux(self, monkeypatch):
+    def test_system_datadir_not_exist_linux(self, monkeypatch, tmpdir):
         """Test that system-wide path isn't used on linux if path not exist."""
+        args = types.SimpleNamespace(basedir=str(tmpdir))
+        standarddir.init(args)
         monkeypatch.setattr(os.path, 'exists', lambda path: False)
         assert standarddir.system_data() == standarddir.data()
 
-    def test_system_datadir_unsupportedos(self, monkeypatch):
+    def test_system_datadir_unsupportedos(self, monkeypatch, tmpdir):
         """Test that system-wide path is not used on non-Linux OS."""
+        args = types.SimpleNamespace(basedir=str(tmpdir))
+        standarddir.init(args)
         monkeypatch.setattr('sys.platform', "potato")
         assert standarddir.system_data() == standarddir.data()

--- a/tests/unit/utils/test_standarddir.py
+++ b/tests/unit/utils/test_standarddir.py
@@ -52,15 +52,15 @@ def no_cachedir_tag(monkeypatch):
                         lambda: None)
 
 
-@pytest.yield_fixture(autouse=True)
-@pytest.mark.usefixtures('no_cachedir_tag')
-def reset_standarddir():
+@pytest.yield_fixture
+def reset_standarddir(no_cachedir_tag):
     """Clean up standarddir arguments before and after each test."""
     standarddir.init(None)
     yield
     standarddir.init(None)
 
 
+@pytest.mark.usefixtures('reset_standarddir')
 @pytest.mark.parametrize('data_subdir, config_subdir, expected', [
     ('foo', 'foo', 'foo/data'),
     ('foo', 'bar', 'foo'),
@@ -80,6 +80,7 @@ def test_get_fake_windows_equal_dir(data_subdir, config_subdir, expected,
     assert standarddir.data() == expected
 
 
+@pytest.mark.usefixtures('reset_standarddir')
 class TestWritableLocation:
 
     """Tests for _writable_location."""
@@ -100,7 +101,7 @@ class TestWritableLocation:
         assert '\\' in loc
 
 
-@pytest.mark.usefixtures('no_cachedir_tag')
+@pytest.mark.usefixtures('reset_standarddir')
 class TestStandardDir:
 
     """Tests for standarddir."""
@@ -159,7 +160,7 @@ class TestStandardDir:
 DirArgTest = collections.namedtuple('DirArgTest', 'arg, expected')
 
 
-@pytest.mark.usefixtures('no_cachedir_tag')
+@pytest.mark.usefixtures('reset_standarddir')
 class TestArguments:
 
     """Tests with confdir/cachedir/datadir arguments."""
@@ -274,6 +275,7 @@ class TestInitCacheDirTag:
         assert not tmpdir.listdir()
 
 
+@pytest.mark.usefixtures('reset_standarddir')
 class TestCreatingDir:
 
     """Make sure inexistent directories are created properly."""
@@ -317,6 +319,7 @@ class TestCreatingDir:
         func()
 
 
+@pytest.mark.usefixtures('reset_standarddir')
 class TestSystemData:
 
     """Test system data path."""

--- a/tests/unit/utils/test_standarddir.py
+++ b/tests/unit/utils/test_standarddir.py
@@ -332,16 +332,18 @@ class TestSystemData:
         assert standarddir.system_data() == "/usr/share/qutebrowser"
 
     @pytest.mark.linux
-    def test_system_datadir_not_exist_linux(self, monkeypatch, tmpdir):
+    def test_system_datadir_not_exist_linux(self, monkeypatch, tmpdir,
+                                            fake_args):
         """Test that system-wide path isn't used on linux if path not exist."""
-        args = types.SimpleNamespace(basedir=str(tmpdir))
-        standarddir.init(args)
+        fake_args.basedir = str(tmpdir)
+        standarddir.init(fake_args)
         monkeypatch.setattr(os.path, 'exists', lambda path: False)
         assert standarddir.system_data() == standarddir.data()
 
-    def test_system_datadir_unsupportedos(self, monkeypatch, tmpdir):
+    def test_system_datadir_unsupportedos(self, monkeypatch, tmpdir,
+                                          fake_args):
         """Test that system-wide path is not used on non-Linux OS."""
-        args = types.SimpleNamespace(basedir=str(tmpdir))
-        standarddir.init(args)
+        fake_args.basedir = str(tmpdir)
+        standarddir.init(fake_args)
         monkeypatch.setattr('sys.platform', "potato")
         assert standarddir.system_data() == standarddir.data()

--- a/tests/unit/utils/test_standarddir.py
+++ b/tests/unit/utils/test_standarddir.py
@@ -275,7 +275,6 @@ class TestInitCacheDirTag:
         assert not tmpdir.listdir()
 
 
-@pytest.mark.usefixtures('reset_standarddir')
 class TestCreatingDir:
 
     """Make sure inexistent directories are created properly."""
@@ -288,6 +287,7 @@ class TestCreatingDir:
         basedir = tmpdir / 'basedir'
         assert not basedir.exists()
         args = types.SimpleNamespace(basedir=str(basedir))
+        standarddir.init(None)
         standarddir.init(args)
 
         func = getattr(standarddir, typ)
@@ -298,6 +298,7 @@ class TestCreatingDir:
         if os.name == 'posix':
             assert basedir.stat().mode & 0o777 == 0o700
 
+    @pytest.mark.usefixtures('reset_standarddir')
     @pytest.mark.parametrize('typ', DIR_TYPES)
     def test_exists_race_condition(self, mocker, tmpdir, typ):
         """Make sure there can't be a TOCTOU issue when creating the file.


### PR DESCRIPTION
`~/.config/qute_test` and `~/.local/share/qute_test` kept showing up on disk.
They really mess with my tab completion, but took me a while to figure out it was these unittests, as I just kept assuming I forgot to delete them. :smile:.

Also, the fixture to prevent creation of `~/.cache/qute_test` wasn't working because `usefixtures` doesn't work on fixture, as a past version of you [pointed out](https://github.com/pytest-dev/pytest/issues/1014).
