### PR TITLE
Refactor filter_hints and generalize auto-follow

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -822,6 +822,7 @@ class HintManager(QObject):
                         self._hide_elem(elem.label)
             except webelem.Error:
                 pass
+        self._handle_auto_follow()
 
     def filter_hints(self, filterstr):
         """Filter displayed hints according to a text.

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -394,6 +394,8 @@ class HintManager(QObject):
         Return:
             A list of hint strings, in the same order as the elements.
         """
+        if not elems:
+            return []
         hint_mode = self._context.hint_mode
         if hint_mode == 'word':
             try:

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -768,8 +768,7 @@ class HintManager(QObject):
         return self._context.hint_mode
 
     def _get_visible_hints(self):
-        """Get elements which are currently visible.
-        """
+        """Get elements which are currently visible."""
         visible = {}
         for string, elem in self._context.elems.items():
             try:
@@ -784,8 +783,7 @@ class HintManager(QObject):
         return visible
 
     def _handle_auto_follow(self, visible=None):
-        """Handle the auto-follow option.
-        """
+        """Handle the auto-follow option."""
         if visible is None:
             visible = self._get_visible_hints()
 

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -805,11 +805,11 @@ class HintManager(QObject):
         if auto_follow == "always":
             follow = True
         elif auto_follow == "unique-match":
-            follow = (keystr or filterstr)
+            follow = keystr or filterstr
         elif auto_follow == "full-match":
             elemstr = str(list(visible.values())[0].elem)
             filter_match = self._filter_matches_exactly(filterstr, elemstr)
-            follow = keystr in visible or filter_match
+            follow = (keystr in visible) or filter_match
         else:
             follow = False
 

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -62,7 +62,6 @@ class HintContext:
     """Context namespace used for hinting.
 
     Attributes:
-        frames: The QWebFrames to use.
         all_elems: A list of all (elem, label) namedtuples ever created.
         elems: A mapping from key strings to (elem, label) namedtuples.
                May contain less elements than `all_elems` due to filtering.
@@ -92,7 +91,6 @@ class HintContext:
         self.to_follow = None
         self.rapid = False
         self.filterstr = None
-        self.frames = []
         self.args = []
         self.tab = None
         self.group = None
@@ -766,7 +764,6 @@ class HintManager(QObject):
             self._context.baseurl = tabbed_browser.current_url()
         except qtutils.QtValueError:
             raise cmdexc.CommandError("No URL set for this page yet!")
-        self._context.tab = tab
         self._context.args = args
         self._context.group = group
         selector = webelem.SELECTORS[self._context.group]

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -778,10 +778,6 @@ class HintManager(QObject):
                     visible[string] = elem
             except webelem.Error:
                 pass
-        if not visible:
-            # Whoops, filtered all hints
-            modeman.leave(self._win_id, usertypes.KeyMode.hint,
-                          'all filtered')
         return visible
 
     def _handle_auto_follow(self, visible=None):
@@ -851,6 +847,12 @@ class HintManager(QObject):
                     self._hide_elem(elem.label)
             except webelem.Error:
                 pass
+
+        if not visible:
+            # Whoops, filtered all hints
+            modeman.leave(self._win_id, usertypes.KeyMode.hint,
+                          'all filtered')
+            return
 
         if self._context.hint_mode == 'number':
             # renumber filtered hints

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -824,7 +824,7 @@ class HintManager(QObject):
             normal_parser = keyparsers[usertypes.KeyMode.normal]
             normal_parser.set_inhibited_timeout(timeout)
             # unpacking gets us the first (and only) key in the dict.
-            self.fire(*visible)
+            self._fire(*visible)
 
     def handle_partial_key(self, keystr):
         """Handle a new partial keypress."""
@@ -904,7 +904,7 @@ class HintManager(QObject):
                 self._handle_auto_follow(filterstr=filterstr,
                                          visible=self._context.elems)
 
-    def fire(self, keystr):
+    def _fire(self, keystr):
         """Fire a completed hint.
 
         Args:
@@ -982,7 +982,7 @@ class HintManager(QObject):
                 keystring = self._context.to_follow
         elif keystring not in self._context.elems:
             raise cmdexc.CommandError("No hint {}!".format(keystring))
