### PR TITLE
Add add_undo parameter for closing tabs

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -427,7 +427,7 @@ class CommandDispatcher:
         url = self._current_url()
         self._open(url, window=True)
         cur_widget = self._current_widget()
-        self._tabbed_browser.close_tab(cur_widget)
+        self._tabbed_browser.close_tab(cur_widget, add_undo=False)
 
     def _back_forward(self, tab, bg, window, count, forward):
         """Helper function for :back/:forward."""

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -217,7 +217,7 @@ class TabbedBrowser(tabwidget.TabWidget):
         for tab in self.widgets():
             self._remove_tab(tab)
 
-    def close_tab(self, tab, add_undo=True):
+    def close_tab(self, tab, *, add_undo=True):
         """Close a tab.
 
         Args:
@@ -244,7 +244,7 @@ class TabbedBrowser(tabwidget.TabWidget):
                 url = config.get('general', 'default-page')
                 self.openurl(url, newtab=True)
 
-    def _remove_tab(self, tab, add_undo=True):
+    def _remove_tab(self, tab, *, add_undo=True):
         """Remove a tab from the tab list and delete it properly.
 
         Args:


### PR DESCRIPTION
By default, closed tabs should be undoable, but when a tab is detached `:undo` should not reopen that tab in the old window. (Fixes #1827)

Note: I have written a test for this which is not included, as the test requires #1831. Adding the test now would just result in a test that always passes, and just add to the noise (especially when it passing doesn't mean anything without #1831).