### PR TITLE
DocstringParser - support python with optimizations on

### DIFF
--- a/qutebrowser/misc/earlyinit.py
+++ b/qutebrowser/misc/earlyinit.py
@@ -300,6 +300,11 @@ def init_log(args):
     log.init_log(args)
     log.init.debug("Log initialized.")
 
+def check_optimize_flag():
+    from qutebrowser.utils import log
+    if sys.flags.optimize >= 2:
+        log.init.warning("Running on optimize level higher than 1, "
+                         "unexpected behaviors may occur.")
 
 def earlyinit(args):
     """Do all needed early initialization.
@@ -327,3 +332,4 @@ def earlyinit(args):
     remove_inputhook()
     check_libraries(args)
     check_ssl_support()
+    check_optimize_flag()

--- a/qutebrowser/utils/docutils.py
+++ b/qutebrowser/utils/docutils.py
@@ -26,7 +26,7 @@ import os.path
 import collections
 
 import qutebrowser
-from qutebrowser.utils import usertypes
+from qutebrowser.utils import usertypes, log, utils
 
 
 def is_git_repo():
@@ -98,6 +98,15 @@ class DocstringParser:
             self.State.arg_inside: self._parse_arg_inside,
             self.State.misc: self._skip,
         }
+        if doc is None:
+            if sys.flags.optimize < 2:
+                log.commands.warning(
+                    "Function {}() from {} has no docstring".format(
+                        utils.qualname(func),
+                        inspect.getsourcefile(func)))
+            self.long_desc = ""
+            self.short_desc = ""
+            return
         for line in doc.splitlines():
             handler = handlers[self._state]
             stop = handler(line)


### PR DESCRIPTION
when running qutebrowser on python with optimlizations `-OO` enabled, it will crash because docstrings will not be available.