### PR TITLE
docker: don't start Xvfb and herbstluftwm

### DIFF
--- a/misc/docker/archlinux/Dockerfile
+++ b/misc/docker/archlinux/Dockerfile
@@ -3,12 +3,9 @@ MAINTAINER Florian Bruhin <me@the-compiler.org>
 
 RUN echo 'Server = http://mirror.de.leaseweb.net/archlinux/$repo/os/$arch' > /etc/pacman.d/mirrorlist
 RUN pacman-key --init && pacman-key --populate archlinux && pacman -Sy --noconfirm archlinux-keyring
-RUN pacman -S --noconfirm pacman | cat && pacman-db-upgrade
+RUN pacman -S --noconfirm pacman && pacman-db-upgrade
 
-RUN pacman -Suyy --noconfirm
-RUN pacman-db-upgrade
-
-RUN pacman -S --noconfirm \
+RUN pacman -Suyy --noconfirm \
     git \
     python-tox \
     qt5-base \

--- a/misc/docker/archlinux/Dockerfile
+++ b/misc/docker/archlinux/Dockerfile
@@ -14,7 +14,6 @@ RUN pacman -S --noconfirm \
     qt5-webkit \
     python-pyqt5 \
     xorg-xinit \
-    herbstluftwm \
     xorg-server-xvfb
 
 RUN echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen
@@ -23,13 +22,9 @@ RUN useradd user && mkdir /home/user && chown -R user:users /home/user
 USER user
 WORKDIR /home/user
 
-ENV DISPLAY=:0
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 
-CMD Xvfb -screen 0 800x600x24 :0 & \
-    sleep 2 && \
-    herbstluftwm & \
-    git clone /outside qutebrowser.git && \
+CMD git clone /outside qutebrowser.git && \
     cd qutebrowser.git && \
     tox -e py35

--- a/misc/docker/archlinux/Dockerfile
+++ b/misc/docker/archlinux/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Florian Bruhin <me@the-compiler.org>
 
 RUN echo 'Server = http://mirror.de.leaseweb.net/archlinux/$repo/os/$arch' > /etc/pacman.d/mirrorlist
 RUN pacman-key --init && pacman-key --populate archlinux && pacman -Sy --noconfirm archlinux-keyring
+RUN pacman -S --noconfirm pacman | cat && pacman-db-upgrade
 
 RUN pacman -Suyy --noconfirm
 RUN pacman-db-upgrade

--- a/misc/docker/debian-jessie/Dockerfile
+++ b/misc/docker/debian-jessie/Dockerfile
@@ -11,10 +11,10 @@ RUN apt-get -y update && \
             python-tox \
             python3-sip \
             xvfb \
+            xauth \
             git \
             python3-setuptools \
             wget \
-            herbstluftwm \
             locales \
             libjs-pdf
 RUN echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen
@@ -23,13 +23,9 @@ RUN useradd user && mkdir /home/user && chown -R user:users /home/user
 USER user
 WORKDIR /home/user
 
-ENV DISPLAY=:0
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 
-CMD Xvfb -screen 0 800x600x24 :0 & \
-    sleep 2 && \
-    herbstluftwm & \
-    git clone /outside qutebrowser.git && \
+CMD git clone /outside qutebrowser.git && \
     cd qutebrowser.git && \
     tox -e py34

--- a/misc/docker/ubuntu-xenial/Dockerfile
+++ b/misc/docker/ubuntu-xenial/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get -y update && \
             git \
             python3-setuptools \
             wget \
-            herbstluftwm \
             language-pack-en \
             libjs-pdf \
             dbus
@@ -25,13 +24,9 @@ RUN useradd user && mkdir /home/user && chown -R user:users /home/user
 USER user
 WORKDIR /home/user
 
-ENV DISPLAY=:0
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 
-CMD Xvfb -screen 0 800x600x24 :0 & \
-    sleep 2 && \
-    herbstluftwm & \
-    git clone /outside qutebrowser.git && \
+CMD git clone /outside qutebrowser.git && \
     cd qutebrowser.git && \
     tox -e py35


### PR DESCRIPTION
Since we use pytest-xvfb, Xvfb is automatically started and stopped by
pytest. The herbstluftwm also runs in the "outer" Xvfb and is not
actually available inside the tests, as the tests run in another
display, while  herbstluftwm runs in :0.

This patch removes herbstluftwm completely (it was not used until now,
so there shouldn't be a problem), and doesn't start Xvfb (the package is
still needed for pytest-xvfb to work).

Additionally, it adds the "xauth" package on debian, because we'll need
it anyway sooner or later. It's automatically included in Ubuntu and
Arch because xvfb depends on it, but on debian, xauth is only
recommended and not installed automatically.