### PR TITLE
Implement unix_filename_rubout.

### DIFF
--- a/tests/unit/misc/test_readline.py
+++ b/tests/unit/misc/test_readline.py
@@ -251,6 +251,24 @@ def test_rl_unix_word_rubout(lineedit, bridge, text, deleted, rest):
 
 
 @pytest.mark.parametrize('text, deleted, rest', [
+    ('test delete|foobar', 'delete', 'test |foobar'),
+    ('test delete |foobar', 'delete ', 'test |foobar'),
+    ('open -t github.com/foo/bar  |', 'bar  ', 'open -t github.com/foo/|'),
+    ('open -t |github.com/foo/bar', '-t ', 'open |github.com/foo/bar'),
+    ('open foo/bar.baz|', 'bar.baz', 'open foo/|'),
+])
+def test_rl_unix_filename_rubout(lineedit, bridge, text, deleted, rest):
+    """Delete filename segment and see if it comes back with yank."""
+    lineedit.set_aug_text(text)
+    bridge.rl_unix_filename_rubout()
+    assert bridge._deleted[lineedit] == deleted
+    assert lineedit.aug_text() == rest
+    lineedit.clear()
+    bridge.rl_yank()
+    assert lineedit.aug_text() == deleted + '|'
+
+
+@pytest.mark.parametrize('text, deleted, rest', [
     fixme(('test foobar| delete', ' delete', 'test foobar|')),
     ('test foobar| delete', ' ', 'test foobar|delete'),  # wrong
     fixme(('test foo|delete bar', 'delete', 'test foo| bar')),
@@ -276,6 +294,7 @@ def test_rl_kill_word(lineedit, bridge, text, deleted, rest):
     ('open -t |github.com/foo/bar', 't ', 'open -|github.com/foo/bar'),
     fixme(('test del<ete>foobar', 'delete', 'test |foobar')),
     ('test del<ete >foobar', 'del', 'test |ete foobar'),  # wrong
+    ('open foo/bar.baz|', 'baz', 'open foo/bar.|'),
 ])
 def test_rl_backward_kill_word(lineedit, bridge, text, deleted, rest):
     """Delete to word beginning and see if it comes back with yank."""

--- a/tests/unit/misc/test_readline.py
+++ b/tests/unit/misc/test_readline.py
@@ -96,6 +96,26 @@ class LineEdit(QLineEdit):
         return ''.join(chars)
 
 
+def _validate_deletion(lineedit, bridge, method, text, deleted, rest):
+    """Run and validate a text deletion method on the ReadLine bridge.
+
+    Args:
+        lineedit: The LineEdit instance.
+        bridge: The ReadlineBridge instance.
+        method: Reference to the method on the bridge to test.
+        text: The starting 'augmented' text (see LineEdit.set_aug_text)
+        deleted: The text that should be deleted when the method is invoked.
+        rest: The augmented text that should remain after method is invoked.
+    """
+    lineedit.set_aug_text(text)
+    method()
+    assert bridge._deleted[lineedit] == deleted
+    assert lineedit.aug_text() == rest
+    lineedit.clear()
+    bridge.rl_yank()
+    assert lineedit.aug_text() == deleted + '|'
+
+
 @pytest.fixture
 def lineedit(qtbot, monkeypatch):
     """Fixture providing a LineEdit."""
@@ -206,13 +226,8 @@ def test_rl_backward_delete_char(text, expected, lineedit, bridge):
 ])
 def test_rl_unix_line_discard(lineedit, bridge, text, deleted, rest):
     """Delete from the cursor to the beginning of the line and yank back."""
-    lineedit.set_aug_text(text)
-    bridge.rl_unix_line_discard()
-    assert bridge._deleted[lineedit] == deleted
-    assert lineedit.aug_text() == rest
-    lineedit.clear()
-    bridge.rl_yank()
-    assert lineedit.aug_text() == deleted + '|'
+    _validate_deletion(lineedit, bridge, bridge.rl_unix_line_discard, text,
+                       deleted, rest)
 
 
 @pytest.mark.parametrize('text, deleted, rest', [
@@ -222,13 +237,8 @@ def test_rl_unix_line_discard(lineedit, bridge, text, deleted, rest):
 ])
 def test_rl_kill_line(lineedit, bridge, text, deleted, rest):
     """Delete from the cursor to the end of line and yank back."""
