### PR TITLE
Fix handling of spaces in completion

### DIFF
--- a/qutebrowser/completion/models/sortfilter.py
+++ b/qutebrowser/completion/models/sortfilter.py
@@ -69,7 +69,7 @@ class CompletionFilterModel(QSortFilterProxyModel):
         with debug.log_time(log.completion, 'Setting filter pattern'):
             self.pattern = val
             val = re.escape(val)
-            val = re.sub(r'\ +', r'.*', val)
+            val = re.sub(r'(\\ )+', r'.*', val)
             self.pattern_re = re.compile(val, re.IGNORECASE)
             self.invalidate()
             sortcol = 0


### PR DESCRIPTION
A quick fix for #1934. It's probably too quick, since the tests added in 0a3853fcb78824372b4c19136c1c74562153c4e3 and faa052ad6f2b04afcf5bc8bb3d1481c8f74a5d6d passed, so they don't prove anything.