### PR TITLE
Check if parent is null element

### DIFF
--- a/qutebrowser/browser/webkit/webkitelem.py
+++ b/qutebrowser/browser/webkit/webkitelem.py
@@ -148,7 +148,7 @@ class WebKitElement(webelem.AbstractWebElement):
     def parent(self):
         self._check_vanished()
         elem = self._elem.parent()
-        if elem is None:
+        if elem is None or elem.isNull():
             return None
         return WebKitElement(elem, tab=self._tab)
 

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -180,6 +180,11 @@ Feature: Using hints
             - data/hints/iframe_target.html
             - data/hello.txt (active)
 
+    Scenario: Clicking on iframe with :hint all current
+        When I open data/hints/iframe.html
+        And I hint with args "all current" and follow a
+        Then no crash should happen
+
     ### hints -> auto-follow-timeout
 
     @not_osx


### PR DESCRIPTION
As null-elements can't be wrapped anyway, I think it makes sense to just return None. The fact we don't check this, nor catch the exception, gives trouble with `:hint all current`.