### PR TITLE
fix handling of choices with no type given (#1871)

### DIFF
--- a/qutebrowser/commands/argparser.py
+++ b/qutebrowser/commands/argparser.py
@@ -119,7 +119,7 @@ def type_conv(param, typ, value, *, str_choices=None):
     if utils.is_enum(typ):
         _check_choices(param, value, [arg_name(e.name) for e in typ])
         return typ[value.replace('-', '_')]
-    elif typ is str:
+    elif typ in [str, None]:
         if str_choices is not None:
             _check_choices(param, value, str_choices)
         return value

--- a/qutebrowser/commands/command.py
+++ b/qutebrowser/commands/command.py
@@ -414,6 +414,9 @@ class Command:
         if isinstance(typ, tuple):
             raise TypeError("{}: Legacy tuple type annotation!".format(
                 self.name))
+        elif param.kind in [inspect.Parameter.VAR_POSITIONAL,
+                            inspect.Parameter.VAR_KEYWORD]:
+            return value
         elif issubclass(typ, typing.Union):
             # this is... slightly evil, I know
             types = list(typ.__union_params__)
@@ -422,11 +425,9 @@ class Command:
             choices = self.get_arg_info(param).choices
             value = argparser.multitype_conv(param, types, value,
                                              str_choices=choices)
-        elif typ is str:
+        elif typ in [str, None]:
             choices = self.get_arg_info(param).choices
             value = argparser.type_conv(param, typ, value, str_choices=choices)
-        elif typ is None:
-            pass
         elif typ is bool:  # no type conversion for flags
             assert isinstance(value, bool)
         else:

--- a/tests/unit/commands/test_cmdutils.py
+++ b/tests/unit/commands/test_cmdutils.py
@@ -295,6 +295,20 @@ class TestRegister:
         else:
             assert cmd._get_call_args(win_id=0) == ([expected], {})
 
+    def test_choices_no_annotation(self):
+        # https://github.com/The-Compiler/qutebrowser/issues/1871
+        @cmdutils.register()
+        @cmdutils.argument('arg', choices=['foo', 'bar'])
+        def fun(arg):
+            """Blah."""
+            pass
+
+        cmd = cmdutils.cmd_dict['fun']
+        cmd.namespace = cmd.parser.parse_args(['fish'])
+
+        with pytest.raises(cmdexc.ArgumentTypeError):
+            cmd._get_call_args(win_id=0)
+
     def test_pos_arg_info(self):
         @cmdutils.register()
         @cmdutils.argument('foo', choices=('a', 'b'))


### PR DESCRIPTION
Fixes #1871.

The fix is basically the one of @The-Compiler with a small bugfix. The
value that caused trouble was the `*args` one, as that was a list and not
a string. This patch makes that `*args` and `**kwargs` are returned
unchanged, which means the fix as The-Compiler wrote it works.