### PR TITLE
Add a way to escape variables

### DIFF
--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -66,10 +66,15 @@ def replace_variables(win_id, arglist):
     def repl_cb(matchobj):
         """Return replacement for given match."""
         var = matchobj.group("var")
+        escaped = matchobj.group("escaped")
+        if escaped is not None:
+            return "{" + escaped + "}"
         if var not in values:
             values[var] = variables[var]()
         return values[var]
-    repl_pattern = re.compile("{(?P<var>" + "|".join(variables.keys()) + ")}")
+    repl_pattern = re.compile(
+        r"{({(?P<escaped>" + "|".join(variables.keys()) + r")})}|" +
+        r"(?={){(?P<var>" + "|".join(variables.keys()) + r")}(?<=})")
 
     try:
         for arg in arglist:

--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -73,8 +73,8 @@ def replace_variables(win_id, arglist):
             values[var] = variables[var]()
         return values[var]
     repl_pattern = re.compile(
-        r"{({(?P<escaped>" + "|".join(variables.keys()) + r")})}|" +
-        r"(?={){(?P<var>" + "|".join(variables.keys()) + r")}(?<=})")
+        r"{{(?P<escaped>" + "|".join(variables.keys()) + r")}}|" +
+        r"{(?P<var>" + "|".join(variables.keys()) + r")}")
 
     try:
         for arg in arglist:

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -615,6 +615,46 @@ Feature: Various utility commands.
         And I run :message-info {clipboard}bar{url}
         Then the message "foobarhttp://localhost:*/hello.txt" should be shown
 
+    Scenario: escaping {{url}} variable
+        When I open data/hello.txt
+        And I run :message-info foo{{url}}bar
+        Then the message "foo{url}bar" should be shown
+
+    Scenario: escaping with multiple curly brackets
+        When I open data/hello.txt
+        And I run :message-info foo{{{url}}}bar
+        Then the message "foo{{url}}bar" should be shown
+
+    Scenario: escaping multiple variables
+        When I open data/hello.txt
+        And I run :message-info foo{{url}}bar{{clipboard}}
+        Then the message "foo{url}bar{clipboard}" should be shown
+
+    Scenario: both escaped and unescaped variables
+        When I open data/hello.txt
+        And I run :message-info foo{{url}}bar{url}
+        Then the message "foo{url}barhttp://localhost:*/hello.txt" should be shown
+
+    Scenario: escaping not a variable
+        When I open data/hello.txt
+        And I run :message-info foo{{hello}}bar
+        Then the message "foo{{hello}}bar" should be shown
+
+    Scenario: escaping variable with unmatched brackets
+        When I open data/hello.txt
+        And I run :message-info foo{url}}bar
+        Then the message "foohttp://localhost:*/hello.txt}bar" should be shown
+
+    Scenario: escaping variable with unmatched brackets 2
+        When I open data/hello.txt
+        And I run :message-info foo{{url}bar
+        Then the message "foo{http://localhost:*/hello.txtbar" should be shown
+
+    Scenario: escaping variable with mutiple unmatched brackets
+        When I open data/hello.txt
+        And I run :message-info foo{{url}bar{{url}}abc{url}}
+        Then the message "foo{http://localhost:*/hello.txtbar{url}abchttp://localhost:*/hello.txt}" should be shown
+
     @xfail_norun
     Scenario: {url} in clipboard should not be expanded
         When I open data/hello.txt


### PR DESCRIPTION
Variables such as {url} and {selection} can now be explicitly
escaped by double curly brackets: {{url}}, {{selection}}.

Only valid variables that would've been replaced are escaped,
so '{{notavariable}}' stays '{{notavariable}}'.

{{url} and {url}} both expand the variable.

This does *not* fully solve issue #1861