### PR TITLE
Filter buffer completion by all columns.

### DIFF
--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -148,7 +148,8 @@ class TabCompletionModel(base.BaseCompletionModel):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        self.columns_to_filter = [self.URL_COLUMN, self.TEXT_COLUMN]
+        self.columns_to_filter = [self.IDX_COLUMN, self.URL_COLUMN,
+                                  self.TEXT_COLUMN]
 
         for win_id in objreg.window_registry:
             tabbed_browser = objreg.get('tabbed-browser', scope='window',


### PR DESCRIPTION
In addition to the url and text column, also filter by the index column
so the user can enter a number to navigate to that tab.

Resolves #1830.

This is an easy enough fix, my only concern would be encouraging an anti-pattern of using completion to type the tab index when `Alt+0-9` would be faster (or filtering by content rather than an index).
Then again, I'm one to talk about anti-patterns when I mostly mash `J/K` until I get the tab I want.