### PR TITLE
pdfjs: compatibility for v1.6.210

### DIFF
--- a/qutebrowser/browser/pdfjs.py
+++ b/qutebrowser/browser/pdfjs.py
@@ -62,8 +62,10 @@ def _generate_pdfjs_script(url):
         url: The url of the pdf page as QUrl.
     """
     return (
-        'PDFJS.verbosity = PDFJS.VERBOSITY_LEVELS.info;\n'
-        'PDFView.open("{url}");\n'
+        'document.addEventListener("DOMContentLoaded", function() {{\n'
+        '  PDFJS.verbosity = PDFJS.VERBOSITY_LEVELS.info;\n'
+        '  (window.PDFView || window.PDFViewerApplication).open("{url}");\n'
+        '}});\n'
     ).format(url=javascript.string_escape(url.toString(QUrl.FullyEncoded)))
 
 

--- a/tests/unit/browser/test_pdfjs.py
+++ b/tests/unit/browser/test_pdfjs.py
@@ -36,11 +36,11 @@ from qutebrowser.browser import pdfjs
      'http://foobar/%22);alert(%22attack!%22);'),
 ])
 def test_generate_pdfjs_script(url, expected):
-    expected_code = ('PDFJS.verbosity = PDFJS.VERBOSITY_LEVELS.info;\n'
-                     'PDFView.open("{}");\n'.format(expected))
+    expected_open = 'open("{}");'.format(expected)
     url = QUrl(url)
     actual = pdfjs._generate_pdfjs_script(url)
-    assert actual == expected_code
+    assert expected_open in actual
+    assert 'PDFView' in actual
 
 
 def test_fix_urls():


### PR DESCRIPTION
Fixes #2012

They renamed `PDFView` to `PDFViewerApplication`, which we need to account
for in our pdfjs scripts.

Also, it seems like the actual viewer is now only created when the DOM
has been loaded. This means that at the time when our script is
executed, the viewer does not yet exist. Thus we need to delay the open
request too by registering a `DOMContentLoaded` handler.