### PR TITLE
Remove cmdutils.arg_or_count

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -717,18 +717,17 @@ class CommandDispatcher:
     def zoom(self, zoom: int=None, count=None):
         """Set the zoom level for the current tab.
 
-        The zoom can be given as argument or as [count]. If neither of both is
-        given, the zoom is set to the default zoom.
+        The zoom can be given as argument or as [count]. If neither is
+        given, the zoom is set to the default zoom. If both are given,
+        use [count].
 
         Args:
             zoom: The zoom percentage to set.
             count: The zoom percentage to set.
         """
-        try:
-            default = config.get('ui', 'default-zoom')
-            level = cmdutils.arg_or_count(zoom, count, default=default)
-        except ValueError as e:
-            raise cmdexc.CommandError(e)
+        level = count if count is not None else zoom
+        if level is None:
+            level = config.get('ui', 'default-zoom')
         tab = self._current_widget()
 
         try:
@@ -914,22 +913,18 @@ class CommandDispatcher:
         if index == 'last':
             self._tab_focus_last()
             return
-        if index is None and count is None:
+        index = count if count is not None else index
+        if index is None:
             self.tab_next()
             return
-        if index is not None and index < 0:
+        if index < 0:
             index = self._count() + index + 1
-        try:
-            idx = cmdutils.arg_or_count(index, count, default=1,
-                                        countzero=self._count())
-        except ValueError as e:
-            raise cmdexc.CommandError(e)
-        cmdutils.check_overflow(idx + 1, 'int')
-        if 1 <= idx <= self._count():
-            self._set_current_index(idx - 1)
+
+        if 1 <= index <= self._count():
+            self._set_current_index(index - 1)
         else:
             raise cmdexc.CommandError("There's no tab with index {}!".format(
-                idx))
+                index))
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('index', choices=['+', '-'])

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -903,11 +903,13 @@ class CommandDispatcher:
         """Select the tab given as argument/[count].
 
         If neither count nor index are given, it behaves like tab-next.
+        If both are given, use count.
 
         Args:
             index: The tab index to focus, starting with 1. The special value
-                   `last` focuses the last focused tab. Negative indexes
-                   counts from the end, such that -1 is the last tab.
+                   `last` focuses the last focused tab (regardless of count).
+                   Negative indices count from the end, such that -1 is the
+                   last tab.
             count: The tab index to focus, starting with 1.
         """
         if index == 'last':

--- a/qutebrowser/commands/cmdutils.py
+++ b/qutebrowser/commands/cmdutils.py
@@ -48,36 +48,6 @@ def check_overflow(arg, ctype):
             "representation.".format(ctype))
 
 
-def arg_or_count(arg, count, default=None, countzero=None):
-    """Get a value based on an argument and count given to a command.
-
-    If both arg and count are set, ValueError is raised.
-    If only arg/count is set, it is used.
-    If none is set, a default is returned or ValueError is raised.
-
-    Args:
-        arg: The argument given to a command.
-        count: The count given to a command.
-        countzero: Special value if count is 0.
-
-    Return:
-        The value to use.
-    """
-    if count is not None and arg is not None:
-        raise ValueError("Both count and argument given!")
-    elif arg is not None:
-        return arg
-    elif count is not None:
-        if countzero is not None and count == 0:
-            return countzero
-        else:
-            return count
-    elif default is not None:
-        return default
-    else:
-        raise ValueError("Either count or argument have to be set!")
-
-
 def check_exclusive(flags, names):
     """Check if only one flag is set with exclusive flags.
 

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -200,7 +200,7 @@ Feature: Tab management
 
     Scenario: :tab-focus with very big index
         When I run :tab-focus 99999999999999
-        Then the error "Numeric argument is too large for internal int representation." should be shown
+        Then the error "There's no tab with index 99999999999999!" should be shown
 
     Scenario: :tab-focus with count
         When I open data/numbers/1.txt
@@ -213,8 +213,14 @@ Feature: Tab management
             - data/numbers/3.txt
 
     Scenario: :tab-focus with count and index
-        When I run :tab-focus 2 with count 2
-        Then the error "Both count and argument given!" should be shown
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I open data/numbers/3.txt in a new tab
+        And I run :tab-focus 4 with count 2
+        Then the following tabs should be open:
+            - data/numbers/1.txt
+            - data/numbers/2.txt (active)
+            - data/numbers/3.txt
 
     Scenario: :tab-focus last
         When I open data/numbers/1.txt

--- a/tests/end2end/features/zoom.feature
+++ b/tests/end2end/features/zoom.feature
@@ -71,7 +71,8 @@ Feature: Zooming in and out
 
     Scenario: Setting zoom with argument and count
         When I run :zoom 50 with count 60
-        Then the error "Both count and argument given!" should be shown
+        Then the message "Zoom level: 60%" should be shown
+        And the zoom should be 60%
 
     # Fixed in QtWebEngine branch
     @xfail

--- a/tests/unit/commands/test_cmdutils.py
+++ b/tests/unit/commands/test_cmdutils.py
@@ -64,29 +64,6 @@ class TestCheckOverflow:
         assert str(excinfo.value) == expected_str
 
 
-class TestArgOrCount:
-
-    @pytest.mark.parametrize('arg, count', [(None, None), (1, 1)])
-    def test_exceptions(self, arg, count):
-        with pytest.raises(ValueError):
-            cmdutils.arg_or_count(arg, count)
-
-    @pytest.mark.parametrize('arg, count', [(1, None), (None, 1)])
-    def test_normal(self, arg, count):
-        assert cmdutils.arg_or_count(arg, count) == 1
-
-    @pytest.mark.parametrize('arg, count, countzero, expected', [
-        (0, None, 2, 0),
-        (None, 0, 2, 2),
-    ])
-    def test_countzero(self, arg, count, countzero, expected):
-        ret = cmdutils.arg_or_count(arg, count, countzero=countzero)
-        assert ret == expected
-
-    def test_default(self):
-        assert cmdutils.arg_or_count(None, None, default=2) == 2
-
-
 class TestCheckExclusive:
 
     @pytest.mark.parametrize('flags', [[], [False, True], [False, False]])


### PR DESCRIPTION
As discussed in #1735. I removed the check that ensures `tab-focus`'s argument is an int, since we are going to bounds-check it anyway. ~~The case where `zoom` uses the `ui default-zoom` value was never tested, but this is now caught by coverage since the logic is explicit.~~ (Never mind; it was tested).