### PR TITLE
Add support for count for special bindings

### DIFF
--- a/qutebrowser/keyinput/basekeyparser.py
+++ b/qutebrowser/keyinput/basekeyparser.py
@@ -126,12 +126,20 @@ class BaseKeyParser(QObject):
             self._debug_log("Ignoring only-modifier keyeevent.")
             return False
         binding = binding.lower()
+        count = None
+        if self._supports_count and self._keystring:
+            try:
+                count = int(self._keystring)
+            except ValueError:
+                self._debug_log("Ignoring non-integer count {}.".format(
+                    self._keystring))
         try:
             cmdstr = self.special_bindings[binding]
         except KeyError:
             self._debug_log("No special binding found for {}.".format(binding))
             return False
-        self.execute(cmdstr, self.Type.special)
+        self.clear_keystring()
+        self.execute(cmdstr, self.Type.special, count)
         return True
 
     def _split_count(self):

--- a/tests/unit/keyinput/test_basekeyparser.py
+++ b/tests/unit/keyinput/test_basekeyparser.py
@@ -183,7 +183,7 @@ class TestSpecialKeys:
         keyparser.handle(fake_keyevent_factory(Qt.Key_A, modifier))
         keyparser.handle(fake_keyevent_factory(Qt.Key_X, modifier))
         keyparser.execute.assert_called_once_with(
-            'ctrla', keyparser.Type.special)
+            'ctrla', keyparser.Type.special, None)
 
     def test_invalid_key(self, fake_keyevent_factory, keyparser):
         keyparser.handle(fake_keyevent_factory(
@@ -217,7 +217,7 @@ class TestKeyChain:
         keyparser.handle(fake_keyevent_factory(Qt.Key_A, modifier))
         keyparser.handle(fake_keyevent_factory(Qt.Key_X, modifier))
         keyparser.execute.assert_called_once_with(
-            'ctrla', keyparser.Type.special)
+            'ctrla', keyparser.Type.special, None)
         assert keyparser._keystring == ''
 
     def test_invalid_special_key(self, fake_keyevent_factory, keyparser):


### PR DESCRIPTION
Fixes #1856.

Note: Special keybindings currently are not supported as part of keychains.