### PR TITLE
Add a :set --cycle flag

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -66,6 +66,7 @@ Changed
 - Completions for `:help` and `:bind` now also show hidden commands
 - The `:buffer` completion now also filters using the first column (id).
 - `:undo` has been improved to reopen tabs at the position they were closed.
+- `:set` now has a `--cycle` flag which lets you cycle through multiple options.
 
 Deprecated
 ~~~~~~~~~~

--- a/qutebrowser/commands/command.py
+++ b/qutebrowser/commands/command.py
@@ -205,7 +205,16 @@ class Command:
 
     def get_pos_arg_info(self, pos):
         """Get an ArgInfo tuple for the given positional parameter."""
-        name = self.pos_args[pos][0]
+        try:
+            name = self.pos_args[pos][0]
+        except IndexError:
+            # Extra arguments could belong to a variadic positional
+            signature = inspect.signature(self.handler)
+            name = next((p.name for p in signature.parameters.values()
+                         if p.kind == inspect.Parameter.VAR_POSITIONAL), None)
+            if name is None:
+                raise
+
         return self._qute_args.get(name, ArgInfo())
 
     def _inspect_special_param(self, param):

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -136,8 +136,9 @@ class Completer(QObject):
             section = parts[cursor_part - 1]
             model = instances.get(completion).get(section)
         elif completion == usertypes.Completion.value:
-            section = parts[cursor_part - 2]
-            option = parts[cursor_part - 1]
+            # Hard-coded indices because values can appear multiple times
+            section = parts[1]
+            option = parts[2]
             try:
                 model = instances.get(completion)[section][option]
             except KeyError:

