### PR TITLE
Make netrc location configurable

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -160,9 +160,9 @@ Contributors, sorted by the number of commits in descending order:
 * Corentin Julé
 * meles5
 * Philipp Hansch
+* Kevin Velghe
 * Daniel Karbach
 * Panagiotis Ktistakis
-* Kevin Velghe
 * Artur Shaik
 * Nathan Isom
 * Thorsten Wißmann

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -69,6 +69,7 @@
 |<<network-ssl-strict,ssl-strict>>|Whether to validate SSL handshakes.
 |<<network-dns-prefetch,dns-prefetch>>|Whether to try to pre-fetch DNS entries to speed up browsing.
 |<<network-custom-headers,custom-headers>>|Set custom headers for qutebrowser HTTP requests.
+|<<network-netrc-file,netrc-file>>|Set location of netrc-file for HTTP authentication.
 |==============
 
 .Quick reference for section ``completion''
@@ -805,6 +806,12 @@ This setting is only available with the QtWebKit backend.
 [[network-custom-headers]]
 === custom-headers
 Set custom headers for qutebrowser HTTP requests.
+
+Default: empty
+
+[[network-netrc-file]]
+=== netrc-file
+Set location of netrc-file for HTTP authentication.
 
 Default: empty
 

--- a/qutebrowser/browser/webkit/network/networkmanager.py
+++ b/qutebrowser/browser/webkit/network/networkmanager.py
@@ -330,7 +330,7 @@ class NetworkManager(QNetworkAccessManager):
             # altogether.
             reply.netrc_used = True
             try:
-                net = netrc.netrc()
+                net = netrc.netrc(os.environ.get('QUTE_NETRC'))
                 authenticators = net.authenticators(reply.url().host())
                 if authenticators is not None:
                     (user, _account, password) = authenticators

--- a/qutebrowser/browser/webkit/network/networkmanager.py
+++ b/qutebrowser/browser/webkit/network/networkmanager.py
@@ -330,7 +330,7 @@ class NetworkManager(QNetworkAccessManager):
             # altogether.
             reply.netrc_used = True
             try:
-                net = netrc.netrc(os.environ.get('QUTE_NETRC'))
+                net = netrc.netrc(config.get('network', 'netrc-file'))
                 authenticators = net.authenticators(reply.url().host())
                 if authenticators is not None:
                     (user, _account, password) = authenticators

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -438,6 +438,10 @@ def data(readonly=False):
              SettingValue(typ.HeaderDict(none_ok=True), ''),
              "Set custom headers for qutebrowser HTTP requests."),
 
+            ('netrc-file',
+             SettingValue(typ.File(none_ok=True), ''),
+             "Set location of netrc-file for HTTP authentication."),
+
             readonly=readonly
         )),
 


### PR DESCRIPTION
This adds a configuration option for the location of the netrc file. By adding a configuration option, we also document the existence of the feature itself.