### PR TITLE
Add --implicit option to :open

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -114,7 +114,8 @@ class CommandDispatcher:
             raise cmdexc.CommandError("No WebView available yet!")
         return widget
 
-    def _open(self, url, tab=False, background=False, window=False):
+    def _open(self, url, explicit=True,
+              tab=False, background=False, window=False):
         """Helper function to open a page.
 
         Args:
@@ -130,9 +131,9 @@ class CommandDispatcher:
             tabbed_browser = self._new_tabbed_browser()
             tabbed_browser.tabopen(url)
         elif tab:
-            tabbed_browser.tabopen(url, background=False, explicit=True)
+            tabbed_browser.tabopen(url, background=False, explicit=explicit)
         elif background:
-            tabbed_browser.tabopen(url, background=True, explicit=True)
+            tabbed_browser.tabopen(url, background=True, explicit=explicit)
         else:
             widget = self._current_widget()
             widget.openurl(url)
@@ -231,7 +232,8 @@ class CommandDispatcher:
                        maxsplit=0, scope='window')
     @cmdutils.argument('url', completion=usertypes.Completion.url)
     @cmdutils.argument('count', count=True)
-    def openurl(self, url=None, bg=False, tab=False, window=False, count=None):
+    def openurl(self, url=None, implicit=False,
+                bg=False, tab=False, window=False, count=None):
         """Open a URL in the current/[count]th tab.
 
         Args:
@@ -239,6 +241,8 @@ class CommandDispatcher:
             bg: Open in a new background tab.
             tab: Open in a new tab.
             window: Open in a new window.
+            implicit: If opening a new tab, treat the tab as implicit (like
+                      clicking on a link).
             count: The tab index to open the URL in, or None.
         """
         if url is None:
@@ -259,7 +263,7 @@ class CommandDispatcher:
                     message.error(self._win_id, str(e))
                     return
         if tab or bg or window:
-            self._open(url, tab, bg, window)
+            self._open(url, not implicit, tab, bg, window)
         else:
             curtab = self._cntwidget(count)
             if curtab is None:

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -114,8 +114,8 @@ class CommandDispatcher:
             raise cmdexc.CommandError("No WebView available yet!")
         return widget
 
-    def _open(self, url, explicit=True,
-              tab=False, background=False, window=False):
+    def _open(self, url, tab=False, background=False, window=False,
+              explicit=True):
         """Helper function to open a page.
 
         Args:
@@ -263,7 +263,7 @@ class CommandDispatcher:
                     message.error(self._win_id, str(e))
                     return
         if tab or bg or window:
-            self._open(url, not implicit, tab, bg, window)
+            self._open(url, tab, bg, window, not implicit)
         else:
             curtab = self._cntwidget(count)
             if curtab is None:

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -1656,9 +1656,4 @@ CHANGED_KEY_COMMANDS = [
     (re.compile(r'^download-remove --all$'), r'download-clear'),
 
     (re.compile(r'^hint links fill "([^"]*)"$'), r'hint links fill \1'),
-
-    (re.compile(r'^set-cmd-text :open -([tb]) {url:pretty}$'),
-                 r'set-cmd-text :open -\1 -i {url:pretty}'),
-    (re.compile(r'^hint links fill :open -t {hint-url}$'),
-                 r'hint links fill :open -t -i {hint-url}'),
 ]

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -1428,9 +1428,9 @@ KEY_DATA = collections.OrderedDict([
         ('set-cmd-text -s :open', ['o']),
         ('set-cmd-text :open {url:pretty}', ['go']),
         ('set-cmd-text -s :open -t', ['O']),
-        ('set-cmd-text :open -t {url:pretty}', ['gO']),
+        ('set-cmd-text :open -t -i {url:pretty}', ['gO']),
         ('set-cmd-text -s :open -b', ['xo']),
-        ('set-cmd-text :open -b {url:pretty}', ['xO']),
+        ('set-cmd-text :open -b -i {url:pretty}', ['xO']),
         ('set-cmd-text -s :open -w', ['wo']),
         ('set-cmd-text :open -w {url:pretty}', ['wO']),
         ('open -t', ['ga', '<Ctrl-T>']),
@@ -1463,7 +1463,7 @@ KEY_DATA = collections.OrderedDict([
         ('hint images', [';i']),
         ('hint images tab', [';I']),
         ('hint links fill :open {hint-url}', [';o']),
-        ('hint links fill :open -t {hint-url}', [';O']),
+        ('hint links fill :open -t -i {hint-url}', [';O']),
         ('hint links yank', [';y']),
         ('hint links yank-primary', [';Y']),
         ('hint --rapid links tab-bg', [';r']),
@@ -1656,4 +1656,9 @@ CHANGED_KEY_COMMANDS = [
     (re.compile(r'^download-remove --all$'), r'download-clear'),
 
     (re.compile(r'^hint links fill "([^"]*)"$'), r'hint links fill \1'),
+
+    (re.compile(r'^set-cmd-text :open -([tb]) {url:pretty}$'),
+                 r'set-cmd-text :open -\1 -i {url:pretty}'),
+    (re.compile(r'^hint links fill :open -t {hint-url}$'),
+                 r'hint links fill :open -t -i {hint-url}'),
 ]

--- a/tests/end2end/features/open.feature
+++ b/tests/end2end/features/open.feature
@@ -43,31 +43,18 @@ Feature: Opening pages
         When I run :tab-only
         And I run :open -t http://localhost:(port)/data/numbers/4.txt
         And I wait until data/numbers/4.txt is loaded
-        Then the session should look like:
-            windows:
-            - tabs:
-              - history:
-                - url: about:blank
-              - active: true
-                history:
-                - active: true
-                  url: http://localhost:*/data/numbers/4.txt
+        Then the following tabs should be open:
+            - about:blank
+            - data/numbers/4.txt (active)
 
     Scenario: Opening in a new background tab
         Given I open about:blank
         When I run :tab-only
         And I run :open -b http://localhost:(port)/data/numbers/5.txt
         And I wait until data/numbers/5.txt is loaded
-        Then the session should look like:
-            windows:
-            - tabs:
-              - active: true
-                history:
-                - active: true
-                  url: about:blank
-              - history:
-                - active: true
-                  url: http://localhost:*/data/numbers/5.txt
+        Then the following tabs should be open:
+            - about:blank (active)
+            - data/numbers/5.txt
 
     Scenario: :open with count
         Given I open about:blank
@@ -86,11 +73,33 @@ Feature: Opening pages
                 - active: true
                   url: http://localhost:*/data/numbers/6.txt
 
+    Scenario: Opening in a new tab (explicit)
+        Given I open about:blank
+        When I set tabs -> new-tab-position-explicit to right
+        And I set tabs -> new-tab-position to left
+        And I run :tab-only
+        And I run :open -t http://localhost:(port)/data/numbers/7.txt
+        And I wait until data/numbers/7.txt is loaded
+        Then the following tabs should be open:
+            - about:blank
+            - data/numbers/7.txt (active)
+
+    Scenario: Opening in a new tab (implicit)
+        Given I open about:blank
+        When I set tabs -> new-tab-position-explicit to right
+        And I set tabs -> new-tab-position to left
+        And I run :tab-only
+        And I run :open -t -i http://localhost:(port)/data/numbers/8.txt
+        And I wait until data/numbers/8.txt is loaded
+        Then the following tabs should be open:
+            - data/numbers/8.txt (active)
+            - about:blank
+
     Scenario: Opening in a new window
         Given I open about:blank
         When I run :tab-only
-        And I run :open -w http://localhost:(port)/data/numbers/7.txt
-        And I wait until data/numbers/7.txt is loaded
+        And I run :open -w http://localhost:(port)/data/numbers/9.txt
+        And I wait until data/numbers/9.txt is loaded
         Then the session should look like:
             windows:
             - tabs:
@@ -102,43 +111,9 @@ Feature: Opening pages
               - active: true
                 history:
                 - active: true
-                  url: http://localhost:*/data/numbers/7.txt
-
-    Scenario: Opening a quickmark
-        When I run :quickmark-add http://localhost:(port)/data/numbers/8.txt quickmarktest
-        And I run :open quickmarktest
-        Then data/numbers/8.txt should be loaded
-
-    Scenario: :open with URL (explicit)
-        Given I open about:blank
-        When I set tabs -> new-tab-position-explicit to right
-        And I set tabs -> new-tab-position to left
-        And I run :tab-only
-        And I run :open -t http://localhost:(port)/data/numbers/9.txt
-        And I wait until data/numbers/9.txt is loaded
-        Then the session should look like:
-            windows:
-            - tabs:
-              - history:
-                - url: about:blank
-              - active: true
-                history:
-                - active: true
                   url: http://localhost:*/data/numbers/9.txt
 
-    Scenario: :open with URL (implicit)
-        Given I open about:blank
-        When I set tabs -> new-tab-position-explicit to right
-        And I set tabs -> new-tab-position to left
-        And I run :tab-only
-        And I run :open -t -i http://localhost:(port)/data/numbers/10.txt
-        And I wait until data/numbers/10.txt is loaded
-        Then the session should look like:
-            windows:
-            - tabs:
-              - active: true
-                history:
-                - active: true
-                  url: http://localhost:*/data/numbers/10.txt
-              - history:
-                - url: about:blank
+    Scenario: Opening a quickmark
+        When I run :quickmark-add http://localhost:(port)/data/numbers/10.txt quickmarktest
+        And I run :open quickmarktest
+        Then data/numbers/10.txt should be loaded

--- a/tests/end2end/features/open.feature
+++ b/tests/end2end/features/open.feature
@@ -108,3 +108,37 @@ Feature: Opening pages
         When I run :quickmark-add http://localhost:(port)/data/numbers/8.txt quickmarktest
         And I run :open quickmarktest
         Then data/numbers/8.txt should be loaded
+
+    Scenario: :open with URL (explicit)
+        Given I open about:blank
+        When I set tabs -> new-tab-position-explicit to right
+        And I set tabs -> new-tab-position to left
+        And I run :tab-only
+        And I run :open -t http://localhost:(port)/data/numbers/9.txt
+        And I wait until data/numbers/9.txt is loaded
+        Then the session should look like:
+            windows:
+            - tabs:
+              - history:
+                - url: about:blank
+              - active: true
+                history:
+                - active: true
+                  url: http://localhost:*/data/numbers/9.txt
+
+    Scenario: :open with URL (implicit)
+        Given I open about:blank
+        When I set tabs -> new-tab-position-explicit to right
+        And I set tabs -> new-tab-position to left
+        And I run :tab-only
+        And I run :open -t -i http://localhost:(port)/data/numbers/10.txt
+        And I wait until data/numbers/10.txt is loaded
+        Then the session should look like:
+            windows:
+            - tabs:
+              - active: true
+                history:
+                - active: true
+                  url: http://localhost:*/data/numbers/10.txt
+              - history:
+                - url: about:blank


### PR DESCRIPTION
Some keybindings with `:open -t` or `:open -b` open a tab which is related to the current one. In particular, `hint links fill :open -t {hint-url}` (default `;O`) essentially opens a link with the ability to inspect it first. Adding an `--implicit` flag to `:open`, which treats any new tab opened by the command as implicitly opened, lets these commands work like opening a link does.