--- a/tests/end2end/features/completion.feature
+++ b/tests/end2end/features/completion.feature
@@ -1,0 +1,80 @@
+Feature: Using completion
+
+    Scenario: Using command completion
+        When I run :set-cmd-text :
+        Then the completion model should be CommandCompletionModel
+
+    Scenario: Using help completion
+        When I run :set-cmd-text -s :help
+        Then the completion model should be HelpCompletionModel
+
+    Scenario: Using quickmark completion
+        When I run :set-cmd-text -s :quickmark-load
+        Then the completion model should be QuickmarkCompletionModel
+
+    Scenario: Using bookmark completion
+        When I run :set-cmd-text -s :bookmark-load
+        Then the completion model should be BookmarkCompletionModel
+
+    Scenario: Using bind completion
+        When I run :set-cmd-text -s :bind X
+        Then the completion model should be BindCompletionModel
+
+    Scenario: Using session completion
+        Given I open data/hello.txt
+        And I run :session-save hello
+        When I run :set-cmd-text -s :session-load
+        And I run :completion-item-focus next
+        And I run :completion-item-focus next
+        And I run :session-delete hello
+        And I run :command-accept
+        Then the error "Session hello not found!" should be shown
+
+    Scenario: Using option completion
+        When I run :set-cmd-text -s :set colors
+        Then the completion model should be SettingOptionCompletionModel
+
+    Scenario: Using value completion
+        When I run :set-cmd-text -s :set colors statusbar.bg
+        Then the completion model should be SettingValueCompletionModel
+
+    Scenario: Using value completion multiple times
+        When I run :set-cmd-text -s :set --cycle colors statusbar.bg black
+        Then the completion model should be SettingValueCompletionModel
+
+    Scenario: Updating the completion in realtime
+        Given I have a fresh instance
+        And I set completion -> quick-complete to false
+        When I open data/hello.txt
+        And I run :set-cmd-text -s :buffer
+        And I run :completion-item-focus next
+        And I open data/hello2.txt in a new background tab
+        And I run :completion-item-focus next
+        And I open data/hello3.txt in a new background tab
+        And I run :completion-item-focus next
+        And I run :command-accept
+        Then the following tabs should be open:
+            - data/hello.txt
+            - data/hello2.txt
+            - data/hello3.txt (active)
+
+    Scenario: Updating the value completion in realtime
+        Given I set colors -> statusbar.bg to green
+        When I run :set-cmd-text -s :set colors statusbar.bg
+        And I set colors -> statusbar.bg to yellow
+        And I run :completion-item-focus next
+        And I run :completion-item-focus next
+        And I set colors -> statusbar.bg to red
+        And I run :command-accept
+        Then colors -> statusbar.bg should be yellow
+
+    Scenario: Deleting an open tab via the completion
+        Given I have a fresh instance
+        When I open data/hello.txt
+        And I open data/hello2.txt in a new tab
+        And I run :set-cmd-text -s :buffer
+        And I run :completion-item-focus next
+        And I run :completion-item-focus next
+        And I run :completion-item-del
+        Then the following tabs should be open:
+            - data/hello.txt (active)

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -150,16 +150,21 @@ def open_path(quteproc, path):
     tab. With "... in a new window", it's opened in a new window.
     """
     new_tab = False
+    new_bg_tab = False
     new_window = False
     wait = True
 
     new_tab_suffix = ' in a new tab'
+    new_bg_tab_suffix = ' in a new background tab'
     new_window_suffix = ' in a new window'
     do_not_wait_suffix = ' without waiting'
 
     if path.endswith(new_tab_suffix):
         path = path[:-len(new_tab_suffix)]
         new_tab = True
+    elif path.endswith(new_bg_tab_suffix):
+        path = path[:-len(new_bg_tab_suffix)]
+        new_bg_tab = True
     elif path.endswith(new_window_suffix):
         path = path[:-len(new_window_suffix)]
         new_window = True
@@ -168,7 +173,8 @@ def open_path(quteproc, path):
         path = path[:-len(do_not_wait_suffix)]
         wait = False
 
-    quteproc.open_path(path, new_tab=new_tab, new_window=new_window, wait=wait)
+    quteproc.open_path(path, new_tab=new_tab, new_bg_tab=new_bg_tab,
+                       new_window=new_window, wait=wait)
 
 
 @bdd.when(bdd.parsers.parse("I set {sect} -> {opt} to {value}"))
@@ -518,3 +524,9 @@ def check_not_scrolled(quteproc):
     x, y = _get_scroll_values(quteproc)
     assert x == 0
     assert y == 0
+
+
+@bdd.then(bdd.parsers.parse("{section} -> {option} should be {value}"))
+def check_option(quteproc, section, option, value):
+    actual_value = quteproc.get_setting(section, option)
+    assert actual_value == value

--- a/tests/end2end/features/set.feature
+++ b/tests/end2end/features/set.feature
@@ -15,6 +15,10 @@ Feature: Setting settings.
         When I run :set colors statusbar.bg
         Then the error "set: The following arguments are required: value" should be shown
 
+    Scenario: With too many values
+        When I run :set colors statusbar.bg green blue
+        Then the error "set: Too many values provided" should be shown
+
     Scenario: Invalid section
         When I run :set blah blub foo
         Then the error "set: Section 'blah' does not exist!" should be shown
@@ -31,6 +35,26 @@ Feature: Setting settings.
     Scenario: Toggling a non-bool option
         When I run :set colors statusbar.bg!
         Then the error "set: Attempted inversion of non-boolean value." should be shown
+
+    Scenario: Cycling an option
+        When I run :set colors statusbar.bg magenta
+        And I run :set --cycle colors statusbar.bg green magenta blue yellow
+        Then colors -> statusbar.bg should be blue
+
+    Scenario: Cycling an option through the end of the list
+        When I run :set colors statusbar.bg yellow
+        And I run :set --cycle colors statusbar.bg green magenta blue yellow
+        Then colors -> statusbar.bg should be green
+
+    Scenario: Cycling an option that's not on the list
+        When I run :set colors statusbar.bg red
+        And I run :set --cycle colors statusbar.bg green magenta blue yellow
+        Then colors -> statusbar.bg should be green
+
+    Scenario: Cycling through a single option
+        When I run :set colors statusbar.bg red
+        And I run :set --cycle colors statusbar.bg red
+        Then colors -> statusbar.bg should be red
 
     Scenario: Getting an option
         When I run :set colors statusbar.bg magenta

--- a/tests/end2end/features/test_completion_bdd.py
+++ b/tests/end2end/features/test_completion_bdd.py
@@ -17,5 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
 
+import re
 import pytest_bdd as bdd
-bdd.scenarios('set.feature')
+bdd.scenarios('completion.feature')
+
+
+@bdd.then(bdd.parsers.parse("the completion model should be {model}"))
+def check_model(quteproc, model):
+    """Make sure the completion model was set to something."""
+    pattern = "New completion [^:]*: {}".format(model)
+    quteproc.wait_for(message=re.compile(pattern))

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -418,19 +418,23 @@ class QuteProc(testprocess.Process):
         yield
         self.set_setting(sect, opt, old_value)
 
-    def open_path(self, path, *, new_tab=False, new_window=False, port=None,
-                  https=False, wait=True):
+    def open_path(self, path, *, new_tab=False, new_bg_tab=False,
+                  new_window=False, port=None, https=False, wait=True):
         """Open the given path on the local webserver in qutebrowser."""
         url = self.path_to_url(path, port=port, https=https)
-        self.open_url(url, new_tab=new_tab, new_window=new_window, wait=wait)
+        self.open_url(url, new_tab=new_tab, new_bg_tab=new_bg_tab,
+                      new_window=new_window, wait=wait)
 
-    def open_url(self, url, *, new_tab=False, new_window=False, wait=True):
+    def open_url(self, url, *, new_tab=False, new_bg_tab=False,
+                 new_window=False, wait=True):
         """Open the given url in qutebrowser."""
         if new_tab and new_window:
             raise ValueError("new_tab and new_window given!")
 
         if new_tab:
             self.send_cmd(':open -t ' + url)
+        elif new_bg_tab:
+            self.send_cmd(':open -b ' + url)
         elif new_window:
             self.send_cmd(':open -w ' + url)
         else:


### PR DESCRIPTION
I'm not so sure about the second commit, I feel like there must be an easier way to do this.

That code in general seems fairly prone to breakage and subtle bugs such as differences between how the completer and the actual command execution decide to map parts to arguments.

I'd love to add the ability to add some test cases for making sure the completer shows the right type of completion at any point as I type a command. (Maybe something could be hacked together with set-cmd-text and waiting for the completion messages to show up?)
