### PR TITLE
Changes check if removing invocation-fixtures fixes the test suite (DO NOT MERGE)

### DIFF
--- a/misc/requirements/requirements-tests.txt
+++ b/misc/requirements/requirements-tests.txt
@@ -15,7 +15,7 @@ Mako==1.0.4
 parse==1.6.6
 parse-type==0.3.4
 py==1.4.31
-pytest==2.9.2
+git+https://github.com/nicoddemus/pytest@revert-invocation-fixtures
 pytest-bdd==2.17.0
 pytest-catchlog==1.2.2
 pytest-cov==2.3.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,7 @@ def pytest_ignore_collect(path):
     """Ignore BDD tests if we're unable to run them."""
     skip_bdd = (hasattr(sys, 'frozen') or
                 int(pytest.__version__.split('.')[0]) == 3)
+    skip_bdd = True
     rel_path = path.relto(os.path.dirname(__file__))
     return rel_path == os.path.join('end2end', 'features') and skip_bdd
 


### PR DESCRIPTION
* Use nicoddemus/pytest fork
* Skip bdd tests

Just to be absolutely sure the removal actually fixes qutebrowser's test suite. :grin: 