### PR TITLE
Make :navigate take a count

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -480,6 +480,9 @@ This tries to automatically click on typical _Previous Page_ or _Next Page_ link
 * +*-b*+, +*--bg*+: Open in a background tab.
 * +*-w*+, +*--window*+: Open in a new window.
 
+==== count
+For `increment` and `decrement`, the number to change the URL by. For `up`, the number of levels to go up in the URL.
+
 [[open]]
 === open
 Syntax: +:open [*--implicit*] [*--bg*] [*--tab*] [*--window*] ['url']+

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -482,7 +482,8 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('where', choices=['prev', 'next', 'up', 'increment',
                                          'decrement'])
-    def navigate(self, where: str, tab=False, bg=False, window=False):
+    @cmdutils.argument('count', count=True)
+    def navigate(self, where: str, tab=False, bg=False, window=False, count=1):
         """Open typical prev/next links or navigate using the URL path.
 
         This tries to automatically click on typical _Previous Page_ or
@@ -526,7 +527,7 @@ class CommandDispatcher:
                 handler(browsertab=widget, win_id=self._win_id, baseurl=url,
                         tab=tab, background=bg, window=window)
             elif where in ['up', 'increment', 'decrement']:
-                new_url = handlers[where](url)
+                new_url = handlers[where](url, count)
                 self._open(new_url, tab, bg, window)
             else:  # pragma: no cover
                 raise ValueError("Got called with invalid value {} for "

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -503,6 +503,8 @@ class CommandDispatcher:
             tab: Open in a new tab.
             bg: Open in a background tab.
             window: Open in a new window.
+            count: How much to increment or decrement the URL by, or number of
+                   levels to go up in the current URL.
         """
         # save the pre-jump position in the special ' mark
         self.set_mark("'")

--- a/qutebrowser/browser/navigate.py
+++ b/qutebrowser/browser/navigate.py
@@ -44,7 +44,8 @@ def incdec(url, count, inc_or_dec):
     """
     segments = set(config.get('general', 'url-incdec-segments'))
     try:
-        new_url = urlutils.incdec_number(url, inc_or_dec, count, segments=segments)
+        new_url = urlutils.incdec_number(url, inc_or_dec, count,
+                                         segments=segments)
     except urlutils.IncDecError as error:
         raise Error(error.msg)
     return new_url
@@ -60,7 +61,7 @@ def path_up(url, count):
     path = url.path()
     if not path or path == '/':
         raise Error("Can't go up!")
-    for i in range(0, min(count, path.count('/'))):
+    for _i in range(0, min(count, path.count('/'))):
         path = posixpath.join(path, posixpath.pardir)
     url.setPath(path)
     return url

--- a/qutebrowser/browser/navigate.py
+++ b/qutebrowser/browser/navigate.py
@@ -36,6 +36,7 @@ def incdec(url, count, inc_or_dec):
 
     Args:
         url: The current url.
+        count: How much to increment or decrement by.
         inc_or_dec: Either 'increment' or 'decrement'.
         tab: Whether to open the link in a new tab.
         background: Open the link in a new background tab.
@@ -54,6 +55,7 @@ def path_up(url, count):
 
     Args:
         url: The current url.
+        count: The number of levels to go up in the url.
     """
     path = url.path()
     if not path or path == '/':

--- a/qutebrowser/browser/navigate.py
+++ b/qutebrowser/browser/navigate.py
@@ -31,7 +31,7 @@ class Error(Exception):
     """Raised when the navigation can't be done."""
 
 
-def incdec(url, inc_or_dec):
+def incdec(url, count, inc_or_dec):
     """Helper method for :navigate when `where' is increment/decrement.
 
     Args:
@@ -43,13 +43,13 @@ def incdec(url, inc_or_dec):
     """
     segments = set(config.get('general', 'url-incdec-segments'))
     try:
-        new_url = urlutils.incdec_number(url, inc_or_dec, segments=segments)
+        new_url = urlutils.incdec_number(url, inc_or_dec, count, segments=segments)
     except urlutils.IncDecError as error:
         raise Error(error.msg)
     return new_url
 
 
-def path_up(url):
+def path_up(url, count):
     """Helper method for :navigate when `where' is up.
 
     Args:
@@ -58,8 +58,9 @@ def path_up(url):
     path = url.path()
     if not path or path == '/':
         raise Error("Can't go up!")
-    new_path = posixpath.join(path, posixpath.pardir)
-    url.setPath(new_path)
+    for i in range(0, min(count, path.count('/'))):
+        path = posixpath.join(path, posixpath.pardir)
+    url.setPath(path)
     return url
 
 

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -499,7 +499,7 @@ class IncDecError(Exception):
         return '{}: {}'.format(self.msg, self.url.toString())
 
 
-def _get_incdec_value(match, incdec, url):
+def _get_incdec_value(match, incdec, url, count):
     """Get an incremented/decremented URL based on a URL match."""
     pre, zeroes, number, post = match.groups()
     # This should always succeed because we match \d+
@@ -507,9 +507,9 @@ def _get_incdec_value(match, incdec, url):
     if incdec == 'decrement':
         if val <= 0:
             raise IncDecError("Can't decrement {}!".format(val), url)
-        val -= 1
+        val -= count
     elif incdec == 'increment':
-        val += 1
+        val += count
     else:
         raise ValueError("Invalid value {} for indec!".format(incdec))
     if zeroes:
@@ -521,7 +521,7 @@ def _get_incdec_value(match, incdec, url):
     return ''.join([pre, zeroes, str(val), post])
 
 
-def incdec_number(url, incdec, segments=None):
+def incdec_number(url, incdec, count=1, segments=None):
     """Find a number in the url and increment or decrement it.
 
     Args:
