### PR TITLE
Completer: don't try to partition search.

### DIFF
--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -226,11 +226,6 @@ class Completer(QObject):
     @pyqtSlot()
     def _update_completion(self):
         """Check if completions are available and activate them."""
-        before_cursor, pattern, after_cursor = self._partition()
-
-        log.completion.debug("Updating completion: {} {} {}".format(
-            before_cursor, pattern, after_cursor))
-
         if self._ignore_change:
             log.completion.debug("Ignoring completion update because "
                                  "ignore_change is True.")
@@ -246,6 +241,11 @@ class Completer(QObject):
             # https://github.com/The-Compiler/qutebrowser/issues/32
             completion.set_model(None)
             return
+
+        before_cursor, pattern, after_cursor = self._partition()
+
+        log.completion.debug("Updating completion: {} {} {}".format(
+            before_cursor, pattern, after_cursor))
 
         pattern = pattern.strip("'\"")
         model = self._get_new_completion(before_cursor, pattern)

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -180,6 +180,7 @@ def _set_cmd_prompt(cmd, txt):
     (':set -t -p |', usertypes.Completion.section, ''),
     (':open -- |', None, ''),
     (':gibberish nonesense |', None, ''),
+    ('/:help|', None, ''),
 ])
 def test_update_completion(txt, kind, pattern, status_command_stub,
                            completer_obj, completion_widget_stub):


### PR DESCRIPTION
Exit before trying to partition if the command prefix is not ':'.

Resolves #1969:
'TypeError with refactored completion when searching for command'