### PR TITLE
Generalize configtypes.List

### DIFF
--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -419,7 +419,7 @@ class ConfigManager(QObject):
         for optname, option in sect.items():
 
             lines.append('#')
-            typestr = ' ({})'.format(option.typ.__class__.__name__)
+            typestr = ' ({})'.format(option.typ.get_name())
             lines.append("# {}{}:".format(optname, typestr))
 
             try:
@@ -430,7 +430,7 @@ class ConfigManager(QObject):
                 continue
             for descline in desc.splitlines():
                 lines += wrapper.wrap(descline)
-            valid_values = option.typ.valid_values
+            valid_values = option.typ.get_valid_values()
             if valid_values is not None:
                 if valid_values.descriptions:
                     for val in valid_values:

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -135,7 +135,8 @@ def data(readonly=False):
              "Whether to find text on a page case-insensitively."),
 
             ('startpage',
-             SettingValue(typ.BaseList(), 'https://duckduckgo.com'),
+             SettingValue(typ.List(typ.Url(), none_ok=True),
+                          'https://duckduckgo.com'),
              "The default page(s) to open at the start, separated by commas."),
 
             ('default-page',
@@ -352,7 +353,7 @@ def data(readonly=False):
              "(requires restart)"),
 
             ('keyhint-blacklist',
-             SettingValue(typ.BaseList(none_ok=True), ''),
+             SettingValue(typ.List(typ.String(), none_ok=True), ''),
              "Keychains that shouldn't be shown in the keyhint dialog\n\n"
              "Globs are supported, so ';*' will blacklist all keychains"
              "starting with ';'. Use '*' to disable keyhints"),
