### PR TITLE
Open download fixes

### DIFF
--- a/qutebrowser/browser/webkit/downloads.py
+++ b/qutebrowser/browser/webkit/downloads.py
@@ -947,7 +947,13 @@ class DownloadManager(QAbstractListModel):
             download.set_filename(target.filename)
         elif isinstance(target, usertypes.OpenFileDownloadTarget):
             tmp_manager = objreg.get('temporary-downloads')
-            fobj = tmp_manager.get_tmpfile(suggested_filename)
+            try:
+                fobj = tmp_manager.get_tmpfile(suggested_filename)
+            except OSError as exc:
+                msg = "Download error: {}".format(exc)
+                message.error(self._win_id, msg)
+                download.cancel()
+                return
             download.finished.connect(download.open_file)
             download.autoclose = True
             download.set_fileobj(fobj)

--- a/qutebrowser/browser/webkit/downloads.py
+++ b/qutebrowser/browser/webkit/downloads.py
@@ -954,11 +954,20 @@ class DownloadManager(QAbstractListModel):
                 message.error(self._win_id, msg)
                 download.cancel()
                 return
-            download.finished.connect(download.open_file)
+            download.finished.connect(
+                functools.partial(self._open_download, download))
             download.autoclose = True
             download.set_fileobj(fobj)
         else:
             log.downloads.error("Unknown download target: {}".format(target))
+
+    def _open_download(self, download):
+        """Open the given download but only if it was successful."""
+        if download.successful:
+            download.open_file()
+        else:
+            log.downloads.debug("{} finished but not successful, not opening!"
+                                .format(download))
 
     def raise_no_download(self, count):
         """Raise an exception that the download doesn't exist.

--- a/qutebrowser/browser/webkit/downloads.py
+++ b/qutebrowser/browser/webkit/downloads.py
@@ -1322,6 +1322,9 @@ class TempDownloadManager(QObject):
             A tempfile.NamedTemporaryFile that should be used to save the file.
         """
         tmpdir = self._get_tmpdir()
+        # Make sure that the filename is not too long
+        if len(suggested_name) > 20:
+            suggested_name = suggested_name[:10] + '...' + suggested_name[-10:]
         fobj = tempfile.NamedTemporaryFile(dir=tmpdir.name, delete=False,
                                            suffix=suggested_name)
         self.files.append(fobj)

--- a/qutebrowser/browser/webkit/downloads.py
+++ b/qutebrowser/browser/webkit/downloads.py
@@ -1322,6 +1322,8 @@ class TempDownloadManager(QObject):
             A tempfile.NamedTemporaryFile that should be used to save the file.
         """
         tmpdir = self._get_tmpdir()
+        encoding = sys.getfilesystemencoding()
+        suggested_name = utils.force_encoding(suggested_name, encoding)
         # Make sure that the filename is not too long
         if len(suggested_name) > 20:
             suggested_name = suggested_name[:10] + '...' + suggested_name[-10:]


### PR DESCRIPTION
Going for the hat-trick with fixes for #1725, #1726 and #1728 as they are all pretty much one-liners.

I've added the length limitation because we rely on the suggested filename to be valid as there's no way for the user to change the filename (as opposed to a normal download), so for the feature to work, the suggested filename has to "work", so better be safe and shorten it.

I will add tests for the "no crash on cancel" feature in the next days. For the other bugfixes, I'd really like to add tests, but the problem is that we don't control what the OS will do if you open the file. We could probably introduce some "test mode" where the download is not opened but still loaded, so we could make sure that at least the filename doesn't crash qutebrowser, but other than that, I'm not sure how this feature could be tested.