### PR TITLE
Implement hint target "current" for webengine

### DIFF
--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -162,11 +162,6 @@ class AbstractWebElement(collections.abc.MutableMapping):
         """Insert the given text into the element."""
         raise NotImplementedError
 
-    def parent(self):
-        """Get the parent element of this element."""
-        # FIXME:qtwebengine get rid of this?
-        raise NotImplementedError
-
     def rect_on_view(self, *, elem_geometry=None, no_js=False):
         """Get the geometry of the element relative to the webview.
 
@@ -294,16 +289,7 @@ class AbstractWebElement(collections.abc.MutableMapping):
 
     def remove_blank_target(self):
         """Remove target from link."""
-        elem = self
-        for _ in range(5):
-            if elem is None:
-                break
-            tag = elem.tag_name()
-            if tag == 'a' or tag == 'area':
-                if elem.get('target', None) == '_blank':
-                    elem['target'] = '_top'
-                break
-            elem = elem.parent()
+        raise NotImplementedError
 
     def resolve_url(self, baseurl):
         """Resolve the URL in the element's src/href attribute.

--- a/qutebrowser/browser/webengine/webengineelem.py
+++ b/qutebrowser/browser/webengine/webengineelem.py
@@ -117,12 +117,6 @@ class WebEngineElement(webelem.AbstractWebElement):
         js_code = javascript.assemble('webelem', 'insert_text', self._id, text)
         self._tab.run_js_async(js_code)
 
-    def parent(self):
-        """Get the parent element of this element."""
-        # FIXME:qtwebengine get rid of this?
-        log.stub()
-        return None
-
     def rect_on_view(self, *, elem_geometry=None, no_js=False):
         """Get the geometry of the element relative to the webview.
 
@@ -163,3 +157,8 @@ class WebEngineElement(webelem.AbstractWebElement):
         log.webelem.debug("Couldn't find rectangle for {!r} ({})".format(
             self, rects))
         return QRect()
+
+    def remove_blank_target(self):
+        js_code = javascript.assemble('webelem', 'remove_blank_target',
+            self._id)
+        self._tab.run_js_async(js_code)

--- a/qutebrowser/browser/webkit/webkitelem.py
+++ b/qutebrowser/browser/webkit/webkitelem.py
@@ -145,7 +145,8 @@ class WebKitElement(webelem.AbstractWebElement):
             this.dispatchEvent(event);
         """.format(javascript.string_escape(text)))
 
-    def parent(self):
+    def _parent(self):
+        """Get the parent element of this element."""
         self._check_vanished()
         elem = self._elem.parent()
         if elem is None or elem.isNull():
@@ -282,6 +283,18 @@ class WebKitElement(webelem.AbstractWebElement):
         else:
             visible_in_frame = visible_on_screen
         return all([visible_on_screen, visible_in_frame])
+
+    def remove_blank_target(self):
+        elem = self
+        for _ in range(5):
+            if elem is None:
+                break
+            tag = elem.tag_name()
+            if tag == 'a' or tag == 'area':
+                if elem.get('target', None) == '_blank':
+                    elem['target'] = '_top'
+                break
+            elem = elem._parent()
 
 
 def get_child_frames(startframe):

--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -159,5 +159,19 @@ window._qutebrowser.webelem = (function() {
         elements[id].setAttribute(name, value);
     };
 
+    funcs.remove_blank_target = function(id) {
+        var elem = elements[id];
+        while (elem !== null) {
+            var tag = elem.tagName.toLowerCase();
+            if (tag === "a" || tag === "area") {
+                if (elem.getAttribute("target") === "_blank") {
+                    elem.setAttribute("target", "_top");
+                }
+                break;
+            }
+            elem = elem.parentElement;
+        }
+    };
+
     return funcs;
 })();


### PR DESCRIPTION
This morning, I noticed that one of the remaining issues in WebEngine causing tests to fail was the "current" hint target.

The problem is caused by the fact the `parent` method isn't implemented yet. This can easily be done by extending the `serialize_elem` to include the parent element. However, this can cause the whole page to be serialized to python. That's why I implemented `remove_blank_target` in javascript instead, and moved the existing implementation to `WebKitElement`.

For my first attempt using `parent`, I needed `__setitem__` in `WebEngineElement`. If you want, I can open a PR with [the comit](https://github.com/paretje/qutebrowser/commit/5fed65adc6c9c0c193b1b01f21c3eacd64251b12).