-        self.fire(keystring)
+        self._fire(keystring)
 
     @pyqtSlot()
     def on_contents_size_changed(self):

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -812,6 +812,9 @@ class HintManager(QObject):
             follow = (keystr in visible) or filter_match
         else:
             follow = False
+            # save the keystr of the only one visible hint to be picked up
+            # later by self.follow_hint
+            self._context.to_follow = list(visible.keys())[0]
 
         if follow:
             # apply auto-follow-timeout
@@ -901,18 +904,12 @@ class HintManager(QObject):
                 self._handle_auto_follow(filterstr=filterstr,
                                          visible=self._context.elems)
 
-    def fire(self, keystr, force=False):
+    def fire(self, keystr):
         """Fire a completed hint.
 
         Args:
             keystr: The keychain string to follow.
-            force: When True, follow even when auto-follow is not 'never'.
         """
-        if not (force or config.get('hints', 'auto-follow') != 'never'):
-            self.handle_partial_key(keystr)
-            self._context.to_follow = keystr
-            return
-
         # Handlers which take a QWebElement
         elem_handlers = {
             Target.normal: self._actions.click,
@@ -985,7 +982,7 @@ class HintManager(QObject):
                 keystring = self._context.to_follow
         elif keystring not in self._context.elems:
             raise cmdexc.CommandError("No hint {}!".format(keystring))
-        self.fire(keystring, force=True)
+        self.fire(keystring)
 
     @pyqtSlot()
     def on_contents_size_changed(self):

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -79,6 +79,7 @@ class HintContext:
         to_follow: The link to follow when enter is pressed.
         args: Custom arguments for userscript/spawn
         rapid: Whether to do rapid hinting.
+        filterstr: Used to save the filter string for restoring in rapid mode.
         tab: The WebTab object we started hinting in.
         group: The group of web elements to hint.
     """
@@ -90,6 +91,7 @@ class HintContext:
         self.baseurl = None
         self.to_follow = None
         self.rapid = False
+        self.filterstr = None
         self.frames = []
         self.args = []
         self.tab = None
@@ -309,7 +311,6 @@ class HintManager(QObject):
         _context: The HintContext for the current invocation.
         _win_id: The window ID this HintManager is associated with.
         _tab_id: The tab ID this HintManager is associated with.
-        _filterstr: Used to save the filter string for restoring in rapid mode.
 
     Signals:
         See HintActions
@@ -342,7 +343,6 @@ class HintManager(QObject):
         self._win_id = win_id
         self._tab_id = tab_id
         self._context = None
-        self._filterstr = None
         self._word_hinter = WordHinter()
 
         self._actions = HintActions(win_id)
@@ -381,7 +381,6 @@ class HintManager(QObject):
                                     window=self._win_id)
         message_bridge.maybe_reset_text(text)
         self._context = None
-        self._filterstr = None
 
     def _hint_strings(self, elems):
         """Calculate the hint strings for elems.
@@ -861,9 +860,9 @@ class HintManager(QObject):
                        and `self._filterstr` are None, all hints are shown.
         """
         if filterstr is None:
-            filterstr = self._filterstr
+            filterstr = self._context.filterstr
         else:
-            self._filterstr = filterstr
+            self._context.filterstr = filterstr
 
         visible = []
         for elem in self._context.all_elems:

--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -363,6 +363,8 @@ class ConfigManager(QObject):
             _get_value_transformer({'false': 'none', 'true': 'debug'}),
         ('ui', 'keyhint-blacklist'):
             _get_value_transformer({'false': '*', 'true': ''}),
+        ('hints', 'auto-follow'):
+            _get_value_transformer({'false': 'never', 'true': 'unique-match'}),
     }
 
     changed = pyqtSignal(str, str)

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -928,8 +928,9 @@ def data(readonly=False):
 
             ('auto-follow',
              SettingValue(typ.Bool(), 'true'),
-             "Follow a hint immediately when the hint text is completely "
-             "matched."),
+             "Follow a hint immediately when there is a unique match on the "
+             "hint text (in letter and word modes) or in the hint filter "
+             "(in number mode)."),
 
             ('auto-follow-timeout',
              SettingValue(typ.Int(), '0'),

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -927,10 +927,21 @@ def data(readonly=False):
              "The dictionary file to be used by the word hints."),
 
             ('auto-follow',
-             SettingValue(typ.Bool(), 'true'),
-             "Follow a hint immediately when there is a unique match on the "
-             "hint text (in letter and word modes) or in the hint filter "
-             "(in number mode)."),
+             SettingValue(typ.String(
+                 valid_values=typ.ValidValues(
+                     ('always', "Auto-follow whenever there is only a single "
+                      "hint on a page."),
+                     ('unique-match', "Auto-follow whenever there is a unique "
+                      "non-empty match in either the hint string (word mode) "
+                      "or filter (number mode)."),
+                     ('full-match', "Follow the hint when the user typed the "
+                      "whole hint (letter, word or number mode) or the "
+                      "element's text (only in number mode)."),
+                     ('never', "The user will always need to press Enter to "
+                      "follow a hint."),
+                 )), 'unique-match'),
+             "Controls when a hint can be automatically followed without the "
+             "user pressing Enter."),
 
             ('auto-follow-timeout',
              SettingValue(typ.Int(), '0'),

--- a/qutebrowser/keyinput/modeparsers.py
+++ b/qutebrowser/keyinput/modeparsers.py
@@ -231,7 +231,7 @@ class HintKeyParser(keyparser.CommandKeyParser):
         if keytype == self.Type.chain:
             hintmanager = objreg.get('hintmanager', scope='tab',
                                      window=self._win_id, tab='current')
-            hintmanager.fire(cmdstr)
+            hintmanager.handle_partial_key(cmdstr)
         else:
             # execute as command
             super().execute(cmdstr, keytype, count)

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -39,10 +39,10 @@ Feature: Using hints
             - data/hello.txt (active)
 
     Scenario: Entering and leaving hinting mode (issue 1464)
-      When I open data/hints/html/simple.html
-      And I run :hint
-      And I run :fake-key -g <Esc>
-      Then no crash should happen
+        When I open data/hints/html/simple.html
+        And I run :hint
+        And I run :fake-key -g <Esc>
+        Then no crash should happen
 
     Scenario: Using :hint spawn with flags and -- (issue 797)
         When I open data/hints/html/simple.html
@@ -225,7 +225,7 @@ Feature: Using hints
     Scenario: Multi-word matching
         When I open data/hints/number.html
         And I set hints -> mode to number
-        And I set hints -> auto-follow to true
+        And I set hints -> auto-follow to unique-match
         And I set hints -> auto-follow-timeout to 0
         And I run :hint all
         And I press the keys "ten pos"
@@ -265,3 +265,92 @@ Feature: Using hints
         And I press the key "s"
         And I run :follow-hint 1
         Then data/numbers/7.txt should be loaded
+
+    ### auto-follow option
+
+    Scenario: Using hints -> auto-follow == 'always' in letter mode
+        When I open data/hints/html/simple.html
+        And I set hints -> mode to letter
+        And I set hints -> auto-follow to always
+        And I run :hint
+        Then data/hello.txt should be loaded
+
+    # unique-match is actually the same as full-match in letter mode
+    Scenario: Using hints -> auto-follow == 'unique-match' in letter mode
+        When I open data/hints/html/simple.html
+        And I set hints -> mode to letter
+        And I set hints -> auto-follow to unique-match
+        And I run :hint
+        And I press the key "a"
+        Then data/hello.txt should be loaded
+
+    Scenario: Using hints -> auto-follow == 'full-match' in letter mode
+        When I open data/hints/html/simple.html
+        And I set hints -> mode to letter
+        And I set hints -> auto-follow to full-match
+        And I run :hint
+        And I press the key "a"
+        Then data/hello.txt should be loaded
+
+    # FIXME: not sure where I broke this...
+    @xfail_norun
+    Scenario: Using hints -> auto-follow == 'never' in letter mode
+        When I open data/hints/html/simple.html
+        And I set hints -> mode to letter
+        And I set hints -> auto-follow to never
+        And I run :hint
+        And I press the key "a"
+        And I press the key "Enter"
+        Then data/hello.txt should be loaded
+
+    Scenario: Using hints -> auto-follow == 'always' in number mode
+        When I open data/hints/html/simple.html
+        And I set hints -> mode to number
+        And I set hints -> auto-follow to always
+        And I run :hint
+        Then data/hello.txt should be loaded
+
+    Scenario: Using hints -> auto-follow == 'unique-match' in number mode
+        When I open data/hints/html/simple.html
+        And I set hints -> mode to number
+        And I set hints -> auto-follow to unique-match
+        And I run :hint
+        And I press the key "f"
+        Then data/hello.txt should be loaded
+
+    Scenario: Using hints -> auto-follow == 'full-match' in number mode
+        When I open data/hints/html/simple.html
+        And I set hints -> mode to number
+        And I set hints -> auto-follow to full-match
+        And I run :hint
+        And I press the key "f"
+        And I press the key "o"
+        And I press the key "l"
+        And I press the key "l"
+        And I press the key "o"
+        And I press the key "w"
+        And I press the key " "
+        And I press the key "m"
+        And I press the key "e"
+        And I press the key "!"
+        Then data/hello.txt should be loaded
+
+    Scenario: Using hints -> auto-follow == 'never' in number mode
+        When I open data/hints/html/simple.html
+        And I set hints -> mode to number
+        And I set hints -> auto-follow to full-match
+        And I run :hint
+        And I press the key "f"
+        And I press the key "o"
+        And I press the key "l"
+        And I press the key "l"
+        And I press the key "o"
+        And I press the key "w"
+        And I press the key " "
+        And I press the key "m"
+        And I press the key "e"
+        And I press the key "!"
+        And I press the key "Enter"
+        Then data/hello.txt should be loaded
+
+    # TODO: tests for word mode - it tries to access /usr/share/dict/words on the system

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -292,6 +292,14 @@ Feature: Using hints
         And I press the key "a"
         Then data/hello.txt should be loaded
 
+    Scenario: Using hints -> auto-follow == 'never' without Enter in letter mode
+        When I open data/hints/html/simple.html
+        And I set hints -> mode to letter
+        And I set hints -> auto-follow to never
+        And I run :hint
+        And I press the key "a"
+        Then "Leaving mode KeyMode.hint (reason: followed)" should not be logged
+
     Scenario: Using hints -> auto-follow == 'never' in letter mode
         When I open data/hints/html/simple.html
         And I set hints -> mode to letter
@@ -325,10 +333,19 @@ Feature: Using hints
         And I press the key "follow me!"
         Then data/hello.txt should be loaded
 
+    Scenario: Using hints -> auto-follow == 'never' without Enter in number mode
+        When I open data/hints/html/simple.html
+        And I set hints -> mode to number
+        And I set hints -> auto-follow to never
+        And I run :hint
+        # this actually presses the keys one by one
+        And I press the key "follow me!"
+        Then "Leaving mode KeyMode.hint (reason: followed)" should not be logged
+
     Scenario: Using hints -> auto-follow == 'never' in number mode
         When I open data/hints/html/simple.html
         And I set hints -> mode to number
-        And I set hints -> auto-follow to full-match
+        And I set hints -> auto-follow to never
         And I run :hint
         # this actually presses the keys one by one
         And I press the key "follow me!"

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -352,4 +352,46 @@ Feature: Using hints
         And I press the key "<Enter>"
         Then data/hello.txt should be loaded
 
-    # TODO: tests for word mode - it tries to access /usr/share/dict/words on the system
+    Scenario: Using hints -> auto-follow == 'always' in word mode
+        When I open data/hints/html/simple.html
+        And I set hints -> mode to word
+        And I set hints -> auto-follow to always
+        And I run :hint
+        Then data/hello.txt should be loaded
+
+    Scenario: Using hints -> auto-follow == 'unique-match' in word mode
+        When I open data/hints/html/simple.html
+        And I set hints -> mode to word
+        And I set hints -> auto-follow to unique-match
+        And I run :hint
+        # the link gets "hello" as the hint
+        And I press the key "h"
+        Then data/hello.txt should be loaded
+
+    Scenario: Using hints -> auto-follow == 'full-match' in word mode
+        When I open data/hints/html/simple.html
+        And I set hints -> mode to word
+        And I set hints -> auto-follow to full-match
+        And I run :hint
+        # this actually presses the keys one by one
+        And I press the key "hello"
+        Then data/hello.txt should be loaded
+
+    Scenario: Using hints -> auto-follow == 'never' without Enter in word mode
+        When I open data/hints/html/simple.html
+        And I set hints -> mode to word
+        And I set hints -> auto-follow to never
+        And I run :hint
+        # this actually presses the keys one by one
+        And I press the key "hello"
+        Then "Leaving mode KeyMode.hint (reason: followed)" should not be logged
+
+    Scenario: Using hints -> auto-follow == 'never' in word mode
+        When I open data/hints/html/simple.html
+        And I set hints -> mode to word
+        And I set hints -> auto-follow to never
+        And I run :hint
+        # this actually presses the keys one by one
+        And I press the key "hello"
+        And I press the key "<Enter>"
+        Then data/hello.txt should be loaded

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -321,16 +321,8 @@ Feature: Using hints
         And I set hints -> mode to number
         And I set hints -> auto-follow to full-match
         And I run :hint
-        And I press the key "f"
-        And I press the key "o"
-        And I press the key "l"
-        And I press the key "l"
-        And I press the key "o"
-        And I press the key "w"
-        And I press the key " "
-        And I press the key "m"
-        And I press the key "e"
-        And I press the key "!"
+        # this actually presses the keys one by one
+        And I press the key "follow me!"
         Then data/hello.txt should be loaded
 
     Scenario: Using hints -> auto-follow == 'never' in number mode
@@ -338,16 +330,8 @@ Feature: Using hints
         And I set hints -> mode to number
         And I set hints -> auto-follow to full-match
         And I run :hint
-        And I press the key "f"
-        And I press the key "o"
-        And I press the key "l"
-        And I press the key "l"
-        And I press the key "o"
-        And I press the key "w"
-        And I press the key " "
-        And I press the key "m"
-        And I press the key "e"
-        And I press the key "!"
+        # this actually presses the keys one by one
+        And I press the key "follow me!"
         And I press the key "<Enter>"
         Then data/hello.txt should be loaded
 

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -292,15 +292,13 @@ Feature: Using hints
         And I press the key "a"
         Then data/hello.txt should be loaded
 
-    # FIXME: not sure where I broke this...
-    @xfail_norun
     Scenario: Using hints -> auto-follow == 'never' in letter mode
         When I open data/hints/html/simple.html
         And I set hints -> mode to letter
         And I set hints -> auto-follow to never
         And I run :hint
         And I press the key "a"
-        And I press the key "Enter"
+        And I press the key "<Enter>"
         Then data/hello.txt should be loaded
 
     Scenario: Using hints -> auto-follow == 'always' in number mode
@@ -350,7 +348,7 @@ Feature: Using hints
         And I press the key "m"
         And I press the key "e"
         And I press the key "!"
-        And I press the key "Enter"
+        And I press the key "<Enter>"
         Then data/hello.txt should be loaded
 
     # TODO: tests for word mode - it tries to access /usr/share/dict/words on the system

--- a/tests/end2end/features/test_hints_bdd.py
+++ b/tests/end2end/features/test_hints_bdd.py
@@ -17,5 +17,30 @@
 # You should have received a copy of the GNU General Public License
 # along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
 
+import textwrap
+
+import pytest
+
 import pytest_bdd as bdd
 bdd.scenarios('hints.feature')
+
+
+@pytest.fixture(autouse=True)
+def set_up_word_hints(tmpdir, quteproc):
+    dict_file = tmpdir / 'dict'
+    dict_file.write(textwrap.dedent("""
+        one
+        two
+        three
+        four
+        five
+        six
+        seven
+        eight
+        nine
+        ten
+        eleven
+        twelve
+        thirteen
+    """))
+    quteproc.set_setting('hints', 'dictionary', str(dict_file))


### PR DESCRIPTION
Fixes #1809 and addresses #219.

Is there a way to test 4ea2d68d771991128846343c87756848ec960bac regarding the partial keystring? In number mode all hint strings are exactly the same length, in letter they are almost the same length so using the word mode is the only sensible way. Unfortunately it requires a system wordlist...