### PR TITLE
Prettify yank pretty-url

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -677,7 +677,9 @@ class CommandDispatcher:
         """Helper method for yank() to get the URL to copy."""
         assert what in ['url', 'pretty-url'], what
         flags = QUrl.RemovePassword
-        if what != 'pretty-url':
+        if what == 'pretty-url':
+            flags |= QUrl.DecodeReserved
+        else:
             flags |= QUrl.FullyEncoded
         url = QUrl(self._current_url())
         url_query = QUrlQuery(url)

--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -54,7 +54,7 @@ def replace_variables(win_id, arglist):
         'url': lambda: _current_url(tabbed_browser).toString(
             QUrl.FullyEncoded | QUrl.RemovePassword),
         'url:pretty': lambda: _current_url(tabbed_browser).toString(
-            QUrl.RemovePassword),
+            QUrl.DecodeReserved | QUrl.RemovePassword),
         'clipboard': utils.get_clipboard,
         'primary': lambda: utils.get_clipboard(selection=True),
     }


### PR DESCRIPTION
This is useful for prettifying URLs like [this](https://wiki.archlinux.org/api.php?action=query&list=recentchanges&rcprop=title%7Cids%7Cuser%7Cflags) (where `%7C` is the `|` symbol).

According to the [QUrl documentation](http://doc.qt.io/qt-5/qurl.html#ComponentFormattingOption-enum), `QUrl::DecodeReserved` is the default for the individual component getters. I think that the corner cases where `encode(decode_also_reserved(url))` does not give the original URL are rare enough - in that case the pretty-url doesn't make much sense in any form.