### PR TITLE
Remove :<count>:cmd syntax support.

### DIFF
--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -86,6 +86,23 @@ def repeat(times: int, command, win_id):
         commandrunner.run_safely(command)
 
 
+@cmdutils.register(maxsplit=1, hide=True, no_cmd_split=True,
+                   no_replace_variables=True)
+@cmdutils.argument('win_id', win_id=True)
+@cmdutils.argument('count', count=True)
+def run_with_count(count_arg: int, command, win_id, count=1):
+    """Run a command with the given count.
+
+    If run_with_count itself is run with a count, it multiplies count_arg.
+
+    Args:
+        count_arg: The count to pass to the command.
+        command: The command to run, with optional args.
+        count: The count that run_with_count itself received.
+    """
+    runners.CommandRunner(win_id).run(command, count_arg * count)
+
+
 @cmdutils.register(hide=True)
 def message_error(text):
     """Show an error message in the statusbar.

--- a/tests/end2end/features/caret.feature
+++ b/tests/end2end/features/caret.feature
@@ -3,7 +3,7 @@ Feature: Caret mode
 
     Background:
         Given I open data/caret.html
-        And I run :tab-only ;; :enter-mode caret
+        And I run :tab-only ;; enter-mode caret
 
     # document
 

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -499,7 +499,7 @@ Feature: Various utility commands.
     Scenario: Using :debug-log-capacity
         When I run :debug-log-capacity 100
         And I run :message-info oldstuff
-        And I run :repeat 20 :message-info otherstuff
+        And I run :repeat 20 message-info otherstuff
         And I run :message-info newstuff
         And I open qute:log
         Then the page should contain the plaintext "newstuff"
@@ -723,3 +723,13 @@ Feature: Various utility commands.
         And I run :command-accept
         And I set general -> private-browsing to false
         Then the message "blah" should be shown
+
+    ## :run-with-count
+
+    Scenario: :run-with-count
+        When I run :run-with-count 2 scroll down
+        Then "command called: scroll ['down'] (count=2)" should be logged
+
+    Scenario: :run-with-count with count
+        When I run :run-with-count 2 scroll down with count 3
+        Then "command called: scroll ['down'] (count=6)" should be logged

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -987,13 +987,13 @@ Feature: Tab management
     Scenario: Using :tab-next after closing last tab (#1448)
         When I set tabs -> last-close to close
         And I run :tab-only
-        And I run :tab-close ;; :tab-next
+        And I run :tab-close ;; tab-next
         Then qutebrowser should quit
         And no crash should happen
 
     Scenario: Using :tab-prev after closing last tab (#1448)
         When I set tabs -> last-close to close
         And I run :tab-only
-        And I run :tab-close ;; :tab-prev
+        And I run :tab-close ;; tab-prev
         Then qutebrowser should quit
         And no crash should happen

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -437,7 +437,8 @@ class QuteProc(testprocess.Process):
             command = command.replace('\\', r'\\')
 
         if count is not None:
-            command = ':{}:{}'.format(count, command.lstrip(':'))
+            command = ':run-with-count {} {}'.format(count,
+                                                     command.lstrip(':'))
 
         self.send_ipc([command])
         if not invalid:

--- a/tests/unit/commands/test_runners.py
+++ b/tests/unit/commands/test_runners.py
@@ -64,15 +64,6 @@ class TestCommandRunner:
         with pytest.raises(cmdexc.NoSuchCommandError):
             list(cr.parse_all(command))
 
-    def test_parse_with_count(self):
-        """Test parsing of commands with a count."""
-        cr = runners.CommandRunner(0)
-        result = cr.parse('20:scroll down')
-        assert result.cmd.name == 'scroll'
-        assert result.count == 20
-        assert result.args == ['down']
-        assert result.cmdline == ['scroll', 'down']
-
     def test_partial_parsing(self):
         """Test partial parsing with a runner where it's enabled.
 

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -181,6 +181,7 @@ def _set_cmd_prompt(cmd, txt):
     (':open -- |', None, ''),
     (':gibberish nonesense |', None, ''),
     ('/:help|', None, ''),
+    ('::bind|', usertypes.Completion.command, ':bind'),
 ])
 def test_update_completion(txt, kind, pattern, status_command_stub,
                            completer_obj, completion_widget_stub):


### PR DESCRIPTION
CommandRunner.parse had some logic for handling commands of form
`:<count>:cmd`. However, this complicated the parsing logic for something
that appears to only be used in tests. One could use it in a
userscript, but this is unlikely as it is undocumented. Removing
support for this simplifies the logic of parse.

The commnd `run-with-count` is added to provide this functionality.
It works like `repeat` but passes the count along to the command
instead of running the command multiple times.

This resolves #1997: Qutebrowser crashes when pasting commands.
This bug was caused by excess stripping of ':' from the command string
by _parse_count.