### PR TITLE
More completion tests

### DIFF
--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -19,7 +19,7 @@
 
 """Completer attached to a CompletionView."""
 
-from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject, QTimer
+from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject, QTimer, QItemSelection
 
 from qutebrowser.config import config
 from qutebrowser.commands import cmdutils, runners
@@ -249,7 +249,8 @@ class Completer(QObject):
         else:
             return s
 
-    def selection_changed(self, selected, _deselected):
+    @pyqtSlot(QItemSelection, QItemSelection)
+    def on_selection_changed(self, selected, _deselected):
         """Change the completed part if a new item was selected.
 
         Called from the views selectionChanged method.

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -355,7 +355,7 @@ class Completer(QObject):
             completion.show()
 
     def _split(self, keep=False):
-        """Get the text _split up in parts.
+        """Get the text split up in parts.
 
         Args:
             keep: Whether to keep special chars and whitespace.

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -241,8 +241,8 @@ class Completer(QObject):
         else:
             return s
 
-    @pyqtSlot(QItemSelection, QItemSelection)
-    def on_selection_changed(self, selected, _deselected):
+    @pyqtSlot(QItemSelection)
+    def on_selection_changed(self, selected):
         """Change the completed part if a new item was selected.
 
         Called from the views selectionChanged method.

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -42,14 +42,7 @@ class Completer(QObject):
         _last_text: The old command text so we avoid double completion updates.
         _signals_connected: Whether the signals are connected to update the
                             completion when the command widget requests that.
-
-    Signals:
-        next_prev_item: Emitted to select the next/previous item in the
-                        completion.
-                        arg0: True for the previous item, False for the next.
     """
-
-    next_prev_item = pyqtSignal(bool)
 
     def __init__(self, cmd, win_id, parent=None):
         super().__init__(parent)
@@ -258,6 +251,7 @@ class Completer(QObject):
             selected: New selection.
             _deselected: Previous selection.
         """
+        self._open_completion_if_needed()
         indexes = selected.indexes()
         if not indexes:
             return
@@ -470,17 +464,3 @@ class Completer(QObject):
         # We also want to update the cursor part and emit _update_completion
         # here, but that's already done for us by cursorPositionChanged
         # anyways, so we don't need to do it twice.
-
-    @cmdutils.register(instance='completer', hide=True,
-                       modes=[usertypes.KeyMode.command], scope='window')
-    def completion_item_prev(self):
-        """Select the previous completion item."""
-        self._open_completion_if_needed()
-        self.next_prev_item.emit(True)
-
-    @cmdutils.register(instance='completer', hide=True,
-                       modes=[usertypes.KeyMode.command], scope='window')
-    def completion_item_next(self):
-        """Select the next completion item."""
-        self._open_completion_if_needed()
-        self.next_prev_item.emit(False)

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -19,7 +19,7 @@
 
 """Completer attached to a CompletionView."""
 
-from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject, QTimer, QItemSelection
+from PyQt5.QtCore import pyqtSlot, QObject, QTimer, QItemSelection
 
 from qutebrowser.config import config
 from qutebrowser.commands import cmdutils, runners

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -125,8 +125,7 @@ class Completer(QObject):
 
     def _model(self):
         """Convenience method to get the current completion model."""
-        completion = objreg.get('completion', scope='window',
-                                window=self._win_id)
+        completion = self.parent()
         return completion.model()
 
     def _get_completion_model(self, completion, parts, cursor_part):
@@ -315,8 +314,7 @@ class Completer(QObject):
             self._ignore_change = False
             return
 
-        completion = objreg.get('completion', scope='window',
-                                window=self._win_id)
+        completion = self.parent()
 
         if self._cmd.prefix() != ':':
             # This is a search or gibberish, so we don't need to complete

