### PR TITLE
Complete hidden commands

### DIFF
--- a/qutebrowser/completion/models/instances.py
+++ b/qutebrowser/completion/models/instances.py
@@ -114,6 +114,13 @@ def init_session_completion():
     _instances[usertypes.Completion.sessions] = model
 
 
+def _init_bind_completion():
+    """Initialize the command completion model."""
+    log.completion.debug("Initializing bind completion.")
+    model = miscmodels.BindCompletionModel()
+    _instances[usertypes.Completion.bind] = model
+
+
 INITIALIZERS = {
     usertypes.Completion.command: _init_command_completion,
     usertypes.Completion.helptopic: _init_helptopic_completion,
@@ -125,6 +132,7 @@ INITIALIZERS = {
     usertypes.Completion.quickmark_by_name: init_quickmark_completions,
     usertypes.Completion.bookmark_by_url: init_bookmark_completions,
     usertypes.Completion.sessions: init_session_completion,
+    usertypes.Completion.bind: _init_bind_completion,
 }
 
 
@@ -182,5 +190,7 @@ def init():
     keyconf = objreg.get('key-config')
     keyconf.changed.connect(
         functools.partial(update, [usertypes.Completion.command]))
+    keyconf.changed.connect(
+        functools.partial(update, [usertypes.Completion.bind]))
 
     objreg.get('config').changed.connect(_update_aliases)

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -286,4 +286,4 @@ def _get_cmd_completions(include_hidden, include_aliases, prefix=''):
             bindings = ', '.join(cmd_to_keys.get(name, []))
             cmdlist.append((name, "Alias for '{}'".format(cmd), bindings))
 
-    return sorted(cmdlist)
+    return cmdlist

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -283,6 +283,7 @@ def _get_cmd_completions(include_hidden, include_aliases, prefix=''):
 
     if include_aliases:
         for name, cmd in config.section('aliases').items():
-            cmdlist.append((name, "Alias for '{}'".format(cmd), ''))
+            bindings = ', '.join(cmd_to_keys.get(name, []))
+            cmdlist.append((name, "Alias for '{}'".format(cmd), bindings))
 
     return sorted(cmdlist)

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -278,7 +278,7 @@ def _get_cmd_completions(include_hidden, include_aliases, prefix=''):
         hide_debug = obj.debug and not objreg.get('args').debug
         hide_hidden = obj.hide and not include_hidden
         if not (hide_debug or hide_hidden or obj.deprecated):
-            bindings = ', '.join(cmd_to_keys[obj.name])
+            bindings = ', '.join(cmd_to_keys.get(obj.name, []))
             cmdlist.append((prefix + obj.name, obj.desc, bindings))
 
     if include_aliases:

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -39,23 +39,11 @@ class CommandCompletionModel(base.BaseCompletionModel):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        assert cmdutils.cmd_dict
-        cmdlist = []
-        for obj in set(cmdutils.cmd_dict.values()):
-            if (obj.hide or (obj.debug and not objreg.get('args').debug) or
-                    obj.deprecated):
-                pass
-            else:
-                cmdlist.append((obj.name, obj.desc))
-        for name, cmd in config.section('aliases').items():
-            cmdlist.append((name, "Alias for '{}'".format(cmd)))
+        cmdlist = _get_cmd_completions(include_aliases=True,
+                                       include_hidden=False)
         cat = self.new_category("Commands")
-
-        # map each command to its bound keys and show these in the misc column
-        key_config = objreg.get('key-config')
-        cmd_to_keys = key_config.get_reverse_bindings_for('normal')
-        for (name, desc) in sorted(cmdlist):
-            self.new_item(cat, name, desc, ', '.join(cmd_to_keys[name]))
+        for (name, desc, misc) in cmdlist:
+            self.new_item(cat, name, desc, misc, )
 
 
 class HelpCompletionModel(base.BaseCompletionModel):
@@ -72,17 +60,11 @@ class HelpCompletionModel(base.BaseCompletionModel):
 
     def _init_commands(self):
         """Fill completion with :command entries."""
-        assert cmdutils.cmd_dict
-        cmdlist = []
-        for obj in set(cmdutils.cmd_dict.values()):
-            if ((obj.debug and not objreg.get('args').debug) or
-                obj.deprecated):
-                pass
-            else:
-                cmdlist.append((':' + obj.name, obj.desc))
+        cmdlist = _get_cmd_completions(include_aliases=False,
+                                       include_hidden=True, prefix=':')
         cat = self.new_category("Commands")
-        for (name, desc) in sorted(cmdlist):
-            self.new_item(cat, name, desc)
+        for (name, desc, misc) in cmdlist:
+            self.new_item(cat, name, desc, misc)
 
     def _init_settings(self):
         """Fill completion with section->option entries."""
@@ -272,20 +254,35 @@ class BindCompletionModel(base.BaseCompletionModel):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        assert cmdutils.cmd_dict
-        cmdlist = []
-        for obj in set(cmdutils.cmd_dict.values()):
-            if ((obj.debug and not objreg.get('args').debug) or
-                obj.deprecated):
-                pass
-            else:
-                cmdlist.append((obj.name, obj.desc))
-        for name, cmd in config.section('aliases').items():
-            cmdlist.append((name, "Alias for '{}'".format(cmd)))
+        cmdlist = _get_cmd_completions(include_hidden=True,
+                                       include_aliases=True)
         cat = self.new_category("Commands")
+        for (name, desc, misc) in cmdlist:
+            self.new_item(cat, name, desc, misc)
 
-        # map each command to its bound keys and show these in the misc column
-        key_config = objreg.get('key-config')
-        cmd_to_keys = key_config.get_reverse_bindings_for('normal')
-        for (name, desc) in sorted(cmdlist):
-            self.new_item(cat, name, desc, ', '.join(cmd_to_keys[name]))
+
+def _get_cmd_completions(include_hidden, include_aliases, prefix=''):
+    """Get a list of completions info for commands, sorted by name.
+
+    Args:
+        include_hidden: True to include commands annotated with hide=True.
+        include_aliases: True to include command aliases.
+        prefix: String to append to the command name.
+
+    Return: A list of tuples of form (name, description, bindings).
+    """
+    assert cmdutils.cmd_dict
+    cmdlist = []
+    cmd_to_keys = objreg.get('key-config').get_reverse_bindings_for('normal')
+    for obj in set(cmdutils.cmd_dict.values()):
+        if ((not obj.debug or objreg.get('args').debug) and
+             not obj.deprecated and
+             (include_hidden or not obj.hide)):
+            bindings = ', '.join(cmd_to_keys[obj.name])
+            cmdlist.append((prefix + obj.name, obj.desc, bindings))
+
+    if include_aliases:
+        for name, cmd in config.section('aliases').items():
+            cmdlist.append((name, "Alias for '{}'".format(cmd), ''))
+
+    return sorted(cmdlist)

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -75,8 +75,8 @@ class HelpCompletionModel(base.BaseCompletionModel):
         assert cmdutils.cmd_dict
         cmdlist = []
         for obj in set(cmdutils.cmd_dict.values()):
-            if (obj.hide or (obj.debug and not objreg.get('args').debug) or
-                    obj.deprecated):
+            if ((obj.debug and not objreg.get('args').debug) or
+                obj.deprecated):
                 pass
             else:
                 cmdlist.append((':' + obj.name, obj.desc))

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -43,7 +43,7 @@ class CommandCompletionModel(base.BaseCompletionModel):
                                        include_hidden=False)
         cat = self.new_category("Commands")
         for (name, desc, misc) in cmdlist:
-            self.new_item(cat, name, desc, misc, )
+            self.new_item(cat, name, desc, misc)
 
 
 class HelpCompletionModel(base.BaseCompletionModel):
@@ -275,9 +275,9 @@ def _get_cmd_completions(include_hidden, include_aliases, prefix=''):
     cmdlist = []
     cmd_to_keys = objreg.get('key-config').get_reverse_bindings_for('normal')
     for obj in set(cmdutils.cmd_dict.values()):
-        if ((not obj.debug or objreg.get('args').debug) and
-             not obj.deprecated and
-             (include_hidden or not obj.hide)):
+        hide_debug = obj.debug and not objreg.get('args').debug
+        hide_hidden = obj.hide and not include_hidden
+        if not (hide_debug or hide_hidden or obj.deprecated):
             bindings = ', '.join(cmd_to_keys[obj.name])
             cmdlist.append((prefix + obj.name, obj.desc, bindings))
 

--- a/qutebrowser/config/parsers/keyconf.py
+++ b/qutebrowser/config/parsers/keyconf.py
@@ -153,7 +153,7 @@ class KeyConfigParser(QObject):
     @cmdutils.register(instance='key-config', maxsplit=1, no_cmd_split=True,
                        no_replace_variables=True)
     @cmdutils.argument('win_id', win_id=True)
