### PR TITLE
Don't pass 2 arguments to shebang

### DIFF
--- a/misc/userscripts/open_download
+++ b/misc/userscripts/open_download
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
 # Both standalone script and qutebrowser userscript that opens a rofi menu with
 # all files from the download director and opens the selected file. It works
 # both as a userscript and a standalone script that is called from outside of
@@ -17,6 +17,8 @@
 #
 # Thorsten Wißmann, 2015 (thorsten` on freenode)
 # Any feedback is welcome!
+
+set -e
 
 # open a file from the download directory using rofi
 DOWNLOAD_DIR=${DOWNLOAD_DIR:-$QUTE_DOWNLOAD_DIR}

--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
 help() {
     blink=$'\e[1;31m' reset=$'\e[0m'
 cat <<EOF
@@ -39,6 +39,7 @@ Configuration:
 EOF
 }
 
+set -o errexit
 set -o pipefail
 shopt -s nocasematch # make regexp matching in bash case insensitive
 

--- a/misc/userscripts/view_in_mpv
+++ b/misc/userscripts/view_in_mpv
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
 #
 # Behavior:
 #   Userscript for qutebrowser which views the current web page in mpv using
@@ -23,6 +23,8 @@
 #
 # Thorsten Wißmann, 2015 (thorsten` on freenode)
 # Any feedback is welcome!
+
+set -e
 
 if [ -z "$QUTE_FIFO" ] ; then
     cat 1>&2 <<EOF


### PR DESCRIPTION
Fix for https://github.com/The-Compiler/qutebrowser/commit/dfbd31f35f718f49b965f91551951061cd3463bd. On most platforms (according to shellcheck), you can't pass two arguments in a shebang. I.e. on Debian you get:
`/usr/bin/env: ‘bash -e’: No such file or directory`