--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -104,7 +104,7 @@ class CompletionView(QTreeView):
     """
 
     resize_completion = pyqtSignal()
-    selection_changed = pyqtSignal(QItemSelection, QItemSelection)
+    selection_changed = pyqtSignal(QItemSelection)
 
     def __init__(self, win_id, parent=None):
         super().__init__(parent)
@@ -255,7 +255,7 @@ class CompletionView(QTreeView):
     def selectionChanged(self, selected, deselected):
         """Extend selectionChanged to call completers selection_changed."""
         super().selectionChanged(selected, deselected)
-        self.selection_changed.emit(selected, deselected)
+        self.selection_changed.emit(selected)
 
     def resizeEvent(self, e):
         """Extend resizeEvent to adjust column size."""

--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -28,7 +28,7 @@ from PyQt5.QtCore import (pyqtSlot, pyqtSignal, Qt, QItemSelectionModel,
                           QItemSelection)
 
 from qutebrowser.config import config, style
-from qutebrowser.completion import completiondelegate, completer
+from qutebrowser.completion import completiondelegate
 from qutebrowser.completion.models import base
 from qutebrowser.utils import qtutils, objreg, utils, usertypes
 from qutebrowser.commands import cmdexc, cmdutils
@@ -187,7 +187,7 @@ class CompletionView(QTreeView):
         Select the previous/next item and write the new text to the
         statusbar.
 
-        Called from the Completer's next_prev_item signal.
+        Helper for completion_item_next and completion_item_prev.
 
         Args:
             prev: True for prev item, False for next one.

--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -181,8 +181,7 @@ class CompletionView(QTreeView):
                 # Item is a real item, not a category header -> success
                 return idx
 
-    @pyqtSlot(bool)
-    def on_next_prev_item(self, prev):
+    def _next_prev_item(self, prev):
         """Handle a tab press for the CompletionView.
 
         Select the previous/next item and write the new text to the
