### PR TITLE
Issue 1033 bookmark display

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -122,8 +122,6 @@ Save the current page as a bookmark, or a specific url.
 
 If no url and title are provided, then save the current page as a bookmark. If a url and title have been provided, then save the given url as a bookmark with the provided title.
 
-You can view all saved bookmarks on the link:qute://bookmarks[bookmarks page].
-
 ==== positional arguments
 * +'url'+: url to save as a bookmark. If None, use url of current page.
 * +'title'+: title of the new bookmark.
@@ -513,8 +511,6 @@ The tab index to print.
 Syntax: +:quickmark-add 'url' 'name'+
 
 Add a new quickmark.
-
-You can view all saved quickmarks on the link:qute://bookmarks[bookmarks page].
 
 ==== positional arguments
 * +'url'+: The url to add as quickmark.

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -122,6 +122,8 @@ Save the current page as a bookmark, or a specific url.
 
 If no url and title are provided, then save the current page as a bookmark. If a url and title have been provided, then save the given url as a bookmark with the provided title.
 
+You can view all saved bookmarks on the link:qute://bookmarks[bookmarks page].
+
 ==== positional arguments
 * +'url'+: url to save as a bookmark. If None, use url of current page.
 * +'title'+: title of the new bookmark.
@@ -511,6 +513,8 @@ The tab index to print.
 Syntax: +:quickmark-add 'url' 'name'+
 
 Add a new quickmark.
+
+You can view all saved quickmarks on the link:qute://bookmarks[bookmarks page].
 
 ==== positional arguments
 * +'url'+: The url to add as quickmark.

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1104,6 +1104,9 @@ class CommandDispatcher:
         If a url and title have been provided, then save the given url as
         a bookmark with the provided title.
 
+        You can view all saved bookmarks on the
+        link:qute://bookmarks[bookmarks page].
+
         Args:
             url: url to save as a bookmark. If None, use url of current page.
             title: title of the new bookmark.

