### PR TITLE
Fix keybinding-related crash

### DIFF
--- a/qutebrowser/config/parsers/keyconf.py
+++ b/qutebrowser/config/parsers/keyconf.py
@@ -262,6 +262,7 @@ class KeyConfigParser(QObject):
             bindings_to_add[sectname] = collections.OrderedDict()
             for command, keychains in sect.items():
                 for e in keychains:
+                    e = e.lower()
                     if not only_new or self._is_new(sectname, command, e):
                         assert e not in bindings_to_add[sectname]
                         bindings_to_add[sectname][e] = command


### PR DESCRIPTION
A quick fix for #1835 (and similar ones, like #1958)

Originally the code intended to load `~/.config/qutebrowser/keys.conf` first, and then apply default bindings for unset keychains. But due to the broken logic the program can assign different bindings to the same keychain (the only real case so far is when `keys.conf` is present). When this happens, the loading code raises a `DuplicateKeychainError` and aborts execution.

There are two solutions:
1. Reorder (default first, `keys.conf` second) + new bindings take precedence (achieved by the `force` parameter of the `KeyConfigParser._add_binding()` method).
2. Fix the original logic.

Currently, the first solution is implemented as the easier one.