-    @cmdutils.argument('command', completion=usertypes.Completion.command)
+    @cmdutils.argument('command', completion=usertypes.Completion.bind)
     def bind(self, key, win_id, command=None, *, mode='normal', force=False):
         """Bind a key to a command.
 

--- a/qutebrowser/config/parsers/keyconf.py
+++ b/qutebrowser/config/parsers/keyconf.py
@@ -424,8 +424,9 @@ class KeyConfigParser(QObject):
 
     def get_reverse_bindings_for(self, section):
         """Get a dict of commands to a list of bindings for the section."""
-        cmd_to_keys = collections.defaultdict(list)
+        cmd_to_keys = {}
         for key, cmd in self.get_bindings_for(section).items():
+            cmd_to_keys.setdefault(cmd, [])
             # put special bindings last
             if utils.is_special_key(key):
                 cmd_to_keys[cmd].append(key)

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -238,7 +238,8 @@ KeyMode = enum('KeyMode', ['normal', 'hint', 'command', 'yesno', 'prompt',
 # Available command completions
 Completion = enum('Completion', ['command', 'section', 'option', 'value',
                                  'helptopic', 'quickmark_by_name',
-                                 'bookmark_by_url', 'url', 'tab', 'sessions'])
+                                 'bookmark_by_url', 'url', 'tab', 'sessions',
+                                 'bind'])
 
 
 # Exit statuses for errors. Needs to be an int for sys.exit.

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -193,7 +193,7 @@ def test_help_completion(qtmodeltester, monkeypatch, stubs):
     """Test the results of command completion.
 
     Validates that:
-        - only non-hidden and non-deprecated commands are included
+        - only non-deprecated commands are included
         - commands are sorted by name
         - the command description is shown in the desc column
         - the binding (if any) is shown in the misc column
