### PR TITLE
Refactor Completion.on_selection_changed and fix #1519

### DIFF
--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -174,15 +174,6 @@ class CommandRunner(QObject):
             count = None
         return (count, cmdstr)
 
-    def _parse_fallback(self, text, count, keep):
-        """Parse the given commandline without a valid command."""
-        if keep:
-            cmdstr, sep, argstr = text.partition(' ')
-            cmdline = [cmdstr, sep] + argstr.split()
-        else:
-            cmdline = text.split()
-        return ParseResult(cmd=None, args=None, cmdline=cmdline, count=count)
-
     def parse(self, text, *, fallback=False, keep=False):
         """Split the commandline text into command and arguments.
 
@@ -210,7 +201,9 @@ class CommandRunner(QObject):
             if not fallback:
                 raise cmdexc.NoSuchCommandError(
                     '{}: no such command'.format(cmdstr))
-            return self._parse_fallback(text, count, keep)
+            cmdline = split.split(text, keep=keep)
+            return ParseResult(cmd=None, args=None, cmdline=cmdline,
+                               count=count)
 
         args = self._split_args(cmd, argstr, keep)
         if keep and args:

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -276,7 +276,7 @@ class Completer(QObject):
                        including a trailing space and we shouldn't continue
                        completing the current item.
         """
-        text = self._cmd.prefix() + ' '.join([*before, newtext])
+        text = self._cmd.prefix() + ' '.join(before + [newtext])
         pos = len(text) + (1 if immediate else 0)
         if after:
             text += ' ' + ' '.join(after)

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -107,7 +107,7 @@ class Completer(QObject):
         log.completion.debug("Before removing flags: {}".format(before_cursor))
         before_cursor = [x for x in before_cursor if not x.startswith('-')]
         log.completion.debug("After removing flags: {}".format(before_cursor))
-        if len(before_cursor) == 0:
+        if not before_cursor:
             # '|' or 'set|'
             model = instances.get(usertypes.Completion.command)
             return sortfilter.CompletionFilterModel(source=model, parent=self)

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -101,14 +101,9 @@ class Completer(QObject):
         Return:
             A completion model.
         """
-        if '--' in before_cursor:
+        if '--' in before_cursor or under_cursor.startswith('-'):
+            # cursor on a flag or after an explicit split (--)
             return None
-        try:
-            if under_cursor.startswith('-'):
-                # cursor on a flag
-                return None
-        except IndexError:
-            pass
         log.completion.debug("Before removing flags: {}".format(before_cursor))
         before_cursor = [x for x in before_cursor if not x.startswith('-')]
         log.completion.debug("After removing flags: {}".format(before_cursor))

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -252,6 +252,7 @@ class Completer(QObject):
             completion.set_model(None)
             return
 
+        pattern = pattern.strip("'\"")
         model = self._get_new_completion(before_cursor, pattern)
 
         log.completion.debug("Setting completion model to {} with pattern '{}'"

--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -104,7 +104,7 @@ class CompletionView(QTreeView):
     """
 
     resize_completion = pyqtSignal()
-    selection_changed = pyqtSignal(QItemSelection)
+    selection_changed = pyqtSignal(str)
 
     def __init__(self, win_id, parent=None):
         super().__init__(parent)
@@ -310,7 +310,11 @@ class CompletionView(QTreeView):
         if not self._active:
             return
         super().selectionChanged(selected, deselected)
