### PR TITLE
Add code to save and restore the old tab position

### DIFF
--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -34,7 +34,7 @@ from qutebrowser.utils import (log, usertypes, utils, qtutils, objreg,
                                urlutils, message)
 
 
-UndoEntry = collections.namedtuple('UndoEntry', ['url', 'history'])
+UndoEntry = collections.namedtuple('UndoEntry', ['url', 'history', 'index'])
 
 
 class TabDeletedError(Exception):
@@ -260,7 +260,7 @@ class TabbedBrowser(tabwidget.TabWidget):
                           window=self._win_id)
         if tab.url().isValid():
             history_data = tab.history.serialize()
-            entry = UndoEntry(tab.url(), history_data)
+            entry = UndoEntry(tab.url(), history_data, idx)
             self._undo_stack.append(entry)
         elif tab.url().isEmpty():
             # There are some good reasons why a URL could be empty
@@ -297,13 +297,13 @@ class TabbedBrowser(tabwidget.TabWidget):
             use_current_tab = (only_one_tab_open and no_history and
                                last_close_url_used)
 
-        url, history_data = self._undo_stack.pop()
+        url, history_data, idx = self._undo_stack.pop()
 
         if use_current_tab:
             self.openurl(url, newtab=False)
             newtab = self.widget(0)
         else:
-            newtab = self.tabopen(url, background=False)
+            newtab = self.tabopen(url, background=False, idx=idx)
 
         newtab.history.deserialize(history_data)
 
@@ -342,7 +342,7 @@ class TabbedBrowser(tabwidget.TabWidget):
 
     @pyqtSlot('QUrl')
     @pyqtSlot('QUrl', bool)
-    def tabopen(self, url=None, background=None, explicit=False):
+    def tabopen(self, url=None, background=None, explicit=False, idx=None):
         """Open a new tab with a given URL.
 
         Inner logic for open-tab and open-tab-bg.
@@ -358,6 +358,7 @@ class TabbedBrowser(tabwidget.TabWidget):
                           - Tabs from clicked links etc. are to the right of
                             the current.
                           - Explicitly opened tabs are at the very right.
+            idx: The index where the new tab should be opened.
 
         Return:
             The opened WebView instance.
@@ -376,7 +377,8 @@ class TabbedBrowser(tabwidget.TabWidget):
         tab = browsertab.create(win_id=self._win_id, parent=self)
         self._connect_tab_signals(tab)
 
-        idx = self._get_new_tab_idx(explicit)
+        if idx is None:
+            idx = self._get_new_tab_idx(explicit)
         self.insertTab(idx, tab, "")
 
         if url is not None:

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -703,6 +703,53 @@ Feature: Tab management
         Then the error "Nothing to undo!" should be shown
         And the error "Nothing to undo!" should be shown
 
+    Scenario: Undo a tab closed by index
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I open data/numbers/3.txt in a new tab
+        And I run :tab-close with count 1
+        And I run :undo
+        Then the following tabs should be open:
+            - data/numbers/1.txt (active)
+            - data/numbers/2.txt
+            - data/numbers/3.txt
+
+    Scenario: Undo a tab closed after switching tabs
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I open data/numbers/3.txt in a new tab
+        And I run :tab-close with count 1
+        And I run :tab-focus 2
+        And I run :undo
+        Then the following tabs should be open:
+            - data/numbers/1.txt (active)
+            - data/numbers/2.txt
+            - data/numbers/3.txt
+
+    Scenario: Undo a tab closed after rearranging tabs
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I open data/numbers/3.txt in a new tab
+        And I run :tab-close with count 1
+        And I run :tab-focus 2
+        And I run :tab-move with count 1
+        And I run :undo
+        Then the following tabs should be open:
+            - data/numbers/1.txt (active)
+            - data/numbers/3.txt
+            - data/numbers/2.txt
+
+    Scenario: Undo a tab closed after new tab opened
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I run :tab-close with count 1
+        And I open data/numbers/3.txt in a new tab
+        And I run :undo
+        Then the following tabs should be open:
+            - data/numbers/1.txt (active)
+            - data/numbers/2.txt
+            - data/numbers/3.txt
+
     # last-close
 
     Scenario: last-close = blank


### PR DESCRIPTION
This makes the default `:undo` setting in qb more like FF and other browsers.