### PR TITLE
Add general->new-instance-open-target.window=last-visible

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -350,6 +350,9 @@ def on_focus_changed(_old, new):
     window = new.window()
     if isinstance(window, mainwindow.MainWindow):
         objreg.register('last-focused-main-window', window, update=True)
+        # A focused window must also be visible, and in this case we should
+        # consider it as the most recently looked-at window
+        objreg.register('last-visible-main-window', window, update=True)
 
 
 def open_desktopservices_url(url):

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -233,7 +233,9 @@ def data(readonly=False):
                      ('last-opened', "Open new tabs in the last opened "
                                      "window."),
                      ('last-focused', "Open new tabs in the most recently "
-                                      "focused window.")
+                                      "focused window."),
+                     ('last-visible', "Open new tabs in the most recently "
+                                      "visible window.")
                  )), 'last-focused'),
              "Which window to choose when opening links as new tabs."),
 

--- a/qutebrowser/utils/objreg.py
+++ b/qutebrowser/utils/objreg.py
@@ -280,6 +280,14 @@ def dump_objects():
     return lines
 
 
+def last_visible_window():
+    """Get the last visible window, or the last focused window if none."""
+    try:
+        return get('last-visible-main-window')
+    except KeyError:
+        return last_focused_window()
+
+
 def last_focused_window():
     """Get the last focused window, or the last window if none."""
     try:


### PR DESCRIPTION
I usually use my browser with a one-window-per-workspace flow. If I
click on a URL anywhere, I personally would prefer it to go to the
browser instance that's on the same workspace.

To this end, the easiest way to accomplish this is to simply track when
windows are made visible and register them as the last visible object.

(To get finer control for when you have multiple windows on the same
workspace, focus changes also update the last visible object - the
implication being here that focusing something also means you're looking
at it)

Not all users may like this behavior, so I consider it strictly optional.