### PR TITLE
Catch exception when completing an invalid command

### DIFF
--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -193,7 +193,10 @@ class CompletionView(QTreeView):
             prev: True for prev item, False for next one.
         """
         idx = self._next_idx(prev)
-        qtutils.ensure_valid(idx)
+        try:
+            qtutils.ensure_valid(idx)
+        except qtutils.QtValueError:
+            return
         self.selectionModel().setCurrentIndex(
             idx, QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows)
 


### PR DESCRIPTION
Addition of a try/except wrapper around the "qtutils.ensure_valid" call in the completion widget. This restores it to the previous behavior of doing nothing when tab is hit with no available completion suggestions, fixing the crash reported in #1731.