### PR TITLE
Setting values of tabs->select-on-remove (Issue #1619)

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -841,13 +841,13 @@ How many tabs to switch forward.
 
 [[tab-only]]
 === tab-only
-Syntax: +:tab-only [*--left*] [*--right*]+
+Syntax: +:tab-only [*--prev*] [*--next*]+
 
 Close all tabs except for the current one.
 
 ==== optional arguments
-* +*-l*+, +*--left*+: Keep tabs to the left of the current.
-* +*-r*+, +*--right*+: Keep tabs to the right of the current.
+* +*-p*+, +*--prev*+: Keep tabs before the current.
+* +*-n*+, +*--next*+: Keep tabs after the current.
 
 [[tab-prev]]
 === tab-prev

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -779,13 +779,13 @@ Duplicate the current tab.
 
 [[tab-close]]
 === tab-close
-Syntax: +:tab-close [*--left*] [*--right*] [*--opposite*]+
+Syntax: +:tab-close [*--prev*] [*--next*] [*--opposite*]+
 
 Close the current/[count]th tab.
 
 ==== optional arguments
-* +*-l*+, +*--left*+: Force selecting the tab to the left of the current tab.
-* +*-r*+, +*--right*+: Force selecting the tab to the right of the current tab.
+* +*-p*+, +*--prev*+: Force selecting the tab before the current tab.
+* +*-n*+, +*--next*+: Force selecting the tab after the current tab.
 * +*-o*+, +*--opposite*+: Force selecting the tab in the opposite direction of what's configured in 'tabs->select-on-remove'.
 
 

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -1029,11 +1029,11 @@ Which tab to select when the focused tab is removed.
 
 Valid values:
 
- * +left+: Select the tab on the left.
- * +right+: Select the tab on the right.
- * +previous+: Select the previously selected tab.
+ * +prev+: Select the tab which came before the closed one (left in horizontal, above in vertical).
+ * +next+: Select the tab which came after the closed one (right in horizontal, below in vertical).
+ * +last-used+: Select the previously selected tab.
 
-Default: +pass:[right]+
+Default: +pass:[next]+
 
 [[tabs-new-tab-position]]
 === new-tab-position

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -1041,12 +1041,12 @@ How new tabs are positioned.
 
 Valid values:
 
- * +left+: On the left of the current tab.
- * +right+: On the right of the current tab.
- * +first+: At the left end.
- * +last+: At the right end.
+ * +prev+: Before the current tab.
+ * +next+: After the current tab.
+ * +first+: At the beginning.
+ * +last+: At the end.
 
-Default: +pass:[right]+
+Default: +pass:[next]+
 
 [[tabs-new-tab-position-explicit]]
 === new-tab-position-explicit
@@ -1054,10 +1054,10 @@ How new tabs opened explicitly are positioned.
 
 Valid values:
 
- * +left+: On the left of the current tab.
- * +right+: On the right of the current tab.
- * +first+: At the left end.
- * +last+: At the right end.
+ * +prev+: Before the current tab.
+ * +next+: After the current tab.
+ * +first+: At the beginning.
+ * +last+: At the end.
 
 Default: +pass:[last]+
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -801,20 +801,20 @@ class CommandDispatcher:
         message.info("Zoom level: {}%".format(level))
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    def tab_only(self, left=False, right=False):
+    def tab_only(self, prev=False, next_=False):
         """Close all tabs except for the current one.
 
         Args:
-            left: Keep tabs to the left of the current.
-            right: Keep tabs to the right of the current.
+            prev: Keep tabs before the current.
+            next_: Keep tabs after the current.
         """
-        cmdutils.check_exclusive((left, right), 'lr')
+        cmdutils.check_exclusive((prev, next_), 'pn')
         cur_idx = self._tabbed_browser.currentIndex()
         assert cur_idx != -1
 
         for i, tab in enumerate(self._tabbed_browser.widgets()):
-            if (i == cur_idx or (left and i < cur_idx) or
-                    (right and i > cur_idx)):
+            if (i == cur_idx or (prev and i < cur_idx) or
+                    (next_ and i > cur_idx)):
                 continue
             else:
                 self._tabbed_browser.close_tab(tab)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -179,12 +179,12 @@ class CommandDispatcher:
             raise cmdexc.CommandError("Last focused tab vanished!")
         self._set_current_index(idx)
 
-    def _get_selection_override(self, left, right, opposite):
+    def _get_selection_override(self, prev, next_, opposite):
         """Helper function for tab_close to get the tab to select.
 
         Args:
-            left: Force selecting the tab to the left of the current tab.
-            right: Force selecting the tab to the right of the current tab.
+            prev: Force selecting the tab before the current tab.
+            next_: Force selecting the tab after the current tab.
             opposite: Force selecting the tab in the opposite direction of
                       what's configured in 'tabs->select-on-remove'.
 
@@ -192,10 +192,10 @@ class CommandDispatcher:
             QTabBar.SelectLeftTab, QTabBar.SelectRightTab, or None if no change
             should be made.
         """
-        cmdutils.check_exclusive((left, right, opposite), 'lro')
-        if left:
+        cmdutils.check_exclusive((prev, next_, opposite), 'pno')
+        if prev:
             return QTabBar.SelectLeftTab
-        elif right:
+        elif next_:
             return QTabBar.SelectRightTab
         elif opposite:
             conf_selection = config.get('tabs', 'select-on-remove')
@@ -206,7 +206,7 @@ class CommandDispatcher:
             elif conf_selection == QTabBar.SelectPreviousTab:
                 raise cmdexc.CommandError(
                     "-o is not supported with 'tabs->select-on-remove' set to "
-                    "'previous'!")
+                    "'last-used'!")
             else:  # pragma: no cover
                 raise ValueError("Invalid select-on-remove value "
                                  "{!r}!".format(conf_selection))