@@ -193,9 +192,6 @@ class CompletionView(QTreeView):
         Args:
             prev: True for prev item, False for next one.
         """
-        if not self.isVisible():
-            # No completion running at the moment, ignore keypress
-            return
         idx = self._next_idx(prev)
         qtutils.ensure_valid(idx)
         self.selectionModel().setCurrentIndex(
@@ -273,6 +269,18 @@ class CompletionView(QTreeView):
         if scrollbar is not None:
             scrollbar.setValue(scrollbar.minimum())
         super().showEvent(e)
+
+    @cmdutils.register(instance='completion', hide=True,
+                       modes=[usertypes.KeyMode.command], scope='window')
+    def completion_item_prev(self):
+        """Select the previous completion item."""
+        self._next_prev_item(True)
+
+    @cmdutils.register(instance='completion', hide=True,
+                       modes=[usertypes.KeyMode.command], scope='window')
+    def completion_item_next(self):
+        """Select the next completion item."""
+        self._next_prev_item(False)
 
     @cmdutils.register(instance='completion', hide=True,
                        modes=[usertypes.KeyMode.command], scope='window')

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -32,7 +32,7 @@ from qutebrowser.config import config
 from qutebrowser.utils import message, log, usertypes, qtutils, objreg, utils
 from qutebrowser.mainwindow import tabbedbrowser
 from qutebrowser.mainwindow.statusbar import bar
-from qutebrowser.completion import completionwidget
+from qutebrowser.completion import completionwidget, completer
 from qutebrowser.keyinput import modeman
 from qutebrowser.browser import commands, downloadview, hints
 from qutebrowser.browser.webkit import downloads
@@ -158,6 +158,15 @@ class MainWindow(QWidget):
         self._downloadview.show()
 
         self._completion = completionwidget.CompletionView(self.win_id, self)
+        cmd = objreg.get('status-command', scope='window', window=self.win_id)
+        completer_obj = completer.Completer(cmd, self.win_id, self._completion)
+        completer_obj.next_prev_item.connect(self._completion.on_next_prev_item)
+        self._completion.selection_changed.connect(
+            completer_obj.on_selection_changed)
+        objreg.register('completer', completer_obj, scope='window',
+                        window=self.win_id)
+        objreg.register('completion', self._completion, scope='window',
+                        window=self.win_id)
 
         self._commandrunner = runners.CommandRunner(self.win_id,
                                                     partial_match=True)

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -131,23 +131,13 @@ class MainWindow(QWidget):
         self._vbox.setContentsMargins(0, 0, 0, 0)
         self._vbox.setSpacing(0)
 
-        log.init.debug("Initializing downloads...")
-        download_manager = downloads.DownloadManager(self.win_id, self)
-        objreg.register('download-manager', download_manager, scope='window',
-                        window=self.win_id)
-
+        self._init_downloadmanager()
         self._downloadview = downloadview.DownloadView(self.win_id)
 
         self.tabbed_browser = tabbedbrowser.TabbedBrowser(self.win_id)
         objreg.register('tabbed-browser', self.tabbed_browser, scope='window',
                         window=self.win_id)
-        dispatcher = commands.CommandDispatcher(self.win_id,
-                                                self.tabbed_browser)
-        objreg.register('command-dispatcher', dispatcher, scope='window',
-                        window=self.win_id)
-        self.tabbed_browser.destroyed.connect(
-            functools.partial(objreg.delete, 'command-dispatcher',
-                              scope='window', window=self.win_id))
+        self._init_command_dispatcher()
 
         # We need to set an explicit parent for StatusBar because it does some
         # show/hide magic immediately which would mean it'd show up as a
@@ -157,13 +147,7 @@ class MainWindow(QWidget):
         self._add_widgets()
         self._downloadview.show()
 
-        self._completion = completionwidget.CompletionView(self.win_id, self)
-        cmd = objreg.get('status-command', scope='window', window=self.win_id)
-        completer_obj = completer.Completer(cmd, self.win_id, self._completion)
-        self._completion.selection_changed.connect(
-            completer_obj.on_selection_changed)
-        objreg.register('completion', self._completion, scope='window',
-                        window=self.win_id)
+        self._init_completion()
 
         self._commandrunner = runners.CommandRunner(self.win_id,
                                                     partial_match=True)
@@ -195,6 +179,30 @@ class MainWindow(QWidget):
             self.setCursor(Qt.BlankCursor)
 
         objreg.get("app").new_window.emit(self)
+
+    def _init_downloadmanager(self):
+        log.init.debug("Initializing downloads...")
+        download_manager = downloads.DownloadManager(self.win_id, self)
+        objreg.register('download-manager', download_manager, scope='window',
+                        window=self.win_id)
+
+    def _init_completion(self):
+        self._completion = completionwidget.CompletionView(self.win_id, self)
+        cmd = objreg.get('status-command', scope='window', window=self.win_id)
+        completer_obj = completer.Completer(cmd, self.win_id, self._completion)
+        self._completion.selection_changed.connect(
+            completer_obj.on_selection_changed)
+        objreg.register('completion', self._completion, scope='window',
+                        window=self.win_id)
+
+    def _init_command_dispatcher(self):
+        dispatcher = commands.CommandDispatcher(self.win_id,
+                                                self.tabbed_browser)
+        objreg.register('command-dispatcher', dispatcher, scope='window',
+                        window=self.win_id)
+        self.tabbed_browser.destroyed.connect(
+            functools.partial(objreg.delete, 'command-dispatcher',
+                              scope='window', window=self.win_id))
 
     def __repr__(self):
         return utils.get_repr(self)

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -160,11 +160,8 @@ class MainWindow(QWidget):
         self._completion = completionwidget.CompletionView(self.win_id, self)
         cmd = objreg.get('status-command', scope='window', window=self.win_id)
         completer_obj = completer.Completer(cmd, self.win_id, self._completion)
-        completer_obj.next_prev_item.connect(self._completion.on_next_prev_item)
         self._completion.selection_changed.connect(
             completer_obj.on_selection_changed)
-        objreg.register('completer', completer_obj, scope='window',
-                        window=self.win_id)
         objreg.register('completion', self._completion, scope='window',
                         window=self.win_id)
 

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -275,6 +275,16 @@ def completion_widget_stub(win_registry):
     objreg.delete('completion', scope='window', window=0)
 
 
+@pytest.yield_fixture
+def status_command_stub(stubs, qtbot, win_registry):
+    """Fixture which provides a fake status-command object."""
+    cmd = stubs.StatusBarCommandStub()
+    objreg.register('status-command', cmd, scope='window', window=0)
+    qtbot.addWidget(cmd)
+    yield cmd
+    objreg.delete('status-command', scope='window', window=0)
+
+
 @pytest.fixture(scope='session')
 def stubs():
     """Provide access to stub objects useful for testing."""

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -268,14 +268,6 @@ def app_stub(stubs):
 
 
 @pytest.yield_fixture
-def completion_widget_stub(win_registry):
-    stub = unittest.mock.Mock()
-    objreg.register('completion', stub, scope='window', window=0)
-    yield stub
-    objreg.delete('completion', scope='window', window=0)
-
-
-@pytest.yield_fixture
 def status_command_stub(stubs, qtbot, win_registry):
     """Fixture which provides a fake status-command object."""
     cmd = stubs.StatusBarCommandStub()

--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -413,7 +413,7 @@ class FakeConfigType:
         self.complete = lambda: [(val, '') for val in valid_values]
 
 
-class FakeStatusbarCommand(QLineEdit):
+class StatusBarCommandStub(QLineEdit):
 
     """Stub for the statusbar command prompt."""
 

--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -381,6 +381,28 @@ class FakeTimer(QObject):
         return self._started
 
 
+class InstaTimer(QObject):
+
+    """Stub for a QTimer that fires instantly on start().
+
+    Useful to test a time-based event without inserting an artificial delay.
+    """
+
+    timeout = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    def start(self):
+        self.timeout.emit()
+
+    def setSingleShot(self, yes):
+        pass
+
+    def setInterval(self, interval):
+        pass
+
+
 class FakeConfigType:
 
     """A stub to provide valid_values for typ attribute of a SettingValue."""

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -48,8 +48,10 @@ def cmd(stubs, qtbot):
 
 
 @pytest.fixture
-def completer_obj(qtbot, cmd, config_stub):
+def completer_obj(qtbot, cmd, config_stub, monkeypatch, stubs):
     """Create the completer used for testing."""
+    monkeypatch.setattr('qutebrowser.completion.completer.QTimer',
+        stubs.InstaTimer)
     config_stub.data = {'completion': {'auto-open': False}}
     return completer.Completer(cmd, 0)
 
@@ -162,7 +164,7 @@ def test_update_completion(txt, expected, cmd, completer_obj,
     """Test setting the completion widget's model based on command text."""
     # this test uses | as a placeholder for the current cursor position
     _set_cmd_prompt(cmd, txt)
