### PR TITLE
Reserve space for favicon with vertical tabs (fixes #1968)

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -609,8 +609,11 @@ class TabBarStyle(QCommonStyle):
             # any sophisticated drawing.
             super().drawControl(QStyle.CE_TabBarTabShape, opt, p, widget)
         elif element == QStyle.CE_TabBarTabLabel:
+            position = config.get('tabs', 'position')
             if not opt.icon.isNull() and layouts.icon.isValid():
                 self._draw_icon(layouts, opt, p)
+            elif position in [QTabWidget.West, QTabWidget.East]:
+                layouts.text.translate(opt.iconSize.width() + 4, 0)
             alignment = (config.get('tabs', 'title-alignment') |
                          Qt.AlignVCenter | Qt.TextHideMnemonic)
             self._style.drawItemText(p, layouts.text, alignment, opt.palette,

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -732,15 +732,15 @@ class TabBarStyle(QCommonStyle):
                       else QIcon.Off)
         # reserve space for favicon when tab bar is vertical (issue #1968)
         position = config.get('tabs', 'position')
-        show_favicons = config.get('tabs', 'show-favicons')
-        if (opt.icon.isNull()
-            and position in [QTabWidget.East, QTabWidget.West]
-            and show_favicons):
+        if (opt.icon.isNull() and
+                position in [QTabWidget.East, QTabWidget.West] and
+                config.get('tabs', 'show-favicons')):
             tab_icon_size = icon_size
         else:
             actual_size = opt.icon.actualSize(icon_size, icon_mode, icon_state)
-            tab_icon_size = QSize(min(actual_size.width(), icon_size.width()),
-                                 min(actual_size.height(), icon_size.height()))
+            tab_icon_size = QSize(
+                min(actual_size.width(), icon_size.width()),
+                min(actual_size.height(), icon_size.height()))
         icon_rect = QRect(text_rect.left(), text_rect.top() + 1,
                           tab_icon_size.width(), tab_icon_size.height())
         icon_rect = self._style.visualRect(opt.direction, opt.rect, icon_rect)

--- a/tests/unit/mainwindow/test_tabwidget.py
+++ b/tests/unit/mainwindow/test_tabwidget.py
@@ -41,6 +41,7 @@ class TestTabWidget:
             'position': 0,
             'select-on-remove': 1,
             'show': 'always',
+            'show-favicons': True,
             'padding': configtypes.PaddingValues(0, 0, 5, 5),
             'indicator-width': 3,
             'indicator-padding': configtypes.PaddingValues(2, 2, 0, 4),


### PR DESCRIPTION
I'm not happy about those four magical pixels. I'm not sure why (maybe because of margins?), but they are needed to align tab labels properly. I have a creeping suspicion they might mess thing up on high DPI displays, but I don't have any to test on.
![vertical_tabs](https://cloud.githubusercontent.com/assets/217806/19013685/81a3e89a-87d8-11e6-8319-cf7b9088c4c3.png)
