### PR TITLE
:open opens quickmark when given a quckmark name

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -249,12 +249,15 @@ class CommandDispatcher:
                                           "set!")
         else:
             try:
-                url = urlutils.fuzzy_url(url)
-            except urlutils.InvalidUrlError as e:
-                # We don't use cmdexc.CommandError here as this can be called
-                # async from edit_url
-                message.error(self._win_id, str(e))
-                return
+                url = objreg.get('quickmark-manager').get(url)
+            except urlmarks.Error:
+                try:
+                    url = urlutils.fuzzy_url(url)
+                except urlutils.InvalidUrlError as e:
+                    # We don't use cmdexc.CommandError here as this can be called
+                    # async from edit_url
+                    message.error(self._win_id, str(e))
+                    return
         if tab or bg or window:
             self._open(url, tab, bg, window)
         else:

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -254,8 +254,8 @@ class CommandDispatcher:
                 try:
                     url = urlutils.fuzzy_url(url)
                 except urlutils.InvalidUrlError as e:
-                    # We don't use cmdexc.CommandError here as this can be called
-                    # async from edit_url
+                    # We don't use cmdexc.CommandError here as this can be 
+                    # called async from edit_url
                     message.error(self._win_id, str(e))
                     return
         if tab or bg or window:

--- a/tests/end2end/features/open.feature
+++ b/tests/end2end/features/open.feature
@@ -103,3 +103,8 @@ Feature: Opening pages
                 history:
                 - active: true
                   url: http://localhost:*/data/numbers/7.txt
+
+    Scenario: Opening a quickmark
+        When I run :quickmark-add http://localhost:(port)/data/numbers/8.txt quickmarktest
+        And I run :open quickmarktest
+        Then data/numbers/8.txt should be loaded


### PR DESCRIPTION
The function CommandDispatcher.openurl now checks in the quickmarks registry to see if the user's URL matches a quickmark's name. If it does, the quickmark is opened instead, otherwise the function proceeds as normal. This addresses issue #1663.