### PR TITLE
Focus field before filling password

### DIFF
--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -342,12 +342,14 @@ cat <<EOF
         for (var j = 0; j < inputs.length; j++) {
             var input = inputs[j];
             if (input.type == "text" || input.type == "email") {
-		input.focus();
+                input.focus();
                 input.value = "$(javascript_escape "${username}")";
+                input.blur();
             }
             if (input.type == "password") {
-		input.focus();
+                input.focus();
                 input.value = "$(javascript_escape "${password}")";
+                input.blur();
             }
         }
     };

--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -342,9 +342,11 @@ cat <<EOF
         for (var j = 0; j < inputs.length; j++) {
             var input = inputs[j];
             if (input.type == "text" || input.type == "email") {
+		input.focus();
                 input.value = "$(javascript_escape "${username}")";
             }
             if (input.type == "password") {
+		input.focus();
                 input.value = "$(javascript_escape "${password}")";
             }
         }


### PR DESCRIPTION
On some websites, e.g. https://www.engie-electrabel.be, you can't login after you filled the login form using `password_fill`. This can be fixed by focusing the input fields, and removing focus afterwards.