### PR TITLE
Fix the behavior of 'last-focused-main-window' and use it for new (IPC) tabs

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -63,6 +63,8 @@ Removed
   and thus removed.
 - The `:completion-item-prev` and `:completion-item-next` commands got merged
   into a new `:completion-focus {prev,next}` command and thus removed.
+- The `ui -> hide-mouse-cursor` setting since it was completely broken and
+  nobody seemed to care.
 
 v0.8.3 (unreleased)
 -------------------

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -33,9 +33,9 @@ import tokenize
 
 from PyQt5.QtWidgets import QApplication, QWidget
 from PyQt5.QtWebKit import QWebSettings
-from PyQt5.QtGui import QDesktopServices, QPixmap, QIcon, QCursor, QWindow
+from PyQt5.QtGui import QDesktopServices, QPixmap, QIcon, QWindow
 from PyQt5.QtCore import (pyqtSlot, qInstallMessageHandler, QTimer, QUrl,
-                          QObject, Qt, QEvent, pyqtSignal)
+                          QObject, QEvent, pyqtSignal)
 try:
     import hunter
 except ImportError:
@@ -339,16 +339,17 @@ def _save_version():
 
 def on_focus_changed(_old, new):
     """Register currently focused main window in the object registry."""
-    if not isinstance(new, QWidget) and new is not None:
+    if new is None:
+        return
+
+    if not isinstance(new, QWidget):
         log.misc.debug("on_focus_changed called with non-QWidget {!r}".format(
             new))
         return
 
-    if new is not None:
-        _maybe_hide_mouse_cursor()
-        objreg.register('last-focused-main-window', new.window(), update=True)
-    else:
-        qApp.restoreOverrideCursor()
+    window = new.window()
+    if isinstance(window, mainwindow.MainWindow):
+        objreg.register('last-focused-main-window', window, update=True)
 
 
 def open_desktopservices_url(url):
@@ -357,17 +358,6 @@ def open_desktopservices_url(url):
     tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                 window=win_id)
     tabbed_browser.tabopen(url)
-
-
-@config.change_filter('ui', 'hide-mouse-cursor', function=True)
-def _maybe_hide_mouse_cursor():
-    """Hide the mouse cursor if it isn't yet and it's configured."""
-    if config.get('ui', 'hide-mouse-cursor'):
-        if qApp.overrideCursor() is not None:
-            return
-        qApp.setOverrideCursor(QCursor(Qt.BlankCursor))
-    else:
-        qApp.restoreOverrideCursor()
 
 
 def _init_modules(args, crash_handler):
@@ -431,8 +421,6 @@ def _init_modules(args, crash_handler):
         os.environ['QT_WAYLAND_DISABLE_WINDOWDECORATION'] = '1'
     else:
         os.environ.pop('QT_WAYLAND_DISABLE_WINDOWDECORATION', None)
-    _maybe_hide_mouse_cursor()
-    objreg.get('config').changed.connect(_maybe_hide_mouse_cursor)
     temp_downloads = downloads.TempDownloadManager(qApp)
     objreg.register('temporary-downloads', temp_downloads)
 

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -342,16 +342,13 @@ def on_focus_changed(_old, new):
     if not isinstance(new, QWidget) and new is not None:
         log.misc.debug("on_focus_changed called with non-QWidget {!r}".format(
             new))
+        return
 
-    if new is None or not isinstance(new, mainwindow.MainWindow):
-        try:
-            objreg.delete('last-focused-main-window')
-        except KeyError:
-            pass
-        qApp.restoreOverrideCursor()
-    else:
-        objreg.register('last-focused-main-window', new.window(), update=True)
+    if new is not None:
         _maybe_hide_mouse_cursor()
+        objreg.register('last-focused-main-window', new.window(), update=True)
+    else:
+        qApp.restoreOverrideCursor()
 
 
 def open_desktopservices_url(url):

--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -350,6 +350,7 @@ class ConfigManager(QObject):
         ('tabs', 'auto-hide'),
         ('tabs', 'hide-always'),
         ('ui', 'display-statusbar-messages'),
+        ('ui', 'hide-mouse-cursor'),
         ('general', 'wrap-search'),
     ]
     CHANGED_OPTIONS = {

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -227,6 +227,16 @@ def data(readonly=False):
              "How to open links in an existing instance if a new one is "
              "launched."),
 
+            ('new-instance-open-target.window',
+             SettingValue(typ.String(
+                 valid_values=typ.ValidValues(
+                     ('last-opened', "Open new tabs in the last"
+                     "opened window."),
+                     ('last-focused', "Open new tabs in the most"
+                     "recently focused window.")
+                 )), 'last-focused'),
+             "Which window to choose when opening links as new tabs."),
+
             ('log-javascript-console',
              SettingValue(typ.String(
                  valid_values=typ.ValidValues(

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -346,10 +346,6 @@ def data(readonly=False):
              "* `{scroll_pos}`: The page scroll position.\n"
              "* `{host}`: The host of the current web page."),
 
-            ('hide-mouse-cursor',
-             SettingValue(typ.Bool(), 'false'),
-             "Whether to hide the mouse cursor."),
-
             ('modal-js-dialog',
              SettingValue(typ.Bool(), 'false'),
              "Use standard JavaScript modal dialog for alert() and confirm()"),

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -69,7 +69,11 @@ def get_window(via_ipc, force_window=False, force_tab=False,
         window_to_raise = window
     else:
         try:
-            window = objreg.last_window()
+            win_mode = config.get('general', 'new-instance-open-target.window')
+            if win_mode == 'last-focused':
+                window = objreg.last_focused_window()
+            elif win_mode == 'last-opened':
+                window = objreg.last_window()
         except objreg.NoWindow:
             # There is no window left, so we open a new one
             window = MainWindow()

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -175,9 +175,6 @@ class MainWindow(QWidget):
         QTimer.singleShot(0, self._connect_resize_keyhint)
         objreg.get('config').changed.connect(self.on_config_changed)
 
-        if config.get('ui', 'hide-mouse-cursor'):
-            self.setCursor(Qt.BlankCursor)
-
         objreg.get("app").new_window.emit(self)
 
     def _init_downloadmanager(self):

--- a/qutebrowser/utils/objreg.py
+++ b/qutebrowser/utils/objreg.py
@@ -178,10 +178,7 @@ def _get_window_registry(window):
             app = get('app')
             win = app.activeWindow()
         elif window == 'last-focused':
-            try:
-                win = get('last-focused-main-window')
-            except KeyError:
-                win = last_window()
+            win = last_focused_window()
         else:
             win = window_registry[window]
     except (KeyError, NoWindow):
@@ -274,6 +271,14 @@ def dump_objects():
         for line in data:
             lines.append("    {}".format(line))
     return lines
+
+
+def last_focused_window():
+    """Get the last focused window, or the last window if none."""
+    try:
+        return get('last-focused-main-window')
+    except KeyError:
+        return last_window()
 
 
 def last_window():

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -330,6 +330,7 @@ class QuteProc(testprocess.Process):
         settings = [
             ('ui', 'message-timeout', '0'),
             ('general', 'auto-save-interval', '0'),
+            ('general', 'new-instance-open-target.window', 'last-opened')
         ]
         if not self._webengine:
             settings.append(('network', 'ssl-strict', 'false'))


### PR DESCRIPTION
Fixes a bunch of “silent” bugs, and one feature request.

I would like to add tests to this but I'm not entirely sure how. (I would need to switch focus, then spawn a new tab via the IPC, then see if the right window got the tab)