### PR TITLE
Add :print --pdf flag to skip printing dialog

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -227,6 +227,7 @@ Contributors, sorted by the number of commits in descending order:
 * Matthias Lisin
 * Marcel Schilling
 * Johannes Martinsson
+* Jeremy Kaplan
 * Jean-Christophe Petkovich
 * Jay Kamat
 * Helen Sherwood-Taylor

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -487,12 +487,13 @@ If the pasted text contains newlines, each line gets opened in its own tab.
 
 [[print]]
 === print
-Syntax: +:print [*--preview*]+
+Syntax: +:print [*--preview*] [*--pdf* 'file']+
 
 Print the current/[count]th tab.
 
 ==== optional arguments
 * +*-p*+, +*--preview*+: Show preview instead of printing.
+* +*-f*+, +*--pdf*+: The file path to write the PDF to.
 
 ==== count
 The tab index to print.

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -301,7 +301,7 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', name='print',
                        scope='window')
     @cmdutils.argument('count', count=True)
-    @cmdutils.argument('pdf', flag='f')
+    @cmdutils.argument('pdf', flag='f', metavar='file')
     def printpage(self, preview=False, count=None, *, pdf=None):
         """Print the current/[count]th tab.
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -31,7 +31,7 @@ from PyQt5.QtWebKit import QWebSettings
 from PyQt5.QtWidgets import QApplication, QTabBar
 from PyQt5.QtCore import Qt, QUrl, QEvent
 from PyQt5.QtGui import QKeyEvent
-from PyQt5.QtPrintSupport import QPrintDialog, QPrintPreviewDialog
+from PyQt5.QtPrintSupport import QPrintDialog, QPrinter, QPrintPreviewDialog
 from PyQt5.QtWebKitWidgets import QWebPage
 import pygments
 import pygments.lexers
@@ -301,12 +301,14 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', name='print',
                        scope='window')
     @cmdutils.argument('count', count=True)
-    def printpage(self, preview=False, count=None):
+    @cmdutils.argument('pdf', flag='f')
+    def printpage(self, preview=False, count=None, *, pdf=None):
         """Print the current/[count]th tab.
 
         Args:
             preview: Show preview instead of printing.
             count: The tab index to print, or None.
+            pdf: The file path to write the PDF to.
         """
         if not qtutils.check_print_compat():
             # WORKAROUND (remove this when we bump the requirements to 5.3.0)
@@ -322,6 +324,14 @@ class CommandDispatcher:
                                     Qt.WindowMinimizeButtonHint)
                 diag.paintRequested.connect(tab.print)
                 diag.exec_()
+            elif pdf:
+                pdf = os.path.expanduser(pdf)
+                directory = os.path.dirname(pdf)
+                if directory and not os.path.exists(directory):
+                    os.mkdir(directory)
+                printer = QPrinter()
+                printer.setOutputFileName(pdf)
+                tab.print(printer)
             else:
                 diag = QPrintDialog()
                 diag.setAttribute(Qt.WA_DeleteOnClose)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -332,6 +332,7 @@ class CommandDispatcher:
                 printer = QPrinter()
                 printer.setOutputFileName(pdf)
                 tab.print(printer)
+                log.misc.debug("Print to file: {}".format(pdf))
             else:
                 diag = QPrintDialog()
                 diag.setAttribute(Qt.WA_DeleteOnClose)

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -179,7 +179,7 @@ def set_setting(quteproc, httpbin, sect, opt, value):
 
 
 @bdd.when(bdd.parsers.parse("I run {command}"))
-def run_command(quteproc, httpbin, command):
+def run_command(quteproc, httpbin, tmpdir, command):
     """Run a qutebrowser command.
 
     The suffix "with count ..." can be used to pass a count to the command.
@@ -199,6 +199,7 @@ def run_command(quteproc, httpbin, command):
 
     command = command.replace('(port)', str(httpbin.port))
     command = command.replace('(testdata)', utils.abs_datapath())
+    command = command.replace('(tmpdir)', str(tmpdir))
 
     quteproc.send_cmd(command, count=count, invalid=invalid)
 

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -339,6 +339,13 @@ Feature: Various utility commands.
         And I run :debug-pyeval QApplication.instance().activeModalWidget().close()
         Then no crash should happen
 
+    Scenario: print pdf
+        Given a new tmpdir
+        When I open data/hello.txt
+        And I run :print --pdf (tmpdir)/hello.pdf
+        And I wait for "Print to file: *" in the log or skip the test
+        Then the file hello.pdf should exist in the tmpdir
+
     # :pyeval
 
     Scenario: Running :pyeval

--- a/tests/end2end/features/test_misc_bdd.py
+++ b/tests/end2end/features/test_misc_bdd.py
@@ -73,3 +73,14 @@ def check_cookie(quteproc, name, value):
     data = json.loads(content)
     print(data)
     assert data['cookies'][name] == value
+
+
+@bdd.given(bdd.parsers.parse('a new tmpdir'))
+def tmpdir(tmpdir_factory):
+    return tmpdir_factory.mktemp('tmpdir')
+
+
+@bdd.then(bdd.parsers.parse('the file {filename} should exist in the tmpdir'))
+def file_exists(quteproc, tmpdir, filename):
+    path = tmpdir / filename
+    assert os.path.exists(str(path))


### PR DESCRIPTION
I've given #1630 a try, and I hope it's up to quality standards. 

I'm having a lot of trouble writing a test for it. I've never used pytest or BDD, but I figure the strategy would be to open up `hello.txt` or something, run `:print --pdf tmp/dir/hello.pdf`, and wait for the pdf to show up. I can keep trying if the test is necessary, but I'll probably need a few hints.