### PR TITLE
Set the bundle identifier to a fake value to allow icu data to be found.

### DIFF
--- a/misc/qutebrowser.spec
+++ b/misc/qutebrowser.spec
@@ -71,4 +71,4 @@ app = BUNDLE(coll,
              name='qutebrowser.app',
              icon=icon,
              info_plist={'NSHighResolutionCapable': 'True'},
-             bundle_identifier=None)
+             bundle_identifier='org.qt-project.Qt.QtWebEngineCore')


### PR DESCRIPTION
This should probably be fixed in pyinstaller, not sure how yet. See [this comment](https://github.com/pyinstaller/pyinstaller/blob/b78bfe530cdc2904f65ce098bdf2de08c9037abb/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py#L24).