@@ -214,12 +214,12 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('count', count=True)
-    def tab_close(self, left=False, right=False, opposite=False, count=None):
+    def tab_close(self, prev=False, next_=False, opposite=False, count=None):
         """Close the current/[count]th tab.
 
         Args:
-            left: Force selecting the tab to the left of the current tab.
-            right: Force selecting the tab to the right of the current tab.
+            prev: Force selecting the tab before the current tab.
+            next_: Force selecting the tab after the current tab.
             opposite: Force selecting the tab in the opposite direction of
                       what's configured in 'tabs->select-on-remove'.
             count: The tab index to close, or None
@@ -228,7 +228,7 @@ class CommandDispatcher:
         if tab is None:
             return
         tabbar = self._tabbed_browser.tabBar()
-        selection_override = self._get_selection_override(left, right,
+        selection_override = self._get_selection_override(prev, next_,
                                                           opposite)
         if selection_override is None:
             self._tabbed_browser.close_tab(tab)

--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -412,6 +412,11 @@ class ConfigManager(QObject):
         ('content', 'cookies-accept'):
             _get_value_transformer({'default': 'no-3rdparty'}),
         ('tabs', 'position'): _transform_position,
+        ('tabs', 'select-on-remove'):
+            _get_value_transformer({
+                'left': 'prev',
+                'right': 'next',
+                'previous': 'last-used'}),
         ('ui', 'downloads-position'): _transform_position,
         ('ui', 'remove-finished-downloads'):
             _get_value_transformer({'false': '-1', 'true': '1000'}),

--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -411,6 +411,14 @@ class ConfigManager(QObject):
     CHANGED_OPTIONS = {
         ('content', 'cookies-accept'):
             _get_value_transformer({'default': 'no-3rdparty'}),
+        ('tabs', 'new-tab-position'):
+            _get_value_transformer({
+                'left': 'prev',
+                'right': 'next'}),
+        ('tabs', 'new-tab-position-explicit'):
+            _get_value_transformer({
+                'left': 'prev',
+                'right': 'next'}),
         ('tabs', 'position'): _transform_position,
         ('tabs', 'select-on-remove'):
             _get_value_transformer({

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -579,7 +579,7 @@ def data(readonly=False):
              "background."),
 
             ('select-on-remove',
-             SettingValue(typ.SelectOnRemove(), 'right'),
+             SettingValue(typ.SelectOnRemove(), 'next'),
              "Which tab to select when the focused tab is removed."),
 
             ('new-tab-position',

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -1781,4 +1781,9 @@ CHANGED_KEY_COMMANDS = [
 
     (re.compile(r'^prompt-yes$'), r'prompt-accept yes'),
     (re.compile(r'^prompt-no$'), r'prompt-accept no'),
+
+    (re.compile(r'^tab-close -l$'), r'tab-close --prev'),
+    (re.compile(r'^tab-close --left$'), r'tab-close --prev'),
+    (re.compile(r'^tab-close -r$'), r'tab-close --next'),
+    (re.compile(r'^tab-close --right$'), r'tab-close --next'),
 ]

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -1786,4 +1786,9 @@ CHANGED_KEY_COMMANDS = [
     (re.compile(r'^tab-close --left$'), r'tab-close --prev'),
     (re.compile(r'^tab-close -r$'), r'tab-close --next'),
     (re.compile(r'^tab-close --right$'), r'tab-close --next'),
+
+    (re.compile(r'^tab-only -l$'), r'tab-only --prev'),
+    (re.compile(r'^tab-only --left$'), r'tab-only --prev'),
+    (re.compile(r'^tab-only -r$'), r'tab-only --next'),
+    (re.compile(r'^tab-only --right$'), r'tab-only --next'),
 ]

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -583,7 +583,7 @@ def data(readonly=False):
              "Which tab to select when the focused tab is removed."),
 
             ('new-tab-position',
-             SettingValue(typ.NewTabPosition(), 'right'),
+             SettingValue(typ.NewTabPosition(), 'next'),
              "How new tabs are positioned."),
 
             ('new-tab-position-explicit',

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1379,18 +1379,20 @@ class SelectOnRemove(MappingType):
     """Which tab to select when the focused tab is removed."""
 
     MAPPING = {
-        'left': QTabBar.SelectLeftTab,
-        'right': QTabBar.SelectRightTab,
-        'previous': QTabBar.SelectPreviousTab,
+        'prev': QTabBar.SelectLeftTab,
+        'next': QTabBar.SelectRightTab,
+        'last-used': QTabBar.SelectPreviousTab,
     }
 
     def __init__(self, none_ok=False):
         super().__init__(
             none_ok,
             valid_values=ValidValues(
-                ('left', "Select the tab on the left."),
-                ('right', "Select the tab on the right."),
-                ('previous', "Select the previously selected tab.")))
+                ('prev', "Select the tab which came before the closed one "
+                 "(left in horizontal, above in vertical)."),
+                ('next', "Select the tab which came after the closed one "
+                 "(right in horizontal, below in vertical)."),
+                ('last-used', "Select the previously selected tab.")))
 
 
 class ConfirmQuit(FlagList):

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1436,10 +1436,10 @@ class NewTabPosition(BaseType):
     def __init__(self, none_ok=False):
         super().__init__(none_ok)
         self.valid_values = ValidValues(
-            ('left', "On the left of the current tab."),
-            ('right', "On the right of the current tab."),
-            ('first', "At the left end."),
-            ('last', "At the right end."))
+            ('prev', "Before the current tab."),
+            ('next', "After the current tab."),
+            ('first', "At the beginning."),
+            ('last', "At the end."))
 
 
 class IgnoreCase(Bool):

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -415,7 +415,7 @@ class TabbedBrowser(tabwidget.TabWidget):
             # On first sight, we'd think we have to decrement
             # self._tab_insert_idx_left here, as we want the next tab to be
             # *before* the one we just opened. However, since we opened a tab
-            # *before* of the currently focused tab, indices will shift by
+            # *before* the currently focused tab, indices will shift by
             # 1 automatically.
         elif pos == 'next':
             idx = self._tab_insert_idx_right

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -61,8 +61,8 @@ class TabbedBrowser(tabwidget.TabWidget):
         _filter: A SignalFilter instance.
         _now_focused: The tab which is focused now.
         _tab_insert_idx_left: Where to insert a new tab with
-                         tabbar -> new-tab-position set to 'left'.
-        _tab_insert_idx_right: Same as above, for 'right'.
+                         tabbar -> new-tab-position set to 'prev'.
+        _tab_insert_idx_right: Same as above, for 'next'.
         _undo_stack: List of UndoEntry namedtuples of closed tabs.
         shutting_down: Whether we're currently shutting down.
         _local_marks: Jump markers local to each page
@@ -410,14 +410,14 @@ class TabbedBrowser(tabwidget.TabWidget):
             pos = config.get('tabs', 'new-tab-position-explicit')
         else:
             pos = config.get('tabs', 'new-tab-position')
-        if pos == 'left':
+        if pos == 'prev':
             idx = self._tab_insert_idx_left
             # On first sight, we'd think we have to decrement
             # self._tab_insert_idx_left here, as we want the next tab to be
             # *before* the one we just opened. However, since we opened a tab
-            # *to the left* of the currently focused tab, indices will shift by
+            # *before* of the currently focused tab, indices will shift by
             # 1 automatically.
-        elif pos == 'right':
+        elif pos == 'next':
             idx = self._tab_insert_idx_right
             self._tab_insert_idx_right += 1
         elif pos == 'first':

--- a/tests/end2end/features/open.feature
+++ b/tests/end2end/features/open.feature
@@ -75,8 +75,8 @@ Feature: Opening pages
 
     Scenario: Opening in a new tab (explicit)
         Given I open about:blank
-        When I set tabs -> new-tab-position-explicit to right
-        And I set tabs -> new-tab-position to left
+        When I set tabs -> new-tab-position-explicit to next
+        And I set tabs -> new-tab-position to prev
         And I run :tab-only
         And I run :open -t http://localhost:(port)/data/numbers/7.txt
         And I wait until data/numbers/7.txt is loaded
@@ -86,8 +86,8 @@ Feature: Opening pages
 
     Scenario: Opening in a new tab (implicit)
         Given I open about:blank
-        When I set tabs -> new-tab-position-explicit to right
-        And I set tabs -> new-tab-position to left
+        When I set tabs -> new-tab-position-explicit to next
+        And I set tabs -> new-tab-position to prev
         And I run :tab-only
         And I run :open -t -i http://localhost:(port)/data/numbers/8.txt
         And I wait until data/numbers/8.txt is loaded

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -35,8 +35,8 @@ Feature: Tab management
             - data/numbers/2.txt
             - data/numbers/3.txt (active)
 
-    Scenario: :tab-close with select-on-remove = right
-        When I set tabs -> select-on-remove to right
+    Scenario: :tab-close with select-on-remove = next
+        When I set tabs -> select-on-remove to next
         And I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new tab
         And I open data/numbers/3.txt in a new tab
@@ -46,8 +46,8 @@ Feature: Tab management
             - data/numbers/1.txt
             - data/numbers/3.txt (active)
 
-    Scenario: :tab-close with select-on-remove = left
-        When I set tabs -> select-on-remove to left
+    Scenario: :tab-close with select-on-remove = prev
+        When I set tabs -> select-on-remove to prev
         And I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new tab
         And I open data/numbers/3.txt in a new tab
@@ -57,8 +57,8 @@ Feature: Tab management
             - data/numbers/1.txt (active)
             - data/numbers/3.txt
 
-    Scenario: :tab-close with select-on-remove = previous
-        When I set tabs -> select-on-remove to previous
+    Scenario: :tab-close with select-on-remove = last-used
+        When I set tabs -> select-on-remove to last-used
         And I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new tab
         And I open data/numbers/3.txt in a new tab
@@ -70,8 +70,8 @@ Feature: Tab management
             - data/numbers/3.txt
             - data/numbers/4.txt (active)
 
-    Scenario: :tab-close with select-on-remove = left and --right
-        When I set tabs -> select-on-remove to left
+    Scenario: :tab-close with select-on-remove = prev and --right
+        When I set tabs -> select-on-remove to prev
         And I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new tab
         And I open data/numbers/3.txt in a new tab
@@ -81,8 +81,8 @@ Feature: Tab management
             - data/numbers/1.txt
             - data/numbers/3.txt (active)
 
-    Scenario: :tab-close with select-on-remove = right and --left
-        When I set tabs -> select-on-remove to right
+    Scenario: :tab-close with select-on-remove = next and --left
+        When I set tabs -> select-on-remove to next
         And I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new tab
         And I open data/numbers/3.txt in a new tab
@@ -92,8 +92,8 @@ Feature: Tab management
             - data/numbers/1.txt (active)
             - data/numbers/3.txt
 
-    Scenario: :tab-close with select-on-remove = left and --opposite
-        When I set tabs -> select-on-remove to left
+    Scenario: :tab-close with select-on-remove = prev and --opposite
+        When I set tabs -> select-on-remove to prev
         And I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new tab
         And I open data/numbers/3.txt in a new tab
@@ -103,8 +103,8 @@ Feature: Tab management
             - data/numbers/1.txt
             - data/numbers/3.txt (active)
 
-    Scenario: :tab-close with select-on-remove = right and --opposite
-        When I set tabs -> select-on-remove to right
+    Scenario: :tab-close with select-on-remove = next and --opposite
+        When I set tabs -> select-on-remove to next
         And I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new tab
         And I open data/numbers/3.txt in a new tab
@@ -114,13 +114,13 @@ Feature: Tab management
             - data/numbers/1.txt (active)
             - data/numbers/3.txt
 
-    Scenario: :tab-close with select-on-remove = previous and --opposite
-        When I set tabs -> select-on-remove to previous
+    Scenario: :tab-close with select-on-remove = last-used and --opposite
+        When I set tabs -> select-on-remove to last-used
         And I run :tab-close --opposite
-        Then the error "-o is not supported with 'tabs->select-on-remove' set to 'previous'!" should be shown
+        Then the error "-o is not supported with 'tabs->select-on-remove' set to 'last-used'!" should be shown
 
     Scenario: :tab-close should restore selection behavior
-        When I set tabs -> select-on-remove to right
+        When I set tabs -> select-on-remove to next
         And I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new tab
         And I open data/numbers/3.txt in a new tab

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -70,24 +70,24 @@ Feature: Tab management
             - data/numbers/3.txt
             - data/numbers/4.txt (active)
 
-    Scenario: :tab-close with select-on-remove = prev and --right
+    Scenario: :tab-close with select-on-remove = prev and --next
         When I set tabs -> select-on-remove to prev
         And I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new tab
         And I open data/numbers/3.txt in a new tab
         And I run :tab-focus 2
-        And I run :tab-close --right
+        And I run :tab-close --next
         Then the following tabs should be open:
             - data/numbers/1.txt
             - data/numbers/3.txt (active)
 
-    Scenario: :tab-close with select-on-remove = next and --left
+    Scenario: :tab-close with select-on-remove = next and --prev
         When I set tabs -> select-on-remove to next
         And I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new tab
         And I open data/numbers/3.txt in a new tab
         And I run :tab-focus 2
-        And I run :tab-close --left
+        And I run :tab-close --prev
         Then the following tabs should be open:
             - data/numbers/1.txt (active)
             - data/numbers/3.txt
@@ -126,7 +126,7 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I open data/numbers/4.txt in a new tab
         And I run :tab-focus 2
-        And I run :tab-close --left
+        And I run :tab-close --prev
         And I run :tab-focus 2
         And I run :tab-close
         Then the following tabs should be open:

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -821,8 +821,8 @@ Feature: Tab management
             - data/hints/html/simple.html (active)
             - data/hello.txt
 
-    Scenario: opening tab with tabs->new-tab-position left
-        When I set tabs -> new-tab-position to left
+    Scenario: opening tab with tabs->new-tab-position prev
+        When I set tabs -> new-tab-position to prev
         And I set tabs -> background-tabs to false
         And I open about:blank
         And I open data/hints/html/simple.html in a new tab
@@ -833,8 +833,8 @@ Feature: Tab management
             - data/hello.txt (active)
             - data/hints/html/simple.html
 
-    Scenario: opening tab with tabs->new-tab-position right
-        When I set tabs -> new-tab-position to right
+    Scenario: opening tab with tabs->new-tab-position next
+        When I set tabs -> new-tab-position to next
         And I set tabs -> background-tabs to false
         And I open about:blank
         And I open data/hints/html/simple.html in a new tab

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -143,29 +143,29 @@ Feature: Tab management
         Then the following tabs should be open:
             - data/numbers/3.txt (active)
 
-    Scenario: :tab-only with --left
+    Scenario: :tab-only with --prev
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new tab
         And I open data/numbers/3.txt in a new tab
         And I run :tab-focus 2
-        And I run :tab-only --left
+        And I run :tab-only --prev
         Then the following tabs should be open:
             - data/numbers/1.txt
             - data/numbers/2.txt (active)
 
-    Scenario: :tab-only with --right
+    Scenario: :tab-only with --next
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new tab
         And I open data/numbers/3.txt in a new tab
         And I run :tab-focus 2
-        And I run :tab-only --right
+        And I run :tab-only --next
         Then the following tabs should be open:
             - data/numbers/2.txt (active)
             - data/numbers/3.txt
 
-    Scenario: :tab-only with --left and --right
-        When I run :tab-only --left --right
-        Then the error "Only one of -l/-r can be given!" should be shown
+    Scenario: :tab-only with --prev and --next
+        When I run :tab-only --prev --next
+        Then the error "Only one of -p/-n can be given!" should be shown
 
     # :tab-focus
 

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -348,6 +348,16 @@ class TestKeyConfigParser:
 
             ('prompt-yes', 'prompt-accept yes'),
             ('prompt-no', 'prompt-accept no'),
+
+            ('tab-close -l', 'tab-close --prev'),
+            ('tab-close --left', 'tab-close --prev'),
+            ('tab-close -r', 'tab-close --next'),
+            ('tab-close --right', 'tab-close --next'),
+
+            ('tab-only -l', 'tab-only --prev'),
+            ('tab-only --left', 'tab-only --prev'),
+            ('tab-only -r', 'tab-only --next'),
+            ('tab-only --right', 'tab-only --next'),
         ]
     )
     def test_migrations(self, old, new_expected):


### PR DESCRIPTION
First commit implements the suggestion from issue #1619, the remaining ones are for naming consistency.

During implementation the names `before` and `after` seemed better suited to me despite disliking the terminology at first. Feel free to cherry-pick 828b7d744a6c5fa0f54853ec13342fdcfce65862 only or I could modify this PR to adapt a different naming convention.
