### PR TITLE
Make sure keyword-only parameters have a default

### DIFF
--- a/qutebrowser/commands/command.py
+++ b/qutebrowser/commands/command.py
@@ -247,9 +247,10 @@ class Command:
                 if self._inspect_special_param(param):
                     continue
                 if (param.kind == inspect.Parameter.KEYWORD_ONLY and
-                      param.default is inspect.Parameter.empty):
+                        param.default is inspect.Parameter.empty):
                     raise TypeError("{}: handler has keyword only argument "
-                                    "without default!".format(self.name))
+                                    "{!r} without default!".format(self.name,
+                                                                   param.name))
                 typ = self._get_type(param)
                 is_bool = typ is bool
                 kwargs = self._param_to_argparse_kwargs(param, is_bool)

--- a/qutebrowser/commands/command.py
+++ b/qutebrowser/commands/command.py
@@ -246,6 +246,10 @@ class Command:
                     continue
                 if self._inspect_special_param(param):
                     continue
+                if (param.kind == inspect.Parameter.KEYWORD_ONLY and
+                      param.default is inspect.Parameter.empty):
+                    raise TypeError("{}: handler has keyword only argument "
+                                    "without default!".format(self.name))
                 typ = self._get_type(param)
                 is_bool = typ is bool
                 kwargs = self._param_to_argparse_kwargs(param, is_bool)

--- a/tests/unit/commands/test_cmdutils.py
+++ b/tests/unit/commands/test_cmdutils.py
@@ -349,6 +349,24 @@ class TestRegister:
         with pytest.raises(IndexError):
             cmd.get_pos_arg_info(2)
 
+    def test_keyword_only_without_default(self):
+        # https://github.com/The-Compiler/qutebrowser/issues/1872
+        def fun(*, target):
+            """Blah."""
+            pass
+
+        with pytest.raises(TypeError):
+            fun = cmdutils.register()(fun)
+
+    def test_typed_keyword_only_without_default(self):
+        # https://github.com/The-Compiler/qutebrowser/issues/1872
+        def fun(*, target: int):
+            """Blah."""
+            pass
+
+        with pytest.raises(TypeError):
+            fun = cmdutils.register()(fun)
+
 
 class TestArgument:
 

--- a/tests/unit/commands/test_cmdutils.py
+++ b/tests/unit/commands/test_cmdutils.py
@@ -324,7 +324,7 @@ class TestRegister:
         # https://github.com/The-Compiler/qutebrowser/issues/1871
         @cmdutils.register()
         @cmdutils.argument('arg', choices=['foo', 'bar'])
-        def fun(*, arg):
+        def fun(*, arg='foo'):
             """Blah."""
             pass
 

--- a/tests/unit/commands/test_cmdutils.py
+++ b/tests/unit/commands/test_cmdutils.py
@@ -355,8 +355,13 @@ class TestRegister:
             """Blah."""
             pass
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError) as excinfo:
             fun = cmdutils.register()(fun)
+
+        expected = ("fun: handler has keyword only argument 'target' without "
+                    "default!")
+        assert str(excinfo.value) == expected
+
 
     def test_typed_keyword_only_without_default(self):
         # https://github.com/The-Compiler/qutebrowser/issues/1872
@@ -364,8 +369,12 @@ class TestRegister:
             """Blah."""
             pass
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError) as excinfo:
             fun = cmdutils.register()(fun)
+
+        expected = ("fun: handler has keyword only argument 'target' without "
+                    "default!")
+        assert str(excinfo.value) == expected
 
 
 class TestArgument:


### PR DESCRIPTION
Fixes #1872.

This prevents `inspect.Parameter.empty` from slipping through to the
command.