### PR TITLE
Fix completion crashes

### DIFF
--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -193,9 +193,8 @@ class CompletionView(QTreeView):
             prev: True for prev item, False for next one.
         """
         idx = self._next_idx(prev)
-        qtutils.ensure_valid(idx)
-        self.selectionModel().setCurrentIndex(
-            idx, QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows)
+        self.selectionModel().setCurrentIndex(idx,
+            QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows)
 
     def set_model(self, model):
         """Switch completion to a new model.

--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -192,9 +192,13 @@ class CompletionView(QTreeView):
         Args:
             prev: True for prev item, False for next one.
         """
-        idx = self._next_idx(prev)
-        self.selectionModel().setCurrentIndex(idx,
-            QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows)
+        # selmodel can be None if 'show' and 'auto-open' are set to False
+        # https://github.com/The-Compiler/qutebrowser/issues/1731
+        selmodel = self.selectionModel()
+        if (selmodel is not None):
+            idx = self._next_idx(prev)
+            selmodel.setCurrentIndex(idx,
+                QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows)
 
     def set_model(self, model):
         """Switch completion to a new model.

--- a/tests/unit/completion/test_completionwidget.py
+++ b/tests/unit/completion/test_completionwidget.py
@@ -148,3 +148,13 @@ def test_completion_item_next_prev(tree, count, expected, completionview):
             completionview.completion_item_next()
     idx = completionview.selectionModel().currentIndex()
     assert filtermodel.data(idx) == expected
+
+
+def test_completion_item_next_prev_no_model(completionview):
+    """Test that next/prev won't crash with no model set.
+
+    This can happen if completion.show and completion.auto-open are False.
+    Regression test for issue #1722.
+    """
+    completionview.completion_item_prev()
+    completionview.completion_item_next()

--- a/tests/unit/completion/test_completionwidget.py
+++ b/tests/unit/completion/test_completionwidget.py
@@ -119,6 +119,8 @@ def test_maybe_resize_completion(completionview, config_stub, qtbot):
     ([['Aa'], []], -1, 'Aa'),
     ([['Aa'], [], []], 1, 'Aa'),
     ([['Aa'], [], []], -1, 'Aa'),
+    ([[]], 1, None),
+    ([[]], -1, None),
 ])
 def test_completion_item_next_prev(tree, count, expected, completionview):
     """Test that on_next_prev_item moves the selection properly.


### PR DESCRIPTION
I _think_ this fixes both issues while preserving the original behavior of `completion.show` and `completion.auto-open`. For some reason I thought that, with both of these set to `false`, you would still be able to tab complete (but without the completion view showing). However, checking out some older commits it looks like that was never how it worked. Can someone confirm?

Maybe that behavior was something that just happened accidentally when I was halfway through refactoring. Like @mlochbaum , I'm now rather confused about what these settings were ever supposed to do :confused: