### PR TITLE
--delete option for bookmark-load

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1162,7 +1162,8 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0)
     @cmdutils.argument('url', completion=usertypes.Completion.bookmark_by_url)
-    def bookmark_load(self, url, tab=False, bg=False, window=False):
+    def bookmark_load(self, url, tab=False, bg=False, window=False,
+                      delete=False):
         """Load a bookmark.
 
         Args:
@@ -1170,12 +1171,15 @@ class CommandDispatcher:
             tab: Load the bookmark in a new tab.
             bg: Load the bookmark in a new background tab.
             window: Load the bookmark in a new window.
+            delete: Whether to delete the bookmark afterwards.
         """
         try:
-            url = urlutils.fuzzy_url(url)
+            qurl = urlutils.fuzzy_url(url)
         except urlutils.InvalidUrlError as e:
             raise cmdexc.CommandError(e)
-        self._open(url, tab, bg, window)
+        self._open(qurl, tab, bg, window)
+        if delete:
+            self.bookmark_del(url)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0)

--- a/tests/end2end/data/numbers/19.txt
+++ b/tests/end2end/data/numbers/19.txt
@@ -1,0 +1,1 @@
+nineteen

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -111,30 +111,30 @@ Feature: quickmarks and bookmarks
     ## quickmarks
 
     Scenario: Saving a quickmark (:quickmark-add)
-        When I run :quickmark-add http://localhost:(port)/data/numbers/8.txt eight
-        Then the quickmark file should contain "eight http://localhost:*/data/numbers/8.txt"
-
-    Scenario: Saving a quickmark (:quickmark-save)
-        When I open data/numbers/9.txt
-        And I run :quickmark-save
-        And I wait for "Entering mode KeyMode.prompt (reason: question asked)" in the log
-        And I press the keys "nine"
-        And I press the keys "<Enter>"
+        When I run :quickmark-add http://localhost:(port)/data/numbers/9.txt nine
         Then the quickmark file should contain "nine http://localhost:*/data/numbers/9.txt"
 
-    Scenario: Saving a duplicate quickmark (without override)
-        When I run :quickmark-add http://localhost:(port)/data/numbers/10.txt ten
-        And I run :quickmark-add http://localhost:(port)/data/numbers/10_2.txt ten
-        And I wait for "Entering mode KeyMode.yesno (reason: question asked)" in the log
-        And I run :prompt-no
+    Scenario: Saving a quickmark (:quickmark-save)
+        When I open data/numbers/10.txt
+        And I run :quickmark-save
+        And I wait for "Entering mode KeyMode.prompt (reason: question asked)" in the log
+        And I press the keys "ten"
+        And I press the keys "<Enter>"
         Then the quickmark file should contain "ten http://localhost:*/data/numbers/10.txt"
 
-    Scenario: Saving a duplicate quickmark (with override)
+    Scenario: Saving a duplicate quickmark (without override)
         When I run :quickmark-add http://localhost:(port)/data/numbers/11.txt eleven
         And I run :quickmark-add http://localhost:(port)/data/numbers/11_2.txt eleven
         And I wait for "Entering mode KeyMode.yesno (reason: question asked)" in the log
+        And I run :prompt-no
+        Then the quickmark file should contain "eleven http://localhost:*/data/numbers/11.txt"
+
+    Scenario: Saving a duplicate quickmark (with override)
+        When I run :quickmark-add http://localhost:(port)/data/numbers/12.txt twelve
+        And I run :quickmark-add http://localhost:(port)/data/numbers/12_2.txt twelve
+        And I wait for "Entering mode KeyMode.yesno (reason: question asked)" in the log
         And I run :prompt-yes
-        Then the quickmark file should contain "eleven http://localhost:*/data/numbers/11_2.txt"
+        Then the quickmark file should contain "twelve http://localhost:*/data/numbers/12_2.txt"
 
     Scenario: Adding a quickmark with an empty name
         When I run :quickmark-add about:blank ""
@@ -146,38 +146,38 @@ Feature: quickmarks and bookmarks
 
     Scenario: Loading a quickmark
         Given I have a fresh instance
-        When I run :quickmark-add http://localhost:(port)/data/numbers/12.txt twelve
-        And I run :quickmark-load twelve
-        Then data/numbers/12.txt should be loaded
+        When I run :quickmark-add http://localhost:(port)/data/numbers/13.txt thirteen
+        And I run :quickmark-load thirteen
+        Then data/numbers/13.txt should be loaded
         And the following tabs should be open:
-            - data/numbers/12.txt (active)
+            - data/numbers/13.txt (active)
 
     Scenario: Loading a quickmark in a new tab
         Given I open about:blank
         When I run :tab-only
-        And I run :quickmark-add http://localhost:(port)/data/numbers/13.txt thirteen
-        And I run :quickmark-load -t thirteen
-        Then data/numbers/13.txt should be loaded
+        And I run :quickmark-add http://localhost:(port)/data/numbers/14.txt fourteen
+        And I run :quickmark-load -t fourteen
+        Then data/numbers/14.txt should be loaded
         And the following tabs should be open:
             - about:blank
-            - data/numbers/13.txt (active)
+            - data/numbers/14.txt (active)
 
     Scenario: Loading a quickmark in a background tab
         Given I open about:blank
         When I run :tab-only