--- a/qutebrowser/browser/urlmarks.py
+++ b/qutebrowser/browser/urlmarks.py
@@ -178,6 +178,9 @@ class QuickmarkManager(UrlMarkManager):
     def quickmark_add(self, win_id, url, name):
         """Add a new quickmark.
 
+        You can view all saved quickmarks on the
+        link:qute://bookmarks[bookmarks page].
+
         Args:
             win_id: The window ID to display the errors in.
             url: The url to add as quickmark.

--- a/qutebrowser/browser/webkit/network/qutescheme.py
+++ b/qutebrowser/browser/webkit/network/qutescheme.py
@@ -267,8 +267,8 @@ def qute_pdfjs(_win_id, request):
 def qute_bookmarks(_win_id, request):
     """Handler for qute:bookmarks. Show a list of all quickmarks / bookmarks"""
 
-    bookmarks  = sorted(objreg.get('bookmark-manager').marks.items(),
-                        key=lambda x: x[1])  # Sort by title
+    bookmarks = sorted(objreg.get('bookmark-manager').marks.items(),
+                       key=lambda x: x[1])  # Sort by title
     quickmarks = sorted(objreg.get('quickmark-manager').marks.items(),
                         key=lambda x: x[0])  # Sort by name
 

--- a/qutebrowser/browser/webkit/network/qutescheme.py
+++ b/qutebrowser/browser/webkit/network/qutescheme.py
@@ -267,8 +267,10 @@ def qute_pdfjs(_win_id, request):
 def qute_bookmarks(_win_id, request):
     """Handler for qute:bookmarks. Show a list of all quickmarks / bookmarks"""
 
-    bookmarks  = objreg.get('bookmark-manager').marks.items()
-    quickmarks = objreg.get('quickmark-manager').marks.items()
+    bookmarks  = sorted(objreg.get('bookmark-manager').marks.items(),
+                        key=lambda x: x[1])  # Sort by title
+    quickmarks = sorted(objreg.get('quickmark-manager').marks.items(),
+                        key=lambda x: x[0])  # Sort by name
 
     html = jinja.render('bookmarks.html',
                         title='Bookmarks',

--- a/qutebrowser/browser/webkit/network/qutescheme.py
+++ b/qutebrowser/browser/webkit/network/qutescheme.py
@@ -261,3 +261,17 @@ def qute_pdfjs(_win_id, request):
             "pdfjs resource requested but not found: {}".format(e.path))
         raise QuteSchemeError("Can't find pdfjs resource '{}'".format(e.path),
                               QNetworkReply.ContentNotFoundError)
+
+
+@add_handler('bookmarks')
+def qute_bookmarks(_win_id, request):
+    """Handler for qute:bookmarks. Show a list of all quickmarks / bookmarks"""
+
+    bookmarks  = objreg.get('bookmark-manager').marks.items()
+    quickmarks = objreg.get('quickmark-manager').marks.items()
+
+    html = jinja.render('bookmarks.html',
+                        title='Bookmarks',
+                        bookmarks=bookmarks,
+                        quickmarks=quickmarks)
+    return html.encode('UTF-8', errors='xmlcharrefreplace')

--- a/qutebrowser/browser/webkit/network/qutescheme.py
+++ b/qutebrowser/browser/webkit/network/qutescheme.py
@@ -264,9 +264,8 @@ def qute_pdfjs(_win_id, request):
 
 
 @add_handler('bookmarks')
-def qute_bookmarks(_win_id, request):
-    """Handler for qute:bookmarks. Show a list of all quickmarks / bookmarks"""
-
+def qute_bookmarks(_win_id, _request):
+    """Handler for qute:bookmarks. Display all quickmarks / bookmarks."""
     bookmarks = sorted(objreg.get('bookmark-manager').marks.items(),
                        key=lambda x: x[1])  # Sort by title
     quickmarks = sorted(objreg.get('quickmark-manager').marks.items(),

--- a/qutebrowser/html/bookmarks.html
+++ b/qutebrowser/html/bookmarks.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+
+{% block script %}
+var win_id = {{ win_id }};
+var cset = function(section, option, el) {
+  value = el.value;
+  window.qute.set(win_id, section, option, value);
+}
+{% endblock %}
+
+{% block style %}
+table { border: 1px solid grey; border-collapse: collapse; width: 100%;}
+pre { margin: 2px; }
+th, td { border: 1px solid grey; padding: 0px 5px; }
+th { background: lightgrey; }
+th pre { color: grey; text-align: left; }
+.noscript, .noscript-text { color:red; }
+.noscript-text { margin-bottom: 5cm; }
+h4 { line-height: 1.2em; }
+{% endblock %}
+
+{% block content %}
+<noscript><h1 class="noscript">View Only</h1><p class="noscript-text">Changing settings requires javascript to be enabled!</p></noscript>
+
+<table>
+    <tr>
+        <th><h3>Bookmark</h3></th>
+        <th><h3>URL</h3></th>
+    </tr>
+    {% for url, title in bookmarks %}
+    <tr>
+        <td><a href="{{url}}">{{title}}</a></td>
+        <td>{{url}}</td>
+    </tr>
+    {% endfor %}
+    <tr>
+        <th><h3>Quickmark</h3></th>
+        <th><h3>URL</h3></th>
+    </tr>
+    {% for name, url in quickmarks %}
+    <tr>
+        <td><a href="{{url}}">{{name}}</a></td>
+        <td>{{url}}</td>
+    </tr>
+    {% endfor %}
+</table>
+
+{% endblock %}

--- a/qutebrowser/html/bookmarks.html
+++ b/qutebrowser/html/bookmarks.html
@@ -1,26 +1,12 @@
 {% extends "base.html" %}
 
-{% block script %}
-var win_id = {{ win_id }};
-var cset = function(section, option, el) {
-  value = el.value;
-  window.qute.set(win_id, section, option, value);
-}
-{% endblock %}
-
 {% block style %}
 table { border: 1px solid grey; border-collapse: collapse; width: 100%;}
-pre { margin: 2px; }
 th, td { border: 1px solid grey; padding: 0px 5px; }
 th { background: lightgrey; }
-th pre { color: grey; text-align: left; }
-.noscript, .noscript-text { color:red; }
-.noscript-text { margin-bottom: 5cm; }
-h4 { line-height: 1.2em; }
 {% endblock %}
 
 {% block content %}
-<noscript><h1 class="noscript">View Only</h1><p class="noscript-text">Changing settings requires javascript to be enabled!</p></noscript>
 
 <table>
     <tr>

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -186,3 +186,16 @@ Feature: quickmarks and bookmarks
         When I run :quickmark-add http://localhost:(port)/data/numbers/15.txt fifteen
         And I run :quickmark-del fifteen
         Then the quickmark file should not contain "fourteen http://localhost:*/data/numbers/15.txt "
+
+    Scenario: Listing quickmarks
+        When I run :quickmark-add http://localhost:(port)/data/numbers/15.txt fifteen
+        And  I run :quickmark-add http://localhost:(port)/data/numbers/14.txt fourteen
+        And I open qute:bookmarks
+        Then the page should contain the plaintext "fifteen"
+        And  the page should contain the plaintext "fourteen"
+
+    Scenario: Listing bookmarks
+        When I open data/title.html
+        And I run :bookmark-add
+        And I open qute:bookmarks
+        Then the page should contain the plaintext "Test title"

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -189,10 +189,10 @@ Feature: quickmarks and bookmarks
 
     Scenario: Listing quickmarks
         When I run :quickmark-add http://localhost:(port)/data/numbers/15.txt fifteen
-        And  I run :quickmark-add http://localhost:(port)/data/numbers/14.txt fourteen
+        And I run :quickmark-add http://localhost:(port)/data/numbers/14.txt fourteen
         And I open qute:bookmarks
         Then the page should contain the plaintext "fifteen"
-        And  the page should contain the plaintext "fourteen"
+        And the page should contain the plaintext "fourteen"
 
     Scenario: Listing bookmarks
         When I open data/title.html


### PR DESCRIPTION
There is a new page now, qute:bookmarks that will display all bookmarks and quickmarks. It's still missing a search / filter feature, but you can use the built-in search / navigation just as easily for now.