### PR TITLE
Combine completion-item-{prev,next}.

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -914,8 +914,7 @@ How many steps to zoom out.
 |<<command-history-next,command-history-next>>|Go forward in the commandline history.
 |<<command-history-prev,command-history-prev>>|Go back in the commandline history.
 |<<completion-item-del,completion-item-del>>|Delete the current completion item.
-|<<completion-item-next,completion-item-next>>|Select the next completion item.
-|<<completion-item-prev,completion-item-prev>>|Select the previous completion item.
+|<<completion-item-focus,completion-item-focus>>|Shift the focus of the completion menu to another item.
 |<<drop-selection,drop-selection>>|Drop selection and keep selection mode enabled.
 |<<enter-mode,enter-mode>>|Enter a key mode.
 |<<follow-hint,follow-hint>>|Follow a hint.
@@ -991,13 +990,14 @@ Go back in the commandline history.
 === completion-item-del
 Delete the current completion item.
 
-[[completion-item-next]]
-=== completion-item-next
-Select the next completion item.
+[[completion-item-focus]]
+=== completion-item-focus
+Syntax: +:completion-item-focus 'which'+
 
-[[completion-item-prev]]
-=== completion-item-prev
-Select the previous completion item.
+Shift the focus of the completion menu to another item.
+
+==== positional arguments
+* +'which'+: 'next' or 'previous'
 
 [[drop-selection]]
 === drop-selection

--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -181,16 +181,14 @@ class CompletionView(QTreeView):
                 # Item is a real item, not a category header -> success
                 return idx
 
-    def _next_prev_item(self, prev):
-        """Handle a tab press for the CompletionView.
-
-        Select the previous/next item and write the new text to the
-        statusbar.
-
-        Helper for completion_item_next and completion_item_prev.
+    @cmdutils.register(instance='completion', hide=True,
+                       modes=[usertypes.KeyMode.command], scope='window')
+    @cmdutils.argument('which', choices=['next', 'prev'])
+    def completion_item_focus(self, which):
+        """Shift the focus of the completion menu to another item.
 
         Args:
-            prev: True for prev item, False for next one.
+            which: 'next' or 'prev'
         """
         # selmodel can be None if 'show' and 'auto-open' are set to False
         # https://github.com/The-Compiler/qutebrowser/issues/1731
@@ -198,7 +196,7 @@ class CompletionView(QTreeView):
         if selmodel is None:
             return
 
-        idx = self._next_idx(prev)
+        idx = self._next_idx(which == 'prev')
         if not idx.isValid():
             return
 
@@ -277,18 +275,6 @@ class CompletionView(QTreeView):
         if scrollbar is not None:
             scrollbar.setValue(scrollbar.minimum())
         super().showEvent(e)
-
-    @cmdutils.register(instance='completion', hide=True,
-                       modes=[usertypes.KeyMode.command], scope='window')
-    def completion_item_prev(self):
-        """Select the previous completion item."""
-        self._next_prev_item(True)
-
-    @cmdutils.register(instance='completion', hide=True,
-                       modes=[usertypes.KeyMode.command], scope='window')
-    def completion_item_next(self):
-        """Select the next completion item."""
-        self._next_prev_item(False)
 
     @cmdutils.register(instance='completion', hide=True,
                        modes=[usertypes.KeyMode.command], scope='window')

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -1415,8 +1415,7 @@ KEY_SECTION_DESC = {
         "Useful hidden commands to map in this section:\n\n"
         " * `command-history-prev`: Switch to previous command in history.\n"
         " * `command-history-next`: Switch to next command in history.\n"
-        " * `completion-item-prev`: Select previous item in completion.\n"
-        " * `completion-item-next`: Select next item in completion.\n"
+        " * `completion-item-focus`: Select another item in completion.\n"
         " * `command-accept`: Execute the command currently in the "
         "commandline."),
     'prompt': (
@@ -1589,8 +1588,8 @@ KEY_DATA = collections.OrderedDict([
     ('command', collections.OrderedDict([
         ('command-history-prev', ['<Ctrl-P>']),
         ('command-history-next', ['<Ctrl-N>']),
-        ('completion-item-prev', ['<Shift-Tab>', '<Up>']),
-        ('completion-item-next', ['<Tab>', '<Down>']),
+        ('completion-item-focus prev', ['<Shift-Tab>', '<Up>']),
+        ('completion-item-focus next', ['<Tab>', '<Down>']),
         ('completion-item-del', ['<Ctrl-D>']),
         ('command-accept', RETURN_KEYS),
     ])),
@@ -1686,4 +1685,7 @@ CHANGED_KEY_COMMANDS = [
     (re.compile(r'^yank -p'), r'yank pretty-url'),
     (re.compile(r'^yank-selected -p'), r'yank selection -s'),
     (re.compile(r'^yank-selected'), r'yank selection'),
+
+    (re.compile(r'^completion-item-next'), r'completion-item-focus next'),
+    (re.compile(r'^completion-item-prev'), r'completion-item-focus prev'),
 ]

--- a/tests/unit/completion/test_completionwidget.py
+++ b/tests/unit/completion/test_completionwidget.py
@@ -122,7 +122,7 @@ def test_maybe_resize_completion(completionview, config_stub, qtbot):
     ([[]], 1, None),
     ([[]], -1, None),
 ])
-def test_completion_item_next_prev(tree, count, expected, completionview):
+def test_completion_item_focus(tree, count, expected, completionview):
     """Test that on_next_prev_item moves the selection properly.
 
     Args:
@@ -140,21 +140,18 @@ def test_completion_item_next_prev(tree, count, expected, completionview):
     filtermodel = sortfilter.CompletionFilterModel(model,
                                                    parent=completionview)
     completionview.set_model(filtermodel)
-    if count < 0:
-        for _ in range(-count):
-            completionview.completion_item_prev()
-    else:
-        for _ in range(count):
-            completionview.completion_item_next()
+    direction = 'prev' if count < 0 else 'next'
+    for _ in range(abs(count)):
+        completionview.completion_item_focus(direction)
     idx = completionview.selectionModel().currentIndex()
     assert filtermodel.data(idx) == expected
 
 
-def test_completion_item_next_prev_no_model(completionview):
+def test_completion_item_focus_no_model(completionview):
     """Test that next/prev won't crash with no model set.
 
     This can happen if completion.show and completion.auto-open are False.
     Regression test for issue #1722.
     """
-    completionview.completion_item_prev()
-    completionview.completion_item_next()
+    completionview.completion_item_focus('prev')
+    completionview.completion_item_focus('next')


### PR DESCRIPTION
- Use a single command completion-item-focus with a next/prev argument.
- Add a rule to translate old configs.
- Regenerate the docs.

See #1095.