-        And I run :quickmark-add http://localhost:(port)/data/numbers/14.txt fourteen
-        And I run :quickmark-load -b fourteen
-        Then data/numbers/14.txt should be loaded
+        And I run :quickmark-add http://localhost:(port)/data/numbers/15.txt fifteen
+        And I run :quickmark-load -b fifteen
+        Then data/numbers/15.txt should be loaded
         And the following tabs should be open:
             - about:blank (active)
-            - data/numbers/14.txt
+            - data/numbers/15.txt
 
     Scenario: Loading a quickmark in a new window
         Given I open about:blank
         When I run :tab-only
-        And I run :quickmark-add http://localhost:(port)/data/numbers/15.txt fifteen
-        And I run :quickmark-load -w fifteen
-        And I wait until data/numbers/15.txt is loaded
+        And I run :quickmark-add http://localhost:(port)/data/numbers/16.txt sixteen
+        And I run :quickmark-load -w sixteen
+        And I wait until data/numbers/16.txt is loaded
         Then the session should look like:
             windows:
             - tabs:
@@ -189,15 +189,15 @@ Feature: quickmarks and bookmarks
               - active: true
                 history:
                 - active: true
-                  url: http://localhost:*/data/numbers/15.txt
+                  url: http://localhost:*/data/numbers/16.txt
 
     Scenario: Loading a quickmark which does not exist
         When I run :quickmark-load -b doesnotexist
         Then the error "Quickmark 'doesnotexist' does not exist!" should be shown
 
     Scenario: Loading a quickmark with -t and -b
-        When I run :quickmark-add http://localhost:(port)/data/numbers/16.txt sixteen
-        When I run :quickmark-load -t -b sixteen
+        When I run :quickmark-add http://localhost:(port)/data/numbers/17.txt seventeen
+        When I run :quickmark-load -t -b seventeen
         Then the error "Only one of -t/-b/-w can be given!" should be shown
 
     Scenario: Deleting a quickmark which does not exist
@@ -205,9 +205,9 @@ Feature: quickmarks and bookmarks
         Then the error "Quickmark 'doesnotexist' not found!" should be shown
 
     Scenario: Deleting a quickmark
-        When I run :quickmark-add http://localhost:(port)/data/numbers/17.txt seventeen
-        And I run :quickmark-del seventeen
-        Then the quickmark file should not contain "seventeen http://localhost:*/data/numbers/17.txt "
+        When I run :quickmark-add http://localhost:(port)/data/numbers/18.txt eighteen
+        And I run :quickmark-del eighteen
+        Then the quickmark file should not contain "eighteen http://localhost:*/data/numbers/18.txt "
 
     Scenario: Deleting the current page's quickmark if it has none
         When I open about:blank
@@ -215,17 +215,17 @@ Feature: quickmarks and bookmarks
         Then the error "Quickmark for 'about:blank' not found!" should be shown
 
     Scenario: Deleting the current page's quickmark
-        When I open data/numbers/18.txt
-        And I run :quickmark-add http://localhost:(port)/data/numbers/18.txt eighteen
+        When I open data/numbers/19.txt
+        And I run :quickmark-add http://localhost:(port)/data/numbers/19.txt nineteen
         And I run :quickmark-del
-        Then the quickmark file should not contain "eighteen http://localhost:*/data/numbers/18.txt"
+        Then the quickmark file should not contain "nineteen http://localhost:*/data/numbers/19.txt"
 
     Scenario: Listing quickmarks
-        When I run :quickmark-add http://localhost:(port)/data/numbers/15.txt fifteen
-        And I run :quickmark-add http://localhost:(port)/data/numbers/14.txt fourteen
+        When I run :quickmark-add http://localhost:(port)/data/numbers/20.txt twenty
+        And I run :quickmark-add http://localhost:(port)/data/numbers/21.txt twentyone
         And I open qute:bookmarks
-        Then the page should contain the plaintext "fifteen"
-        And the page should contain the plaintext "fourteen"
+        Then the page should contain the plaintext "twenty"
+        And the page should contain the plaintext "twentyone"
 
     Scenario: Listing bookmarks
         When I open data/title.html

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -103,6 +103,11 @@ Feature: quickmarks and bookmarks
         And I run :bookmark-add --toggle
         Then the bookmark file should not contain "http://localhost:*/data/numbers/7.txt "
 
+    Scenario: Loading a bookmark with --delete
+        When I run :bookmark-add http://localhost:(port)/data/numbers/8.txt "eight"
+        And I run :bookmark-load -d http://localhost:(port)/data/numbers/8.txt
+        Then the bookmark file should not contain "http://localhost:*/data/numbers/8.txt "
+
     ## quickmarks
 
     Scenario: Saving a quickmark (:quickmark-add)


### PR DESCRIPTION
Uzbl has a very nice feature called temp bookmarks which are deleted once you visit them. Adding a `--delete` flag to `bookmark-load` allows a user to replicate this functionality without creating a new kind of bookmark. This is similar to `bookmark-del` with no arguments, but doesn't require the user to wait for the page to load and also works even if the bookmarked page redirects.

A similar feature might be useful for `quickmark-load` but my impression is that there's no reason to create a shortcut name for a mark if you only plan on visiting it once.