### PR TITLE
Test completion

### DIFF
--- a/tests/end2end/features/completion.feature
+++ b/tests/end2end/features/completion.feature
@@ -1,0 +1,7 @@
+Feature: Command bar completion
+
+    Scenario: No warnings when completing with one entry (#1600)
+        Given I open about:blank
+        When I run :set-cmd-text -s :open
+        And I run :completion-item-focus next
+        Then no crash should happen

--- a/tests/end2end/features/test_completion_bdd.py
+++ b/tests/end2end/features/test_completion_bdd.py
@@ -1,0 +1,21 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2016 Ryan Roden-Corrent (rcorre) <ryan@rcorre.net>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest_bdd as bdd
+bdd.scenarios('completion.feature')


### PR DESCRIPTION
Add tests for completion bugs fixd by #1811 as discussed in #1899.

These tests cover #1600 and #1812. #1519 doesn't actually appear to be fixed.

Note that #1840 also adds `completion.feature` and `test_completion_bdd.py` so someone will have to resolve a conflict (just an add/add so not a big deal).
