### PR TITLE
Fix viewsource userscript

### DIFF
--- a/misc/userscripts/qutebrowser_viewsource
+++ b/misc/userscripts/qutebrowser_viewsource
@@ -24,9 +24,9 @@
 # Caveat: Does not use authentication of any kind. Add it in if you want it to.
 #
 
-path=/tmp/qutebrowser_$(mktemp XXXXXXXX).html
+path=$(mktemp --tmpdir qutebrowser_XXXXXXXX.html)
 
-curl "$QUTE_URL" > $path
+curl "$QUTE_URL" > "$path"
 urxvt -e vim "$path"
 
 rm "$path"


### PR DESCRIPTION
For months, I've been wondering what created these files in my home directory, till I finally found out after I'd run this userscript quite a few times. If you give a template to `mktemp`, it stops assuming `--tmpdir`, you have to give it explicitly.