-        self.selection_changed.emit(selected)
+        indexes = selected.indexes()
+        if not indexes:
+            return
+        data = self.model().data(indexes[0])
+        self.selection_changed.emit(data)
 
     def resizeEvent(self, e):
         """Extend resizeEvent to adjust column size."""

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -204,6 +204,7 @@ def test_update_completion(txt, expected, status_command_stub, completer_obj,
     (':|set', 'set', ':set|'),
     (':|set ', 'set', ':set|'),
     (':|se', 'set', ':set|'),
+    (':|se ', 'set', ':set|'),
     (':s|e', 'set', ':set|'),
     (':se|', 'set', ':set|'),
     (':|se fonts', 'set', ':set| fonts'),
@@ -248,8 +249,6 @@ def test_on_selection_changed(before, newtxt, after, completer_obj,
         config_stub.data['completion']['quick-complete'] = quick_complete
         model.count = unittest.mock.Mock(return_value=count)
         _set_cmd_prompt(status_command_stub, before)
-        # TODO: refactor so cursor_part is a local rather than class variable
-        completer_obj._update_cursor_part()
         completer_obj.on_selection_changed(selection)
         model.data.assert_called_with(indexes[0])
         assert status_command_stub.text() == expected_txt

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -174,7 +174,6 @@ def _set_cmd_prompt(cmd, txt):
     (':open -t |', usertypes.Completion.url),
     (':open --tab |', usertypes.Completion.url),
     (':open | -t', usertypes.Completion.url),
-    (':--foo --bar |', None),
     (':tab-detach |', None),
     (':bind --mode=caret <c-x> |', usertypes.Completion.command),
     pytest.mark.xfail(reason='issue #74')((':bind --mode caret <c-x> |',

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -222,7 +222,10 @@ def test_update_completion(txt, expected, status_command_stub, completer_obj,
     (":set fonts hints 'Comic Sans'|", '12px Hack',
      ":set fonts hints '12px Hack'|"),
     (":set fonts hints 'Comic| Sans'", '12px Hack',
-     ":set fonts hints '12px Hack'|")
+     ":set fonts hints '12px Hack'|"),
+    # open has maxsplit=0, so treat the last two tokens as one and don't quote
+    (':open foo bar|', 'baz', ':open baz|'),
+    (':open foo| bar', 'baz', ':open baz|'),
 ])
 def test_on_selection_changed(before, newtxt, after, completer_obj,
                               config_stub, status_command_stub,

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -82,7 +82,7 @@ def instances(monkeypatch):
     }
     instances[usertypes.Completion.value] = {
         'general': {
-            'ignore-case': FakeCompletionModel(usertypes.Completion.value),
+            'editor': FakeCompletionModel(usertypes.Completion.value),
         }
     }
     monkeypatch.setattr('qutebrowser.completion.completer.instances',
@@ -150,7 +150,10 @@ def _set_cmd_prompt(cmd, txt):
     (':set gen|', usertypes.Completion.section, 'gen'),
     (':set general |', usertypes.Completion.option, ''),
     (':set what |', None, ''),
-    (':set general ignore-case |', usertypes.Completion.value, ''),
+    (':set general editor |', usertypes.Completion.value, ''),
+    (':set general editor gv|', usertypes.Completion.value, 'gv'),
+    (':set general editor "gvim -f"|', usertypes.Completion.value, 'gvim -f'),
+    (':set general editor "gvim |', usertypes.Completion.value, 'gvim'),
     (':set general huh |', None, ''),
     (':help |', usertypes.Completion.helptopic, ''),
     (':help     |', usertypes.Completion.helptopic, ''),

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -176,6 +176,7 @@ def _set_cmd_prompt(cmd, txt):
                                            usertypes.Completion.command)),
     (':set -t -p |', usertypes.Completion.section),
     (':open -- |', None),
+    (':gibberish nonesense |', None),
 ])
 def test_update_completion(txt, expected, status_command_stub, completer_obj,
                            completion_widget_stub):

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -242,18 +242,13 @@ def test_on_selection_changed(before, newtxt, after, completer_obj,
     then we expect a space to be appended after the current word.
     """
     model = unittest.mock.Mock()
-    model.data = unittest.mock.Mock(return_value=newtxt)
-    indexes = [unittest.mock.Mock()]
-    selection = unittest.mock.Mock()
-    selection.indexes = unittest.mock.Mock(return_value=indexes)
     completion_widget_stub.model.return_value = model
 
     def check(quick_complete, count, expected_txt, expected_pos):
         config_stub.data['completion']['quick-complete'] = quick_complete
-        model.count = unittest.mock.Mock(return_value=count)
+        model.count = lambda: count
         _set_cmd_prompt(status_command_stub, before)
-        completer_obj.on_selection_changed(selection)
-        model.data.assert_called_with(indexes[0])
+        completer_obj.on_selection_changed(newtxt)
         assert status_command_stub.text() == expected_txt
         assert status_command_stub.cursorPosition() == expected_pos
 
@@ -283,16 +278,11 @@ def test_quickcomplete_flicker(status_command_stub, completer_obj,
     quick-complete an entry after maxsplit.
     """
     model = unittest.mock.Mock()
-    model.data = unittest.mock.Mock(return_value='http://example.com')
-    indexes = [unittest.mock.Mock()]
-    selection = unittest.mock.Mock()
-    selection.indexes = unittest.mock.Mock(return_value=indexes)
-    completion_widget_stub.model.return_value = model
-
-    config_stub.data['completion']['quick-complete'] = True
     model.count = unittest.mock.Mock(return_value=1)
-    _set_cmd_prompt(status_command_stub, ':open |')
-    completer_obj.on_selection_changed(selection)
+    completion_widget_stub.model.return_value = model
+    config_stub.data['completion']['quick-complete'] = True
 
+    _set_cmd_prompt(status_command_stub, ':open |')
+    completer_obj.on_selection_changed('http://example.com')
     completer_obj.schedule_completion_update()
     assert not completion_widget_stub.set_model.called

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -261,6 +261,7 @@ def test_on_selection_changed(before, newtxt, after, completer_obj,
         after_txt += ' '
     check(True, 1, after_txt, after_pos)
 
+
 def test_quickcomplete_flicker(status_command_stub, completer_obj,
                                completion_widget_stub, config_stub):
     """Validate fix for #1519: bookmark-load background highlighting quirk.
@@ -271,7 +272,8 @@ def test_quickcomplete_flicker(status_command_stub, completer_obj,
     one completion available, it keeps the completionmenu open.
 
     This test validates that the completion model is not re-set after we
-    quick-complete an entry after maxsplit."""
+    quick-complete an entry after maxsplit.
+    """
     model = unittest.mock.Mock()
     model.data = unittest.mock.Mock(return_value='http://example.com')
     indexes = [unittest.mock.Mock()]

--- a/tests/unit/completion/test_completionwidget.py
+++ b/tests/unit/completion/test_completionwidget.py
@@ -96,64 +96,56 @@ def test_maybe_resize_completion(completionview, config_stub, qtbot):
         completionview.maybe_resize_completion()
 
 
-@pytest.mark.parametrize('which, tree, count, expected', [
-    ('next', [['Aa']], 1, 'Aa'),
-    ('prev', [['Aa']], 1, 'Aa'),
-    ('next', [['Aa'], ['Ba']], 1, 'Aa'),
-    ('prev', [['Aa'], ['Ba']], 1, 'Ba'),
-    ('next', [['Aa'], ['Ba']], 2, 'Ba'),
-    ('prev', [['Aa'], ['Ba']], 2, 'Aa'),
-    ('next', [['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], 3, 'Ac'),
-    ('next', [['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], 4, 'Ba'),
-    ('next', [['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], 6, 'Ca'),
-    ('next', [['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], 7, 'Aa'),
-    ('prev', [['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], 1, 'Ca'),
-    ('prev', [['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], 2, 'Bb'),
-    ('prev', [['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], 4, 'Ac'),
-    ('next', [[], ['Ba', 'Bb']], 1, 'Ba'),
-    ('prev', [[], ['Ba', 'Bb']], 1, 'Bb'),
-    ('next', [[], [], ['Ca', 'Cb']], 1, 'Ca'),
-    ('prev', [[], [], ['Ca', 'Cb']], 1, 'Cb'),
-    ('next', [['Aa'], []], 1, 'Aa'),
-    ('prev', [['Aa'], []], 1, 'Aa'),
-    ('next', [['Aa'], [], []], 1, 'Aa'),
-    ('prev', [['Aa'], [], []], 1, 'Aa'),
-    ('next', [['Aa'], [], ['Ca', 'Cb']], 2, 'Ca'),
-    ('prev', [['Aa'], [], ['Ca', 'Cb']], 1, 'Cb'),
-    ('next', [[]], 1, None),
-    ('prev', [[]], 1, None),
-    ('next-category', [['Aa']], 1, 'Aa'),
-    ('prev-category', [['Aa']], 1, 'Aa'),
-    ('next-category', [['Aa'], ['Ba']], 1, 'Aa'),
-    ('prev-category', [['Aa'], ['Ba']], 1, 'Ba'),
-    ('next-category', [['Aa'], ['Ba']], 2, 'Ba'),
-    ('prev-category', [['Aa'], ['Ba']], 2, 'Aa'),
-    ('next-category', [['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], 2, 'Ba'),
-    ('prev-category', [['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], 2, 'Ba'),
-    ('next-category', [['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], 3, 'Ca'),
-    ('prev-category', [['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']], 3, 'Aa'),
-    ('next-category', [[], ['Ba', 'Bb']], 1, 'Ba'),
-    ('prev-category', [[], ['Ba', 'Bb']], 1, 'Ba'),
-    ('next-category', [[], [], ['Ca', 'Cb']], 1, 'Ca'),
-    ('prev-category', [[], [], ['Ca', 'Cb']], 1, 'Ca'),
-    ('next-category', [[], [], ['Ca', 'Cb']], 2, 'Ca'),
-    ('prev-category', [[], [], ['Ca', 'Cb']], 2, 'Ca'),
-    ('next-category', [['Aa'], [], []], 1, 'Aa'),
-    ('prev-category', [['Aa'], [], []], 1, 'Aa'),
-    ('next-category', [['Aa'], [], ['Ca', 'Cb']], 2, 'Ca'),
-    ('prev-category', [['Aa'], [], ['Ca', 'Cb']], 1, 'Ca'),
-    ('next-category', [[]], 1, None),
-    ('prev-category', [[]], 1, None),
+@pytest.mark.parametrize('which, tree, expected', [
+    ('next', [['Aa']], ['Aa', None, None]),
+    ('prev', [['Aa']], ['Aa', None, None]),
+    ('next', [['Aa'], ['Ba']], ['Aa', 'Ba', 'Aa']),
+    ('prev', [['Aa'], ['Ba']], ['Ba', 'Aa', 'Ba']),
+    ('next', [['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']],
+        ['Aa', 'Ab', 'Ac', 'Ba', 'Bb', 'Ca', 'Aa']),
+    ('prev', [['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']],
+        ['Ca', 'Bb', 'Ba', 'Ac', 'Ab', 'Aa', 'Ca']),
+    ('next', [[], ['Ba', 'Bb']], ['Ba', 'Bb', 'Ba']),
+    ('prev', [[], ['Ba', 'Bb']], ['Bb', 'Ba', 'Bb']),
+    ('next', [[], [], ['Ca', 'Cb']], ['Ca', 'Cb', 'Ca']),
+    ('prev', [[], [], ['Ca', 'Cb']], ['Cb', 'Ca', 'Cb']),
+    ('next', [['Aa'], []], ['Aa', None]),
+    ('prev', [['Aa'], []], ['Aa', None]),
+    ('next', [['Aa'], [], []], ['Aa', None]),
+    ('prev', [['Aa'], [], []], ['Aa', None]),
+    ('next', [['Aa'], [], ['Ca', 'Cb']], ['Aa', 'Ca', 'Cb', 'Aa']),
+    ('prev', [['Aa'], [], ['Ca', 'Cb']], ['Cb', 'Ca', 'Aa', 'Cb']),
+    ('next', [[]], [None, None]),
+    ('prev', [[]], [None, None]),
+    ('next-category', [['Aa']], ['Aa', None, None]),
+    ('prev-category', [['Aa']], ['Aa', None, None]),
+    ('next-category', [['Aa'], ['Ba']], ['Aa', 'Ba', 'Aa']),
+    ('prev-category', [['Aa'], ['Ba']], ['Ba', 'Aa', 'Ba']),
+    ('next-category', [['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']],
+        ['Aa', 'Ba', 'Ca', 'Aa']),
+    ('prev-category', [['Aa', 'Ab', 'Ac'], ['Ba', 'Bb'], ['Ca']],
+        ['Ca', 'Ba', 'Aa', 'Ca']),
+    ('next-category', [[], ['Ba', 'Bb']], ['Ba', None, None]),
+    ('prev-category', [[], ['Ba', 'Bb']], ['Ba', None, None]),
+    ('next-category', [[], [], ['Ca', 'Cb']], ['Ca', None, None]),
+    ('prev-category', [[], [], ['Ca', 'Cb']], ['Ca', None, None]),
+    ('next-category', [['Aa'], [], []], ['Aa', None, None]),
+    ('prev-category', [['Aa'], [], []], ['Aa', None, None]),
+    ('next-category', [['Aa'], [], ['Ca', 'Cb']], ['Aa', 'Ca', 'Aa']),
+    ('prev-category', [['Aa'], [], ['Ca', 'Cb']], ['Ca', 'Aa', 'Ca']),
+    ('next-category', [[]], [None, None]),
+    ('prev-category', [[]], [None, None]),
 ])
-def test_completion_item_focus(which, tree, count, expected, completionview,
-                               qtbot):
+def test_completion_item_focus(which, tree, expected, completionview, qtbot):
     """Test that on_next_prev_item moves the selection properly.
 
     Args:
+        which: the direction in which to move the selection.
         tree: Each list represents a completion category, with each string
               being an item under that category.
-        count: Number of times to go forward (or back if negative).
-        expected: item data that should be selected after going back/forward.
+        expected: expected argument from on_selection_changed for each
+                  successive movement. None implies no signal should be
+                  emitted.
     """
     model = base.BaseCompletionModel()
     for catdata in tree:
@@ -164,15 +156,14 @@ def test_completion_item_focus(which, tree, count, expected, completionview,
     filtermodel = sortfilter.CompletionFilterModel(model,
                                                    parent=completionview)
     completionview.set_model(filtermodel)
-    if expected is None:
-        for _ in range(count):
-            completionview.completion_item_focus(which)
-    else:
-        with qtbot.waitSignal(completionview.selection_changed):
-            for _ in range(count):
+    for entry in expected:
+        if entry is None:
+            with qtbot.assertNotEmitted(completionview.selection_changed):
                 completionview.completion_item_focus(which)
-    idx = completionview.selectionModel().currentIndex()
-    assert filtermodel.data(idx) == expected
+        else:
+            with qtbot.waitSignal(completionview.selection_changed) as sig:
+                completionview.completion_item_focus(which)
+                assert sig.args == [entry]
 
 
 @pytest.mark.parametrize('which', ['next', 'prev', 'next-category',


### PR DESCRIPTION
While trying to fix #1519 I noticed the code seemed excessively complicated. I rewrote using locals rather than class variables that are persisted between method calls.

[The fix](https://github.com/The-Compiler/qutebrowser/commit/6e5cc62a0dd6bc4b06cecc13173f86c3803516e7) is independent of the refactoring but I think the refactored version is worth it (~100 less lines of code, and that's including quite a few more test cases :grin:)