### PR TITLE
Fix nested expansion of {variables} in command args

### DIFF
--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -537,3 +537,11 @@ Feature: Various utility commands.
         And I put "foo" into the clipboard
         And I run :message-info {clipboard}bar{url}
         Then the message "foobarhttp://localhost:*/hello.txt" should be shown
+
+    @xfail_norun
+    Scenario: {url} in clipboard should not be expanded
+        When I open data/hello.txt
+        # FIXME: {url} should be escaped, otherwise it is replaced before it enters clipboard
+        And I put "{url}" into the clipboard
+        And I run :message-info {clipboard}bar{url}
+        Then the message "{url}barhttp://localhost:*/hello.txt" should be shown


### PR DESCRIPTION
Fixes the problem described in https://github.com/The-Compiler/qutebrowser/pull/1791#issuecomment-239284646.

Unfortunately without escaping, it can't be tested using BDD tests, because we can't set the clipboard to contain `{url}`.