### PR TITLE
Allow {url} and {url:pretty} as parts of arguments

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -696,7 +696,7 @@ You can use the `{url}` and `{url:pretty}` variables here which will get replace
 
 [[spawn]]
 === spawn
-Syntax: +:spawn [*--userscript*] [*--verbose*] [*--detach*] 'cmdline'+
+Syntax: +:spawn [*--userscript*] [*--verbose*] [*--detach*] 'cmdline' ['cmdline' ...]+
 
 Spawn a command in a shell.
 
@@ -714,10 +714,6 @@ Note the `{url}` and `{url:pretty}` variables might be useful here. `{url}` gets
 
 * +*-v*+, +*--verbose*+: Show notifications when the command started/exited.
 * +*-d*+, +*--detach*+: Whether the command should be detached from qutebrowser.
-
-==== note
-* This command does not split arguments after the last argument and handles quotes literally.
-* This command does not replace variables like +\{url\}+.
 
 [[stop]]
 === stop

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -696,7 +696,7 @@ You can use the `{url}` and `{url:pretty}` variables here which will get replace
 
 [[spawn]]
 === spawn
-Syntax: +:spawn [*--userscript*] [*--verbose*] [*--detach*] 'cmdline' ['cmdline' ...]+
+Syntax: +:spawn [*--userscript*] [*--verbose*] [*--detach*] 'cmdline'+
 
 Spawn a command in a shell.
 
@@ -714,6 +714,9 @@ Note the `{url}` and `{url:pretty}` variables might be useful here. `{url}` gets
 
 * +*-v*+, +*--verbose*+: Show notifications when the command started/exited.
 * +*-d*+, +*--detach*+: Whether the command should be detached from qutebrowser.
+
+==== note
+* This command does not split arguments after the last argument and handles quotes literally.
 
 [[stop]]
 === stop

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -111,6 +111,7 @@ Bind a key to a command.
 ==== note
 * This command does not split arguments after the last argument and handles quotes literally.
 * With this command, +;;+ is interpreted literally instead of splitting off a second command.
+* This command does not replace variables like +\{url\}+.
 
 [[bookmark-add]]
 === bookmark-add
@@ -412,6 +413,7 @@ Execute a command after some time.
 ==== note
 * This command does not split arguments after the last argument and handles quotes literally.
 * With this command, +;;+ is interpreted literally instead of splitting off a second command.
+* This command does not replace variables like +\{url\}+.
 
 [[messages]]
 === messages
@@ -579,6 +581,7 @@ Repeat a given command.
 ==== note
 * This command does not split arguments after the last argument and handles quotes literally.
 * With this command, +;;+ is interpreted literally instead of splitting off a second command.
+* This command does not replace variables like +\{url\}+.
 
 [[report]]
 === report
@@ -714,6 +717,7 @@ Note the `{url}` and `{url:pretty}` variables might be useful here. `{url}` gets
 
 ==== note
 * This command does not split arguments after the last argument and handles quotes literally.
+* This command does not replace variables like +\{url\}+.
 
 [[stop]]
 === stop

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -992,7 +992,7 @@ class CommandDispatcher:
             self._tabbed_browser.setUpdatesEnabled(True)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
-                       maxsplit=0)
+                       maxsplit=0, no_replace_variables=True)
     def spawn(self, cmdline, userscript=False, verbose=False, detach=False):
         """Spawn a command in a shell.
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -991,9 +991,8 @@ class CommandDispatcher:
         finally:
             self._tabbed_browser.setUpdatesEnabled(True)
 
-    @cmdutils.register(instance='command-dispatcher', scope='window',
-                       maxsplit=0, no_replace_variables=True)
-    def spawn(self, cmdline, userscript=False, verbose=False, detach=False):
+    @cmdutils.register(instance='command-dispatcher', scope='window')
+    def spawn(self, *cmdline, userscript=False, verbose=False, detach=False):
         """Spawn a command in a shell.
 
         Note the `{url}` and `{url:pretty}` variables might be useful here.