@@ -845,7 +846,7 @@ def data(readonly=False):
              "Whether host blocking is enabled."),
 
             ('host-blocking-whitelist',
-             SettingValue(typ.BaseList(none_ok=True), 'piwik.org'),
+             SettingValue(typ.List(typ.String(), none_ok=True), 'piwik.org'),
              "List of domains that should always be loaded, despite being "
              "ad-blocked.\n\n"
              "Domains may contain * and ? wildcards and are otherwise "

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -684,8 +684,8 @@ def data(readonly=False):
 
             ('object-cache-capacities',
              SettingValue(
-                 typ.WebKitBytesList(length=3, maxsize=MAXVALS['int'],
-                                     none_ok=True), ''),
+                 typ.LengthList(typ.WebKitBytes(maxsize=MAXVALS['int'],
+                                none_ok=True), none_ok=True, length=3), ''),
              "The capacities for the global memory cache for dead objects "
              "such as stylesheets or scripts. Syntax: cacheMinDeadCapacity, "
              "cacheMaxDead, totalCapacity.\n\n"

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -135,8 +135,7 @@ def data(readonly=False):
              "Whether to find text on a page case-insensitively."),
 
             ('startpage',
-             SettingValue(typ.List(typ.String(), none_ok=True),
-                          'https://duckduckgo.com'),
+             SettingValue(typ.List(typ.String()), 'https://duckduckgo.com'),
              "The default page(s) to open at the start, separated by commas."),
 
             ('default-page',

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -254,7 +254,7 @@ def data(readonly=False):
 
         ('ui', sect.KeyValue(
             ('zoom-levels',
-             SettingValue(typ.PercList(minval=0),
+             SettingValue(typ.List(typ.Perc(minval=0)),
                           '25%,33%,50%,67%,75%,90%,100%,110%,125%,150%,175%,'
                           '200%,250%,300%,400%,500%'),
              "The available zoom levels, separated by commas."),
@@ -826,7 +826,7 @@ def data(readonly=False):
 
             ('host-block-lists',
              SettingValue(
-                 typ.UrlList(none_ok=True),
+                 typ.List(typ.Url(), none_ok=True),
                  'http://www.malwaredomainlist.com/hostslist/hosts.txt,'
                  'http://someonewhocares.org/hosts/hosts,'
                  'http://winhelp2002.mvps.org/hosts.zip,'
@@ -916,13 +916,13 @@ def data(readonly=False):
              "auto-follow."),
 
             ('next-regexes',
-             SettingValue(typ.RegexList(flags=re.IGNORECASE),
+             SettingValue(typ.List(typ.Regex(flags=re.IGNORECASE)),
                           r'\bnext\b,\bmore\b,\bnewer\b,\b[>→≫]\b,\b(>>|»)\b,'
                           r'\bcontinue\b'),
              "A comma-separated list of regexes to use for 'next' links."),
 
             ('prev-regexes',
-             SettingValue(typ.RegexList(flags=re.IGNORECASE),
+             SettingValue(typ.List(typ.Regex(flags=re.IGNORECASE)),
                           r'\bprev(ious)?\b,\bback\b,\bolder\b,\b[<←≪]\b,'
                           r'\b(<<|«)\b'),
              "A comma-separated list of regexes to use for 'prev' links."),

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -135,7 +135,7 @@ def data(readonly=False):
              "Whether to find text on a page case-insensitively."),
 
             ('startpage',
-             SettingValue(typ.List(), 'https://duckduckgo.com'),
+             SettingValue(typ.BaseList(), 'https://duckduckgo.com'),
              "The default page(s) to open at the start, separated by commas."),
 
             ('default-page',
@@ -352,7 +352,7 @@ def data(readonly=False):
              "(requires restart)"),
 
             ('keyhint-blacklist',
-             SettingValue(typ.List(none_ok=True), ''),
+             SettingValue(typ.BaseList(none_ok=True), ''),
              "Keychains that shouldn't be shown in the keyhint dialog\n\n"
              "Globs are supported, so ';*' will blacklist all keychains"
              "starting with ';'. Use '*' to disable keyhints"),
@@ -845,7 +845,7 @@ def data(readonly=False):
              "Whether host blocking is enabled."),
 
             ('host-blocking-whitelist',
-             SettingValue(typ.List(none_ok=True), 'piwik.org'),
+             SettingValue(typ.BaseList(none_ok=True), 'piwik.org'),
              "List of domains that should always be loaded, despite being "
              "ad-blocked.\n\n"
              "Domains may contain * and ? wildcards and are otherwise "

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -684,8 +684,8 @@ def data(readonly=False):
 
             ('object-cache-capacities',
              SettingValue(
-                 typ.LengthList(typ.WebKitBytes(maxsize=MAXVALS['int'],
-                                none_ok=True), none_ok=True, length=3), ''),
+                 typ.List(typ.WebKitBytes(maxsize=MAXVALS['int'],
+                          none_ok=True), none_ok=True, length=3), ''),
              "The capacities for the global memory cache for dead objects "
              "such as stylesheets or scripts. Syntax: cacheMinDeadCapacity, "
              "cacheMaxDead, totalCapacity.\n\n"

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -135,7 +135,7 @@ def data(readonly=False):
              "Whether to find text on a page case-insensitively."),
 
             ('startpage',
-             SettingValue(typ.List(typ.Url(), none_ok=True),
+             SettingValue(typ.List(typ.String(), none_ok=True),
                           'https://duckduckgo.com'),
              "The default page(s) to open at the start, separated by commas."),
 

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -327,9 +327,15 @@ class List(BaseType):
             self.inner_type.validate(val.strip())
 
 
-class BaseList(List):
+class FlagList(List):
 
-    """Base class for a list using BaseType."""
+    """Base class for a list setting that contains one or more flags.
+
+    Lists with duplicate flags are invalid and each item is checked against
+    self.valid_values (if not empty).
+    """
+
+    combinable_values = None
 
     def __init__(self, none_ok=False, valid_values=None):
         super().__init__(BaseType(), none_ok)
@@ -340,20 +346,6 @@ class BaseList(List):
             super().validate(value)
         else:
             self._basic_validation(value)
-
-
-class FlagList(BaseList):
-
-    """Base class for a list setting that contains one or more flags.
-
-    Lists with duplicate flags are invalid and each item is checked against
-    self.valid_values (if not empty).
-    """
-
-    combinable_values = None
-
-    def validate(self, value):
-        super().validate(value)
         if not value:
             return
         vals = super().transform(value)

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -299,7 +299,7 @@ class UniqueCharString(String):
                 value, "String contains duplicate values!")
 
 
-class GenList(BaseType):
+class List(BaseType):
 
     """Base class for a (string-)list setting."""
 
@@ -311,19 +311,20 @@ class GenList(BaseType):
         if not value:
             return None
         else:
-            return [self.inner_type.transform(v) for v in value.split(',')]
+            return [self.inner_type.transform(v.strip())
+                    for v in value.split(',')]
 
     def validate(self, value):
         self._basic_validation(value)
         if not value:
             return
         for val in value.split(','):
-            self.inner_type.validate(val)
+            self.inner_type.validate(val.strip())
 
 
-class List(GenList):
+class BaseList(List):
 
-    """Base class for a (string-)list setting."""
+    """Base class for a list using BaseType."""
 
     def __init__(self, none_ok=False, valid_values=None):
         super().__init__(BaseType(), none_ok)
@@ -334,13 +335,9 @@ class List(GenList):
             super().validate(value)
         else:
             self._basic_validation(value)
-        if value:
-            vals = super().transform(value)
-            if None in vals:
-                raise configexc.ValidationError(value, "may not be empty!")
 
 
-class FlagList(GenList):
+class FlagList(BaseList):
 
     """Base class for a list setting that contains one or more flags.
 
@@ -348,17 +345,10 @@ class FlagList(GenList):
     self.valid_values (if not empty).
     """
 
-    def __init__(self, none_ok=False, valid_values=None):
-        super().__init__(BaseType(), none_ok)
-        self.inner_type.valid_values = valid_values
-
     combinable_values = None
 
     def validate(self, value):
-        if self.inner_type.valid_values is not None:
-            super().validate(value)
-        else:
-            self._basic_validation(value)
+        super().validate(value)
         if not value:
             return
         vals = super().transform(value)
@@ -471,7 +461,7 @@ class Int(BaseType):
                                             "smaller!".format(self.maxval))
 
 
-class IntList(GenList):
+class IntList(List):
 
     """Base class for an int-list setting."""
 
@@ -560,7 +550,7 @@ class Perc(BaseType):
                                             "less!".format(self.maxval))
 
 
-class PercList(GenList):
+class PercList(List):
 
     """Base class for a list of percentages.
 
@@ -855,7 +845,7 @@ class Regex(BaseType):
             return re.compile(value, self.flags)
 
 
-class RegexList(GenList):
+class RegexList(List):
 
     """A list of regexes."""
 
@@ -1009,7 +999,7 @@ class WebKitBytes(BaseType):
         return int(val) * multiplicator
 
 
-class WebKitBytesList(GenList):
+class WebKitBytesList(List):
 
     """A size with an optional suffix.
 
@@ -1361,7 +1351,7 @@ class Url(BaseType):
                                             "{}".format(val.errorString()))
 
 
-class UrlList(GenList):
+class UrlList(List):
 
     """A list of URLs."""
 

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -311,12 +311,12 @@ class List(BaseType):
 
     """Base class for a (string-)list setting."""
 
+    _show_inner_type = True
+
     def __init__(self, inner_type, none_ok=False, length=None):
         super().__init__(none_ok)
         self.inner_type = inner_type
         self.length = length
-
-    _show_inner_type = True
 
     def get_name(self):
         name = super().get_name()
@@ -356,11 +356,11 @@ class FlagList(List):
 
     combinable_values = None
 
+    _show_inner_type = False
+
     def __init__(self, none_ok=False, valid_values=None):
         super().__init__(BaseType(), none_ok)
         self.inner_type.valid_values = valid_values
-
-    _show_inner_type = False
 
     def validate(self, value):
         if self.inner_type.valid_values is not None:
@@ -1140,12 +1140,12 @@ class Padding(List):
 
     """Setting for paddings around elements."""
 
+    _show_inner_type = False
+
     def __init__(self, none_ok=False, valid_values=None):
         super().__init__(Int(minval=0, none_ok=none_ok),
                          none_ok=none_ok, length=4)
         self.inner_type.valid_values = valid_values
-
-    _show_inner_type = False
 
     def transform(self, value):
         elems = super().transform(value)

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1285,9 +1285,7 @@ class Url(BaseType):
         if not value:
             return
         val = self.transform(value)
-        if val is None:
-            raise configexc.ValidationError(value, "URL may not be empty!")
-        elif not val.isValid():
+        if not val.isValid():
             raise configexc.ValidationError(value, "invalid URL - "
                                             "{}".format(val.errorString()))
 

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -461,15 +461,6 @@ class Int(BaseType):
                                             "smaller!".format(self.maxval))
 
 
-class IntList(List):
-
-    """Base class for an int-list setting."""
-
-    def __init__(self, none_ok=False, valid_values=None):
-        super().__init__(Int(none_ok=none_ok), none_ok=none_ok)
-        self.inner_type.valid_values = valid_values
-
-
 class Float(BaseType):
 
     """Base class for a float setting.
@@ -548,19 +539,6 @@ class Perc(BaseType):
         if self.maxval is not None and intval > self.maxval:
             raise configexc.ValidationError(value, "must be {}% or "
                                             "less!".format(self.maxval))
-
-
-class PercList(List):
-
-    """Base class for a list of percentages.
-
-    Attributes:
-        minval: Minimum value (inclusive).
-        maxval: Maximum value (inclusive).
-    """
-
-    def __init__(self, minval=None, maxval=None, none_ok=False):
-        super().__init__(Perc(minval, maxval, none_ok), none_ok=none_ok)
 
 
 class PercOrInt(BaseType):
@@ -843,14 +821,6 @@ class Regex(BaseType):
             return None
         else:
             return re.compile(value, self.flags)
-
-
-class RegexList(List):
-
-    """A list of regexes."""
-
-    def __init__(self, flags=0, none_ok=False):
-        super().__init__(Regex(flags, none_ok), none_ok=none_ok)
 
 
 class File(BaseType):
@@ -1171,9 +1141,13 @@ PaddingValues = collections.namedtuple('PaddingValues', ['top', 'bottom',
                                                          'left', 'right'])
 
 
-class Padding(IntList):
+class Padding(List):
 
     """Setting for paddings around elements."""
+
+    def __init__(self, none_ok=False, valid_values=None):
+        super().__init__(Int(none_ok=none_ok), none_ok=none_ok)
+        self.inner_type.valid_values = valid_values
 
     def validate(self, value):
         self._basic_validation(value)
@@ -1349,15 +1323,6 @@ class Url(BaseType):
         elif not val.isValid():
             raise configexc.ValidationError(value, "invalid URL - "
                                             "{}".format(val.errorString()))
-
-
-class UrlList(List):
-
-    """A list of URLs."""
-
-    def __init__(self, none_ok=False, valid_values=None):
-        super().__init__(Url(), none_ok)
-
 
 
 class HeaderDict(BaseType):

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -124,6 +124,14 @@ class BaseType:
         self.none_ok = none_ok
         self.valid_values = None
 
+    def get_name(self):
+        """Get a name for the type for documentation"""
+        return self.__class__.__name__
+
+    def get_valid_values(self):
+        """Get the type's valid values for documentation"""
+        return self.valid_values
+
     def _basic_validation(self, value):
         """Do some basic validation for the value (empty, non-printable chars).
 
@@ -308,6 +316,17 @@ class List(BaseType):
         self.inner_type = inner_type
         self.length = length
 
+    _show_inner_type = True
+
+    def get_name(self):
+        name = super().get_name()
+        if self._show_inner_type:
+            name += " of " + self.inner_type.get_name()
+        return name
+
+    def get_valid_values(self):
+        return self.inner_type.get_valid_values()
+
     def transform(self, value):
         if not value:
             return None
@@ -340,6 +359,8 @@ class FlagList(List):
     def __init__(self, none_ok=False, valid_values=None):
         super().__init__(BaseType(), none_ok)
         self.inner_type.valid_values = valid_values
+
+    _show_inner_type = False
 
     def validate(self, value):
         if self.inner_type.valid_values is not None:
@@ -1123,6 +1144,8 @@ class Padding(List):
         super().__init__(Int(minval=0, none_ok=none_ok),
                          none_ok=none_ok, length=4)
         self.inner_type.valid_values = valid_values
+
+    _show_inner_type = False
 
     def transform(self, value):
         elems = super().transform(value)

--- a/scripts/dev/src2asciidoc.py
+++ b/scripts/dev/src2asciidoc.py
@@ -357,7 +357,7 @@ def _generate_setting_section(f, sectname, sect):
         f.write("=== {}".format(optname) + "\n")
         f.write(sect.descriptions[optname] + "\n")
         f.write("\n")
-        valid_values = option.typ.valid_values
+        valid_values = option.typ.get_valid_values()
         if valid_values is not None:
             f.write("Valid values:\n")
             f.write("\n")

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -398,7 +398,9 @@ class FlagListSubclass(configtypes.FlagList):
 
     def __init__(self, none_ok=False):
         super().__init__(none_ok)
-        self.valid_values = configtypes.ValidValues('foo', 'bar', 'baz')
+        self.inner_type.valid_values = configtypes.ValidValues('foo',
+                                                               'bar', 'baz')
+        self.inner_type.none_ok = none_ok
 
 
 class TestFlagList:

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -1813,6 +1813,34 @@ class TestEncoding:
         assert klass().transform(val) == expected
 
 
+class TestUrl:
+
+    """Test Url."""
+
+    TESTS = {
+        'http://qutebrowser.org/': QUrl('http://qutebrowser.org/'),
+        'http://heise.de/': QUrl('http://heise.de/'),
+        '': None,
+    }
+
+    @pytest.fixture
+    def klass(self):
+        return configtypes.Url
+
+    @pytest.mark.parametrize('val', sorted(TESTS))
+    def test_validate_valid(self, klass, val):
+        klass(none_ok=True).validate(val)
+
+    @pytest.mark.parametrize('val', ['', '+'])
+    def test_validate_invalid(self, klass, val):
+        with pytest.raises(configexc.ValidationError):
+            klass().validate(val)
+
+    @pytest.mark.parametrize('val, expected', sorted(TESTS.items()))
+    def test_transform_single(self, klass, val, expected):
+        assert klass().transform(val) == expected
+
+
 class TestSessionName:
 
     """Test SessionName."""

--- a/tests/unit/config/test_configtypes_hypothesis.py
+++ b/tests/unit/config/test_configtypes_hypothesis.py
@@ -36,7 +36,7 @@ def gen_classes():
             pass
         elif member is configtypes.MappingType:
             pass
-        elif member is configtypes.GenList:
+        elif member is configtypes.List:
             pass
         elif member is configtypes.FormatString:
             yield functools.partial(member, fields=['a', 'b'])

--- a/tests/unit/config/test_configtypes_hypothesis.py
+++ b/tests/unit/config/test_configtypes_hypothesis.py
@@ -36,7 +36,7 @@ def gen_classes():
             pass
         elif member is configtypes.MappingType:
             pass
-        elif member is configtypes.List:
+        elif member in [configtypes.List, configtypes.LengthList]:
             pass
         elif member is configtypes.FormatString:
             yield functools.partial(member, fields=['a', 'b'])

--- a/tests/unit/config/test_configtypes_hypothesis.py
+++ b/tests/unit/config/test_configtypes_hypothesis.py
@@ -36,7 +36,7 @@ def gen_classes():
             pass
         elif member is configtypes.MappingType:
             pass
-        elif member in [configtypes.List, configtypes.LengthList]:
+        elif member is configtypes.List:
             pass
         elif member is configtypes.FormatString:
             yield functools.partial(member, fields=['a', 'b'])

--- a/tests/unit/config/test_configtypes_hypothesis.py
+++ b/tests/unit/config/test_configtypes_hypothesis.py
@@ -37,7 +37,8 @@ def gen_classes():
         elif member is configtypes.MappingType:
             pass
         elif member is configtypes.List:
-            pass
+            yield functools.partial(member, inner_type=configtypes.Int())
+            yield functools.partial(member, inner_type=configtypes.Url())
         elif member is configtypes.FormatString:
             yield functools.partial(member, fields=['a', 'b'])
         elif issubclass(member, configtypes.BaseType):

--- a/tests/unit/config/test_configtypes_hypothesis.py
+++ b/tests/unit/config/test_configtypes_hypothesis.py
@@ -36,6 +36,8 @@ def gen_classes():
             pass
         elif member is configtypes.MappingType:
             pass
+        elif member is configtypes.GenList:
+            pass
         elif member is configtypes.FormatString:
             yield functools.partial(member, fields=['a', 'b'])
         elif issubclass(member, configtypes.BaseType):


### PR DESCRIPTION
As promised, code for #989. In addition to the `List` type, which is basically the same as the one described there, I implemented `LengthList` (no pun intended, seriously) which enforces a length on the value provided it isn't empty. Everything was tested for compatibility by recreating the old classes as subclasses of the new ones, and then those versions and their tests were deleted.

The old classes mostly conflated the inner `none_ok` with the outer one, and I haven't given serious thought to which one is required in all cases. Probably worth looking over. Also, three of the values just used plain `List` when they should probably have stricter requirements; for now they use a new class `BaseList`.