@@ -211,8 +211,9 @@ def test_help_completion(qtmodeltester, monkeypatch, stubs):
     assert actual == [
         ("Commands", [
             (':drop', 'drop all user data', ''),
+            (':hide', '', ''),
             (':roll', 'never gonna give you up', ''),
-            (':stop', 'stop qutebrowser', '')
+            (':stop', 'stop qutebrowser', ''),
         ]),
         ("Settings", [
             ('general->time', 'Is an illusion.', ''),

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -189,7 +189,7 @@ def test_command_completion(qtmodeltester, monkeypatch, stubs, config_stub,
     ]
 
 
-def test_help_completion(qtmodeltester, monkeypatch, stubs):
+def test_help_completion(qtmodeltester, monkeypatch, stubs, key_config_stub):
     """Test the results of command completion.
 
     Validates that:
@@ -201,6 +201,7 @@ def test_help_completion(qtmodeltester, monkeypatch, stubs):
         - only the first line of a multiline description is shown
     """
     module = 'qutebrowser.completion.models.miscmodels'
+    key_config_stub.set_bindings_for('normal', {'s': 'stop', 'rr': 'roll'})
     _patch_cmdutils(monkeypatch, stubs, module + '.cmdutils')
     _patch_configdata(monkeypatch, stubs, module + '.configdata.DATA')
     model = miscmodels.HelpCompletionModel()
@@ -212,8 +213,8 @@ def test_help_completion(qtmodeltester, monkeypatch, stubs):
         ("Commands", [
             (':drop', 'drop all user data', ''),
             (':hide', '', ''),
-            (':roll', 'never gonna give you up', ''),
-            (':stop', 'stop qutebrowser', ''),
+            (':roll', 'never gonna give you up', 'rr'),
+            (':stop', 'stop qutebrowser', 's'),
         ]),
         ("Settings", [
             ('general->time', 'Is an illusion.', ''),

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -448,3 +448,34 @@ def test_setting_value_completion(qtmodeltester, monkeypatch, stubs,
             ('11', '', ''),
         ])
     ]
+
+
+def test_bind_completion(qtmodeltester, monkeypatch, stubs, config_stub,
+                         key_config_stub):
+    """Test the results of command completion.
+
+    Validates that:
+        - only non-hidden and non-deprecated commands are included
+        - commands are sorted by name
+        - the command description is shown in the desc column
+        - the binding (if any) is shown in the misc column
+        - aliases are included
+    """
+    _patch_cmdutils(monkeypatch, stubs,
+                    'qutebrowser.completion.models.miscmodels.cmdutils')
+    config_stub.data['aliases'] = {'rock': 'roll'}
+    key_config_stub.set_bindings_for('normal', {'s': 'stop', 'rr': 'roll'})
+    model = miscmodels.BindCompletionModel()
+    qtmodeltester.data_display_may_return_none = True
+    qtmodeltester.check(model)
+
+    actual = _get_completions(model)
+    assert actual == [
+        ("Commands", [
+            ('drop', 'drop all user data', ''),
+            ('hide', '', ''),
+            ('rock', "Alias for 'roll'", ''),
+            ('roll', 'never gonna give you up', 'rr'),
+            ('stop', 'stop qutebrowser', 's')
+        ])
+    ]

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -173,7 +173,9 @@ def test_command_completion(qtmodeltester, monkeypatch, stubs, config_stub,
     _patch_cmdutils(monkeypatch, stubs,
                     'qutebrowser.completion.models.miscmodels.cmdutils')
     config_stub.data['aliases'] = {'rock': 'roll'}
-    key_config_stub.set_bindings_for('normal', {'s': 'stop', 'rr': 'roll'})
+    key_config_stub.set_bindings_for('normal', {'s': 'stop',
+                                                'rr': 'roll',
+                                                'ro': 'rock'})
     model = miscmodels.CommandCompletionModel()
     qtmodeltester.data_display_may_return_none = True
     qtmodeltester.check(model)
@@ -182,7 +184,7 @@ def test_command_completion(qtmodeltester, monkeypatch, stubs, config_stub,
     assert actual == [
         ("Commands", [
             ('drop', 'drop all user data', ''),
-            ('rock', "Alias for 'roll'", ''),
+            ('rock', "Alias for 'roll'", 'ro'),
             ('roll', 'never gonna give you up', 'rr'),
             ('stop', 'stop qutebrowser', 's')
         ])
@@ -465,7 +467,9 @@ def test_bind_completion(qtmodeltester, monkeypatch, stubs, config_stub,
     _patch_cmdutils(monkeypatch, stubs,
                     'qutebrowser.completion.models.miscmodels.cmdutils')
     config_stub.data['aliases'] = {'rock': 'roll'}
-    key_config_stub.set_bindings_for('normal', {'s': 'stop', 'rr': 'roll'})
+    key_config_stub.set_bindings_for('normal', {'s': 'stop',
+                                                'rr': 'roll',
+                                                'ro': 'rock'})
     model = miscmodels.BindCompletionModel()
     qtmodeltester.data_display_may_return_none = True
     qtmodeltester.check(model)
@@ -475,7 +479,7 @@ def test_bind_completion(qtmodeltester, monkeypatch, stubs, config_stub,
         ("Commands", [
             ('drop', 'drop all user data', ''),
             ('hide', '', ''),
-            ('rock', "Alias for 'roll'", ''),
+            ('rock', "Alias for 'roll'", 'ro'),
             ('roll', 'never gonna give you up', 'rr'),
             ('stop', 'stop qutebrowser', 's')
         ])

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -453,7 +453,7 @@ def test_setting_value_completion(qtmodeltester, monkeypatch, stubs,
 
 def test_bind_completion(qtmodeltester, monkeypatch, stubs, config_stub,
                          key_config_stub):
-    """Test the results of command completion.
+    """Test the results of keybinding command completion.
 
     Validates that:
         - only non-hidden and non-deprecated commands are included


### PR DESCRIPTION
Note that with the refactoring in 52d0735, bindings are now included in the help completion model but not shown as it allocates 0 width for the `misc` column. Doing so can clip some setting descriptions so I wasn't sure if it was worth it.

Resolves #1707 