### PR TITLE
also use rel paths for toplevel docs

### DIFF
--- a/doc/help/index.asciidoc
+++ b/doc/help/index.asciidoc
@@ -7,12 +7,12 @@ Documentation
 The following help pages are currently available:
 
 * link:../quickstart.html[Quick start guide]
-* link:../FAQ.html[Frequently asked questions]
-* link:../CHANGELOG.html[Change Log]
+* link:../../FAQ.html[Frequently asked questions]
+* link:../../CHANGELOG.html[Change Log]
 * link:commands.html[Documentation of commands]
 * link:settings.html[Documentation of settings]
 * link:../userscripts.html[How to write userscripts]
-* link:../CONTRIBUTING.html[Contributing to qutebrowser]
+* link:../../CONTRIBUTING.html[Contributing to qutebrowser]
 
 Getting help
 ------------


### PR DESCRIPTION
Another fix for #1490.