### PR TITLE
Update version number to 0.8.2

### DIFF
--- a/qutebrowser/__init__.py
+++ b/qutebrowser/__init__.py
@@ -28,7 +28,7 @@ __copyright__ = "Copyright 2014-2016 Florian Bruhin (The Compiler)"
 __license__ = "GPL"
 __maintainer__ = __author__
 __email__ = "mail@qutebrowser.org"
-__version_info__ = (0, 8, 1)
+__version_info__ = (0, 8, 2)
 __version__ = '.'.join(str(e) for e in __version_info__)
 __description__ = "A keyboard-driven, vim-like browser based on PyQt5 and QtWebKit."
 

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -396,7 +396,7 @@ class TestDefaultConfig:
         If it did change, place a new qutebrowser-vx.y.z.conf in old_configs
         and then increment the version.
         """
-        assert qutebrowser.__version__ == '0.8.1'
+        assert qutebrowser.__version__ == '0.8.2'
 
     @pytest.mark.parametrize('filename',
         os.listdir(os.path.join(os.path.dirname(__file__), 'old_configs')),


### PR DESCRIPTION
Bump version info to 0.8.2 so that it shows up in `qutebrowser --version`

My apologies if this is left at 0.8.1 for a reason, it just seemed like a small oversight.  Noticed when I ran `qutebrowser --version` and despite being the latest git commit, still showed 0.8.1

I guess this doesn't make a whole lot of difference - release-wise, it by necessity won't make it in until it's obsolete - but handy for git-compilers, at least.