@@ -566,7 +566,7 @@ def incdec_number(url, incdec, segments=None):
         if not match:
             continue
 
-        setter(_get_incdec_value(match, incdec, url))
+        setter(_get_incdec_value(match, incdec, url, count))
         return url
 
     raise IncDecError("No number found in URL!", url)

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -527,6 +527,7 @@ def incdec_number(url, incdec, count=1, segments=None):
     Args:
         url: The current url
         incdec: Either 'increment' or 'decrement'
+        count: The number to increment or decrement by
         segments: A set of URL segments to search. Valid segments are:
                   'host', 'path', 'query', 'anchor'.
                   Default: {'path', 'query'}

--- a/tests/end2end/features/navigate.feature
+++ b/tests/end2end/features/navigate.feature
@@ -11,6 +11,11 @@ Feature: Using :navigate
         And I run :navigate up
         Then data/navigate should be loaded
 
+    Scenario: Navigating up by count
+        When I open data/navigate/sub/index.html
+        And I run :navigate up with count 2
+        Then data/navigate should be loaded
+
     # prev/next
 
     Scenario: Navigating to previous page
@@ -59,6 +64,16 @@ Feature: Using :navigate
         When I open data/navigate
         And I run :navigate increment
         Then the error "No number found in URL!" should be shown
+
+    Scenario: Incrementing number in URL by count
+        When I open data/numbers/3.txt
+        And I run :navigate increment with count 3
+        Then data/numbers/6.txt should be loaded
+
+    Scenario: Decrementing number in URL by count
+        When I open data/numbers/8.txt
+        And I run :navigate decrement with count 5
+        Then data/numbers/3.txt should be loaded
 
     Scenario: Setting url-incdec-segments
         When I set general -> url-incdec-segments to anchor

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -620,6 +620,32 @@ class TestIncDecNumber:
             base_url, incdec, segments={'host', 'path', 'query', 'anchor'})
         assert new_url == expected_url
 
+    @pytest.mark.parametrize('incdec', ['increment', 'decrement'])
+    @pytest.mark.parametrize('value', [
+        '{}foo', 'foo{}', 'foo{}bar', '42foo{}'
+    ])
+    @pytest.mark.parametrize('url', [
+        'http://example.com:80/v1/path/{}/test',
+        'http://example.com:80/v1/query_test?value={}',
+        'http://example.com:80/v1/anchor_test#{}',
+        'http://host_{}_test.com:80',
+        'http://m4ny.c0m:80/number5/3very?where=yes#{}'
+    ])
+    @pytest.mark.parametrize('count', [1, 5, 100])
+    def test_incdec_number_count(self, incdec, value, url, count):
+        """Test incdec_number with valid URLs and a count."""
+        base_value = value.format(20)
+        if incdec == 'increment':
+            expected_value = value.format(20 + count)
+        else:
+            expected_value = value.format(20 - count)
+
+        base_url = QUrl(url.format(base_value))
+        expected_url = QUrl(url.format(expected_value))
+        new_url = urlutils.incdec_number(
+            base_url, incdec, count, segments={'host', 'path', 'query', 'anchor'})
+        assert new_url == expected_url
+
     @pytest.mark.parametrize('number, expected, incdec', [
         ('01', '02', 'increment'),
         ('09', '10', 'increment'),

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -643,7 +643,8 @@ class TestIncDecNumber:
         base_url = QUrl(url.format(base_value))
         expected_url = QUrl(url.format(expected_value))
         new_url = urlutils.incdec_number(
-            base_url, incdec, count, segments={'host', 'path', 'query', 'anchor'})
+            base_url, incdec, count,
+            segments={'host', 'path', 'query', 'anchor'})
         assert new_url == expected_url
 
     @pytest.mark.parametrize('number, expected, incdec', [


### PR DESCRIPTION
After opening #1854 I thought I'd try and implement it myself. `:navigate increment` and `decrement` now change the url by the count, and `:navigate up` goes up by count levels. At the moment ctrl-a and ctrl-x don't take counts due to #1856, but binding the commands to other keys works as expected, as does `[count]gu`. The behaviors of `:navigate prev` and `next` are unchanged except for that they now consume a count but don't do anything with it.

My experience with python is pretty minimal, so let me know if I messed something up or forgot anything.