-    completer_obj.update_completion()
+    completer_obj.schedule_completion_update()
     if expected is None:
         assert not completion_widget_stub.set_model.called
     else:

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -193,10 +193,10 @@ def test_completion_item_next(completer_obj, status_command_stub,
     (':foo |', '', True, 1, ":foo '' |"),
     (':foo |', None, True, 1, ":foo |"),
 ])
-def test_selection_changed(before, newtxt, count, quick_complete, after,
+def test_on_selection_changed(before, newtxt, count, quick_complete, after,
                            completer_obj, status_command_stub,
                            completion_widget_stub, config_stub):
-    """Test that change_completed_part modifies the cmd text properly.
+    """Test that on_selection_changed modifies the cmd text properly.
 
     The | represents the current cursor position in the cmd prompt.
     If quick-complete is True and there is only 1 completion (count == 1),
@@ -213,6 +213,6 @@ def test_selection_changed(before, newtxt, count, quick_complete, after,
     _set_cmd_prompt(status_command_stub, before)
     # schedule_completion_update is needed to pick up the cursor position
     completer_obj.schedule_completion_update()
-    completer_obj.selection_changed(selection, None)
+    completer_obj.on_selection_changed(selection, None)
     model.data.assert_called_with(indexes[0])
     _validate_cmd_prompt(status_command_stub, after)

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -219,7 +219,8 @@ def test_selection_changed(before, newtxt, count, quick_complete, after,
     selection.indexes = unittest.mock.Mock(return_value=indexes)
     completion_widget_stub.model = unittest.mock.Mock(return_value=model)
     _set_cmd_prompt(cmd, before)
-    completer_obj.update_cursor_part()
+    # schedule_completion_update is needed to pick up the cursor position
+    completer_obj.schedule_completion_update()
     completer_obj.selection_changed(selection, None)
     model.data.assert_called_with(indexes[0])
     _validate_cmd_prompt(cmd, after)

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -187,24 +187,6 @@ def test_update_completion(txt, expected, status_command_stub, completer_obj,
         assert arg.srcmodel.kind == expected
 
 
-def test_completion_item_prev(completer_obj, status_command_stub, config_stub,
-                              qtbot):
-    """Test that completion_item_prev emits next_prev_item."""
-    status_command_stub.setText(':')
-    with qtbot.waitSignal(completer_obj.next_prev_item) as blocker:
-        completer_obj.completion_item_prev()
-    assert blocker.args == [True]
-
-
-def test_completion_item_next(completer_obj, status_command_stub, config_stub,
-                              qtbot):
-    """Test that completion_item_next emits next_prev_item."""
-    status_command_stub.setText(':')
-    with qtbot.waitSignal(completer_obj.next_prev_item) as blocker:
-        completer_obj.completion_item_next()
-    assert blocker.args == [False]
-
-
 @pytest.mark.parametrize('before, newtxt, quick_complete, count, after', [
     (':foo |', 'bar', False, 1, ':foo bar|'),
     (':foo |', 'bar', True, 2, ':foo bar|'),

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -216,6 +216,6 @@ def test_on_selection_changed(before, newtxt, count, quick_complete, after,
     _set_cmd_prompt(status_command_stub, before)
     # schedule_completion_update is needed to pick up the cursor position
     completer_obj.schedule_completion_update()
-    completer_obj.on_selection_changed(selection, None)
+    completer_obj.on_selection_changed(selection)
     model.data.assert_called_with(indexes[0])
     _validate_cmd_prompt(status_command_stub, after)

--- a/tests/unit/completion/test_completionwidget.py
+++ b/tests/unit/completion/test_completionwidget.py
@@ -26,7 +26,6 @@ from PyQt5.QtGui import QStandardItem, QColor
 
 from qutebrowser.completion import completionwidget
 from qutebrowser.completion.models import base, sortfilter
-from qutebrowser.utils import objreg
 
 
 @pytest.fixture

--- a/tests/unit/completion/test_completionwidget.py
+++ b/tests/unit/completion/test_completionwidget.py
@@ -120,9 +120,7 @@ def test_maybe_resize_completion(completionview, config_stub, qtbot):
     ([['Aa'], [], []], 1, 'Aa'),
     ([['Aa'], [], []], -1, 'Aa'),
 ])
-def test_on_next_prev_item(tree, count, expected, completionview,
-                           config_stub, qtbot, monkeypatch,
-                           status_command_stub):
+def test_completion_item_next_prev(tree, count, expected, completionview):
     """Test that on_next_prev_item moves the selection properly.
 
     Args:
@@ -140,10 +138,11 @@ def test_on_next_prev_item(tree, count, expected, completionview,
     filtermodel = sortfilter.CompletionFilterModel(model,
                                                    parent=completionview)
     completionview.set_model(filtermodel)
-    # actually calling show() will pop a window during the test, so just fool
-    # the completionview into thinking it is visible instead
-    monkeypatch.setattr(completionview, 'isVisible', lambda: True)
-    for _ in range(abs(count)):
-        completionview.on_next_prev_item(count < 0)
+    if count < 0:
+        for _ in range(-count):
+            completionview.completion_item_prev()
+    else:
+        for _ in range(count):
+            completionview.completion_item_next()
     idx = completionview.selectionModel().currentIndex()
     assert filtermodel.data(idx) == expected

--- a/tests/unit/completion/test_completionwidget.py
+++ b/tests/unit/completion/test_completionwidget.py
@@ -29,7 +29,7 @@ from qutebrowser.completion.models import base, sortfilter
 from qutebrowser.utils import objreg
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def completionview(qtbot, status_command_stub, config_stub, win_registry,
                    mocker):
     """Create the CompletionView used for testing."""
@@ -65,10 +65,7 @@ def completionview(qtbot, status_command_stub, config_stub, win_registry,
     mocker.patch('qutebrowser.completion.completer.Completer', autospec=True)
     view = completionwidget.CompletionView(win_id=0)
     qtbot.addWidget(view)
-    yield view
-    # the constructor registers both 'completion' (itself) and 'completer'
-    objreg.delete('completion', scope='window', window=0)
-    objreg.delete('completer', scope='window', window=0)
+    return view
 
 
 def test_set_model(completionview):

--- a/tests/unit/completion/test_completionwidget.py
+++ b/tests/unit/completion/test_completionwidget.py
@@ -1,0 +1,152 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2016 Ryan Roden-Corrent (rcorre) <ryan@rcorre.net>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the CompletionView Object."""
+
+import unittest.mock
+
+import pytest
+from PyQt5.QtGui import QStandardItem, QColor
+
+from qutebrowser.completion import completionwidget
+from qutebrowser.completion.models import base, sortfilter
+from qutebrowser.utils import objreg
+
+
+@pytest.yield_fixture
+def completionview(qtbot, status_command_stub, config_stub, win_registry,
+                   monkeypatch):
+    """Create the CompletionView used for testing."""
+    config_stub.data = {
+        'completion': {
+            'show': True,
+            'auto-open': True,
+            'scrollbar-width': 12,
+            'scrollbar-padding': 2,
+            'shrink': False,
+        },
+        'colors': {
+            'completion.fg': QColor(),
+            'completion.bg': QColor(),
+            'completion.alternate-bg': QColor(),
+            'completion.category.fg': QColor(),
+            'completion.category.bg': QColor(),
+            'completion.category.border.top': QColor(),
+            'completion.category.border.bottom': QColor(),
+            'completion.item.selected.fg': QColor(),
+            'completion.item.selected.bg': QColor(),
+            'completion.item.selected.border.top': QColor(),
+            'completion.item.selected.border.bottom': QColor(),
+            'completion.match.fg': QColor(),
+            'completion.scrollbar.fg': QColor(),
+            'completion.scrollbar.bg': QColor(),
+        },
+        'fonts': {
+            'completion': 'Comic Sans Monospace'
+        }
+    }
+    # mock the Completer that the widget creates in its constructor
+    monkeypatch.setattr('qutebrowser.completion.completer.Completer',
+        lambda *args: unittest.mock.Mock())
+    view = completionwidget.CompletionView(win_id=0)
+    qtbot.addWidget(view)
+    yield view
+    # the constructor registers both 'completion' (itself) and 'completer'
+    objreg.delete('completion', scope='window', window=0)
+    objreg.delete('completer', scope='window', window=0)
+
+
+def test_set_model(completionview):
+    """Ensure set_model actually sets the model and expands all categories."""
+    model = base.BaseCompletionModel()
+    filtermodel = sortfilter.CompletionFilterModel(model)
+    for i in range(3):
+        model.appendRow(QStandardItem(str(i)))
+    completionview.set_model(filtermodel)
+    assert completionview.model() == filtermodel
+    for i in range(model.rowCount()):
+        assert completionview.isExpanded(filtermodel.index(i, 0))
+
+
+def test_set_pattern(completionview):
+    model = sortfilter.CompletionFilterModel(base.BaseCompletionModel())
+    model.set_pattern = unittest.mock.Mock()
+    completionview.set_model(model)
+    completionview.set_pattern('foo')
+    model.set_pattern.assert_called_with('foo')
+
+
+def test_maybe_resize_completion(completionview, config_stub, qtbot):
+    """Ensure completion is resized only if shrink is True."""
+    with qtbot.assertNotEmitted(completionview.resize_completion):
+        completionview.maybe_resize_completion()
+    config_stub.data = {'completion': {'shrink': True}}
+    with qtbot.waitSignal(completionview.resize_completion):
+        completionview.maybe_resize_completion()
+
+
+@pytest.mark.parametrize('tree, count, expected', [
+    ([['Aa']], 1, 'Aa'),
+    ([['Aa']], -1, 'Aa'),
+    ([['Aa'], ['Ba']], 1, 'Aa'),
+    ([['Aa'], ['Ba']], -1, 'Ba'),
+    ([['Aa'], ['Ba']], 2, 'Ba'),
+    ([['Aa'], ['Ba']], -2, 'Aa'),
+    ([['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], 3, 'Ac'),
+    ([['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], 4, 'Ba'),
+    ([['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], 6, 'Ca'),
+    ([['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], 7, 'Aa'),
+    ([['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], -1, 'Ca'),
+    ([['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], -2, 'Bb'),
+    ([['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], -4, 'Ac'),
+    ([[], ['Ba', 'Bb']], 1, 'Ba'),
+    ([[], ['Ba', 'Bb']], -1, 'Bb'),
+    ([[], [], ['Ca', 'Cb']], 1, 'Ca'),
+    ([[], [], ['Ca', 'Cb']], -1, 'Cb'),
+    ([['Aa'], []], 1, 'Aa'),
+    ([['Aa'], []], -1, 'Aa'),
+    ([['Aa'], [], []], 1, 'Aa'),
+    ([['Aa'], [], []], -1, 'Aa'),
+])
+def test_on_next_prev_item(tree, count, expected, completionview,
+                           config_stub, qtbot, monkeypatch,
+                           status_command_stub):
+    """Test that on_next_prev_item moves the selection properly.
+
+    Args:
+        tree: Each entry array represents a completion category, with each
+              string being an item under that category.
+        count: Number of times to go forward (or back if negative).
+        expected: item data that should be selected after going back/forward.
+    """
+    model = base.BaseCompletionModel()
+    for catdata in tree:
+        cat = QStandardItem()
+        model.appendRow(cat)
+        for name in catdata:
+            cat.appendRow(QStandardItem(name))
+    filtermodel = sortfilter.CompletionFilterModel(model)
+    completionview.set_model(filtermodel)
+    # actually calling show() will pop a window during the test, so just fool
+    # the completionview into thinking it is visible instead
+    monkeypatch.setattr(completionview, 'isVisible', lambda: True)
+    for i in range(abs(count)):
+        completionview.on_next_prev_item(count < 0)
+    idx = completionview.selectionModel().currentIndex()
+    assert filtermodel.data(idx) == expected


### PR DESCRIPTION
There are kinda two things going on in this PR (sorry, maybe should've done two).

The first two commits are touching up tests for `Completer`. I took a look at how it actually gets used and saw that the public entry point is `schedule_completion_update` rather than `update_completion`, so in c00ce1e I'm testing that instead. In 124bdf2 I marked functions that aren't used externally as private (but I can omit that commit if you'd rather keep them public).

The second bit adds tests for the `CompletionView`, which was previously untested. I decided to use the real `BaseCompletionModel` and `SortFilter` instead of mocking them out. `test_next_previous_item` is flaky, and occasionally fails with

```
None:None:0:
    QtWarningMsg: QItemSelectionModel: Selecting when no model has been set will result in a no-op.
```

Any idea what might cause this? I've been struggling to track it down.