### PR TITLE
fix #1657

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -201,6 +201,7 @@ class HintManager(QObject):
                                     window=self._win_id)
         message_bridge.maybe_reset_text(text)
         self._context = None
+        self._filterstr = None
 
     def _hint_strings(self, elems):
         """Calculate the hint strings for elems.


### PR DESCRIPTION
The _filterstr attribute was not cleaned up properly and persisted
between hintings. In this case, it was set to something representing the
Escape key.