@@ -1012,14 +1011,7 @@ class CommandDispatcher:
             detach: Whether the command should be detached from qutebrowser.
             cmdline: The commandline to execute.
         """
-        try:
-            cmd, *args = shlex.split(cmdline)
-        except ValueError as e:
-            raise cmdexc.CommandError("Error while splitting command: "
-                                      "{}".format(e))
-
-        args = runners.replace_variables(self._win_id, args)
-
+        cmd, *args = cmdline
         log.procs.debug("Executing {} with args {}, userscript={}".format(
             cmd, args, userscript))
         if userscript:

--- a/qutebrowser/commands/command.py
+++ b/qutebrowser/commands/command.py
@@ -82,7 +82,7 @@ class Command:
         no_cmd_split: If true, ';;' to split sub-commands is ignored.
         backend: Which backend the command works with (or None if it works with
                  both)
-        no_replace_variables: Whether or not to replace variables like {url}
+        no_replace_variables: Don't replace variables like {url}
         _qute_args: The saved data from @cmdutils.argument
         _needs_js: Whether the command needs javascript enabled
         _modes: The modes the command can be executed in.

--- a/qutebrowser/commands/command.py
+++ b/qutebrowser/commands/command.py
@@ -82,6 +82,7 @@ class Command:
         no_cmd_split: If true, ';;' to split sub-commands is ignored.
         backend: Which backend the command works with (or None if it works with
                  both)
+        no_replace_variables: Whether or not to replace variables like {url}
         _qute_args: The saved data from @cmdutils.argument
         _needs_js: Whether the command needs javascript enabled
         _modes: The modes the command can be executed in.
@@ -95,7 +96,7 @@ class Command:
                  hide=False, modes=None, not_modes=None, needs_js=False,
                  debug=False, ignore_args=False, deprecated=False,
                  no_cmd_split=False, star_args_optional=False, scope='global',
-                 backend=None):
+                 backend=None, no_replace_variables=False):
         # I really don't know how to solve this in a better way, I tried.
         # pylint: disable=too-many-locals
         if modes is not None and not_modes is not None:
@@ -127,6 +128,7 @@ class Command:
         self.handler = handler
         self.no_cmd_split = no_cmd_split
         self.backend = backend
+        self.no_replace_variables = no_replace_variables
 
         self.docparser = docutils.DocstringParser(handler)
         self.parser = argparser.ArgumentParser(

--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -52,16 +52,16 @@ def replace_variables(win_id, arglist):
     args = []
     tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                 window=win_id)
-    if '{url}' in arglist:
+    if any('{url}' in arg for arg in arglist):
         url = _current_url(tabbed_browser).toString(QUrl.FullyEncoded |
                                                     QUrl.RemovePassword)
-    if '{url:pretty}' in arglist:
+    if any('{url:pretty}' in arg for arg in arglist):
         pretty_url = _current_url(tabbed_browser).toString(QUrl.RemovePassword)
     for arg in arglist:
-        if arg == '{url}':
-            args.append(url)
-        elif arg == '{url:pretty}':
-            args.append(pretty_url)
+        if '{url}' in arg:
+            args.append(arg.replace('{url}', url))
+        elif '{url:pretty}' in arg:
+            args.append(arg.replace('{url:pretty}', pretty_url))
         else:
             args.append(arg)
     return args
@@ -279,7 +279,10 @@ class CommandRunner(QObject):
                                       window=self._win_id)
             cur_mode = mode_manager.mode
 
-            args = replace_variables(self._win_id, result.args)
+            if result.cmd.no_replace_variables:
+                args = result.args
+            else:
+                args = replace_variables(self._win_id, result.args)
             if count is not None:
                 if result.count is not None:
                     raise cmdexc.CommandMetaError("Got count via command and "

--- a/qutebrowser/config/parsers/keyconf.py
+++ b/qutebrowser/config/parsers/keyconf.py
@@ -150,7 +150,8 @@ class KeyConfigParser(QObject):
             data = str(self)
             f.write(data)
 
-    @cmdutils.register(instance='key-config', maxsplit=1, no_cmd_split=True)
+    @cmdutils.register(instance='key-config', maxsplit=1, no_cmd_split=True,
+                       no_replace_variables=True)
     @cmdutils.argument('win_id', win_id=True)
     @cmdutils.argument('key', completion=usertypes.Completion.empty)
     @cmdutils.argument('command', completion=usertypes.Completion.command)

--- a/qutebrowser/mainwindow/statusbar/command.py
+++ b/qutebrowser/mainwindow/statusbar/command.py
@@ -23,7 +23,7 @@ from PyQt5.QtCore import pyqtSignal, pyqtSlot, Qt, QSize
 from PyQt5.QtWidgets import QSizePolicy
 
 from qutebrowser.keyinput import modeman, modeparsers
-from qutebrowser.commands import cmdexc, cmdutils, runners
+from qutebrowser.commands import cmdexc, cmdutils
 from qutebrowser.misc import cmdhistory, split
 from qutebrowser.misc import miscwidgets as misc
 from qutebrowser.utils import usertypes, log, objreg
@@ -109,7 +109,6 @@ class Command(misc.MinimalLineEditMixin, misc.CommandLineEdit):
             append: If given, the text is appended to the current text.
         """
         args = split.simple_split(text)
-        args = runners.replace_variables(self._win_id, args)
         text = ' '.join(args)
 
         if space:

--- a/qutebrowser/mainwindow/statusbar/command.py
+++ b/qutebrowser/mainwindow/statusbar/command.py
@@ -108,9 +108,6 @@ class Command(misc.MinimalLineEditMixin, misc.CommandLineEdit):
             space: If given, a space is added to the end.
             append: If given, the text is appended to the current text.
         """
-        args = split.simple_split(text)
-        text = ' '.join(args)
-
         if space:
             text += ' '
         if append:

--- a/qutebrowser/mainwindow/statusbar/command.py
+++ b/qutebrowser/mainwindow/statusbar/command.py
@@ -24,7 +24,7 @@ from PyQt5.QtWidgets import QSizePolicy
 
 from qutebrowser.keyinput import modeman, modeparsers
 from qutebrowser.commands import cmdexc, cmdutils
-from qutebrowser.misc import cmdhistory, split
+from qutebrowser.misc import cmdhistory
 from qutebrowser.misc import miscwidgets as misc
 from qutebrowser.utils import usertypes, log, objreg
 

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -39,7 +39,7 @@ from PyQt5.QtCore import QUrl
 from PyQt5.QtWidgets import QApplication  # pylint: disable=unused-import
 
 
-@cmdutils.register(maxsplit=1, no_cmd_split=True)
+@cmdutils.register(maxsplit=1, no_cmd_split=True, no_replace_variables=True)
 @cmdutils.argument('win_id', win_id=True)
 def later(ms: int, command, win_id):
     """Execute a command after some time.
@@ -69,7 +69,7 @@ def later(ms: int, command, win_id):
         raise
 
 
-@cmdutils.register(maxsplit=1, no_cmd_split=True)
+@cmdutils.register(maxsplit=1, no_cmd_split=True, no_replace_variables=True)
 @cmdutils.argument('win_id', win_id=True)
 def repeat(times: int, command, win_id):
     """Repeat a given command.

--- a/scripts/dev/src2asciidoc.py
+++ b/scripts/dev/src2asciidoc.py
@@ -239,7 +239,8 @@ def _get_command_doc_notes(cmd):
     Yield:
         Strings which should be added to the docs.
     """
-    if cmd.maxsplit is not None or cmd.no_cmd_split or cmd.no_replace_variables:
+    if (cmd.maxsplit is not None or cmd.no_cmd_split or
+            cmd.no_replace_variables):
         yield ""
         yield "==== note"
         if cmd.maxsplit is not None:

--- a/scripts/dev/src2asciidoc.py
+++ b/scripts/dev/src2asciidoc.py
@@ -249,7 +249,7 @@ def _get_command_doc_notes(cmd):
             yield ("* With this command, +;;+ is interpreted literally "
                    "instead of splitting off a second command.")
         if cmd.no_replace_variables:
-            yield "* This command does not replace variables like +\{url\}+."
+            yield r"* This command does not replace variables like +\{url\}+."
 
 
 def _get_action_metavar(action, nargs=1):

--- a/scripts/dev/src2asciidoc.py
+++ b/scripts/dev/src2asciidoc.py
@@ -239,7 +239,7 @@ def _get_command_doc_notes(cmd):
     Yield:
         Strings which should be added to the docs.
     """
-    if cmd.maxsplit is not None or cmd.no_cmd_split:
+    if cmd.maxsplit is not None or cmd.no_cmd_split or cmd.no_replace_variables:
         yield ""
         yield "==== note"
         if cmd.maxsplit is not None:
@@ -248,6 +248,8 @@ def _get_command_doc_notes(cmd):
         if cmd.no_cmd_split:
             yield ("* With this command, +;;+ is interpreted literally "
                    "instead of splitting off a second command.")
+        if cmd.no_replace_variables:
+            yield "* This command does not replace variables like +\{url\}+."
 
 
 def _get_action_metavar(action, nargs=1):

--- a/scripts/dev/src2asciidoc.py
+++ b/scripts/dev/src2asciidoc.py
@@ -240,7 +240,7 @@ def _get_command_doc_notes(cmd):
         Strings which should be added to the docs.
     """
     if (cmd.maxsplit is not None or cmd.no_cmd_split or
-            cmd.no_replace_variables):
+            cmd.no_replace_variables and cmd.name != "spawn"):
         yield ""
         yield "==== note"
         if cmd.maxsplit is not None:
@@ -249,7 +249,7 @@ def _get_command_doc_notes(cmd):
         if cmd.no_cmd_split:
             yield ("* With this command, +;;+ is interpreted literally "
                    "instead of splitting off a second command.")
-        if cmd.no_replace_variables:
+        if cmd.no_replace_variables and cmd.name != "spawn":
             yield r"* This command does not replace variables like +\{url\}+."
 
 


### PR DESCRIPTION
This makes commands like `:open web.archive.org/web/{url}` possible.

It also adds a no_replace_variables command register argument that stops the replacement from happening, which is important for commands like `:bind` and `:spawn` that take a command as an argument.