### PR TITLE
Handle unicode characters in Completer.

### DIFF
--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -157,6 +157,7 @@ class Completer(QObject):
         result = runner.parse(text, fallback=True, keep=True)
         parts = [x for x in result.cmdline if x]
         pos = self._cmd.cursorPosition() - len(self._cmd.prefix())
+        pos = min(pos, len(text))
         log.completion.debug('partitioning {} around position {}'.format(parts,
                                                                          pos))
         for i, part in enumerate(parts):

--- a/tests/end2end/features/completion.feature
+++ b/tests/end2end/features/completion.feature
@@ -22,3 +22,8 @@ Feature: Command bar completion
         # Make sure qutebrowser doesn't hang
         And I run :message-info "Still alive!"
         Then the message "Still alive!" should be shown
+
+    Scenario: Crash when pasting emoji into the command line (#2007)
+        Given I open about:blank
+        When I run :set-cmd-text -s :🌀
+        Then no crash should happen


### PR DESCRIPTION
Just limit the cursor position to the length of the text to avoid
crashes in this case.

Resolves #2007.