-    lineedit.set_aug_text(text)
-    bridge.rl_kill_line()
-    assert bridge._deleted[lineedit] == deleted
-    assert lineedit.aug_text() == rest
-    lineedit.clear()
-    bridge.rl_yank()
-    assert lineedit.aug_text() == deleted + '|'
+    _validate_deletion(lineedit, bridge, bridge.rl_kill_line, text, deleted,
+                       rest)
 
 
 @pytest.mark.parametrize('text, deleted, rest', [
@@ -241,13 +251,8 @@ def test_rl_kill_line(lineedit, bridge, text, deleted, rest):
 ])
 def test_rl_unix_word_rubout(lineedit, bridge, text, deleted, rest):
     """Delete to word beginning and see if it comes back with yank."""
-    lineedit.set_aug_text(text)
-    bridge.rl_unix_word_rubout()
-    assert bridge._deleted[lineedit] == deleted
-    assert lineedit.aug_text() == rest
-    lineedit.clear()
-    bridge.rl_yank()
-    assert lineedit.aug_text() == deleted + '|'
+    _validate_deletion(lineedit, bridge, bridge.rl_unix_word_rubout, text,
+                       deleted, rest)
 
 
 @pytest.mark.parametrize('text, deleted, rest', [
@@ -259,13 +264,8 @@ def test_rl_unix_word_rubout(lineedit, bridge, text, deleted, rest):
 ])
 def test_rl_unix_filename_rubout(lineedit, bridge, text, deleted, rest):
     """Delete filename segment and see if it comes back with yank."""
-    lineedit.set_aug_text(text)
-    bridge.rl_unix_filename_rubout()
-    assert bridge._deleted[lineedit] == deleted
-    assert lineedit.aug_text() == rest
-    lineedit.clear()
-    bridge.rl_yank()
-    assert lineedit.aug_text() == deleted + '|'
+    _validate_deletion(lineedit, bridge, bridge.rl_unix_filename_rubout, text,
+                       deleted, rest)
 
 
 @pytest.mark.parametrize('text, deleted, rest', [
@@ -278,13 +278,8 @@ def test_rl_unix_filename_rubout(lineedit, bridge, text, deleted, rest):
 ])
 def test_rl_kill_word(lineedit, bridge, text, deleted, rest):
     """Delete to word end and see if it comes back with yank."""
-    lineedit.set_aug_text(text)
-    bridge.rl_kill_word()
-    assert bridge._deleted[lineedit] == deleted
-    assert lineedit.aug_text() == rest
-    lineedit.clear()
-    bridge.rl_yank()
-    assert lineedit.aug_text() == deleted + '|'
+    _validate_deletion(lineedit, bridge, bridge.rl_kill_word, text, deleted,
+                       rest)
 
 
 @pytest.mark.parametrize('text, deleted, rest', [
@@ -298,13 +293,8 @@ def test_rl_kill_word(lineedit, bridge, text, deleted, rest):
 ])
 def test_rl_backward_kill_word(lineedit, bridge, text, deleted, rest):
     """Delete to word beginning and see if it comes back with yank."""
-    lineedit.set_aug_text(text)
-    bridge.rl_backward_kill_word()
-    assert bridge._deleted[lineedit] == deleted
-    assert lineedit.aug_text() == rest
-    lineedit.clear()
-    bridge.rl_yank()
-    assert lineedit.aug_text() == deleted + '|'
+    _validate_deletion(lineedit, bridge, bridge.rl_backward_kill_word, text,
+                       deleted, rest)
 
 
 def test_rl_yank_no_text(lineedit, bridge):


### PR DESCRIPTION
unix_filename_rubout deletes to the previous slash or whitespace,
unlike the previously implemented backwards-kill-word which treats and
non-alphanumeric character as a boundary.

To illustrate, given the text 'foo/bar.baz', unix_filename_rubout will
delete 'bar.baz' while backwards-kill-word will delete only 'baz'.

See #1710.