### PR TITLE
Use space in shortcuts

### DIFF
--- a/qutebrowser/config/parsers/keyconf.py
+++ b/qutebrowser/config/parsers/keyconf.py
@@ -117,7 +117,7 @@ class KeyConfigParser(QObject):
             for cmd, keys in data.items():
                 lines.append(cmd)
                 for k in keys:
-                    lines.append(' ' * 4 + k)
+                    lines.append(' ' * 4 + k.replace(" ", "<space>"))
                 lines.append('')
         return '\n'.join(lines) + '\n'
 
@@ -389,7 +389,7 @@ class KeyConfigParser(QObject):
                                  "command!".format(line))
         else:
             assert self._cur_section is not None
-            self._add_binding(self._cur_section, line, self._cur_command)
+            self._add_binding(self._cur_section, line.replace("<space>", " "), self._cur_command)
 
     def _add_binding(self, sectname, keychain, command, *, force=False):
         """Add a new binding from keychain to command in section sectname."""

--- a/qutebrowser/config/parsers/keyconf.py
+++ b/qutebrowser/config/parsers/keyconf.py
@@ -166,7 +166,7 @@ class KeyConfigParser(QObject):
         """
         if utils.is_special_key(key):
             # <Ctrl-t>, <ctrl-T>, and <ctrl-t> should be considered equivalent
-            key = key.lower()
+            key = key.lower().replace('<space>', ' ')
 
         if command is None:
             cmd = self.get_bindings_for(mode).get(key, None)
@@ -208,7 +208,7 @@ class KeyConfigParser(QObject):
         """
         if utils.is_special_key(key):
             # <Ctrl-t>, <ctrl-T>, and <ctrl-t> should be considered equivalent
-            key = key.lower()
+            key = key.lower().replace('<space>', ' ')
 
         mode = self._normalize_sectname(mode)
         for m in mode.split(','):

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -470,7 +470,7 @@ class KeyParseError(Exception):
 
 def is_special_key(keystr):
     """True if keystr is a 'special' keystring (e.g. <ctrl-x> or <space>)."""
-    return keystr.startswith('<') and keystr.endswith('>')
+    return keystr.startswith('<') and keystr.endswith('>') or keystr.startswith('<space>')
 
 
 def _parse_single_key(keystr):


### PR DESCRIPTION
In VIM, I use <space> as leader. Since I use it in all shortcuts (including changing buffers), I would like to also be able to use it in `qutebrowser`. This patch adds the possibility to have linked shortcuts with space.
For example: 

```
tab-prev
    <space>h
```
