### PR TITLE
Allow :open-editor in modes other than insert

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1472,8 +1472,8 @@ class CommandDispatcher:
             self.on_editing_finished, elem))
         ed.edit(text)
 
-    @cmdutils.register(instance='command-dispatcher',
-                       modes=[KeyMode.insert], hide=True, scope='window')
+    @cmdutils.register(instance='command-dispatcher', hide=True,
+                       scope='window')
     def open_editor(self):
         """Open an external editor with the currently selected form field.
 

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -67,3 +67,29 @@ Feature: Opening external editors
         And I wait for "Read back: foobar" in the log
         And I run :click-element id qute-button
         Then the javascript message "text: foobar" should be logged
+
+    Scenario: Spawning an editor in normal mode
+        When I set up a fake editor returning "foobar"
+        And I open data/editor.html
+        And I run :click-element id qute-textarea
+        And I wait for "Clicked editable element!" in the log
+        And I run :leave-mode
+        And I wait for "Leaving mode KeyMode.insert (reason: leave current)" in the log
+        And I run :open-editor
+        And I wait for "Read back: foobar" in the log
+        And I run :click-element id qute-button
+        Then the javascript message "text: foobar" should be logged
+
+    Scenario: Spawning an editor in caret mode
+        When I set up a fake editor returning "foobar"
+        And I open data/editor.html
+        And I run :click-element id qute-textarea
+        And I wait for "Clicked editable element!" in the log
+        And I run :leave-mode
+        And I wait for "Leaving mode KeyMode.insert (reason: leave current)" in the log
+        And I run :enter-mode caret
+        And I wait for "Entering mode KeyMode.caret (reason: command)" in the log
+        And I run :open-editor
+        And I wait for "Read back: foobar" in the log
+        And I run :click-element id qute-button
+        Then the javascript message "text: foobar" should be logged


### PR DESCRIPTION
':open-editor' can now be run in all modes.

Resolves #1902