### PR TITLE
Stop progress bar from growing status bar height

### DIFF
--- a/qutebrowser/mainwindow/statusbar/progress.py
+++ b/qutebrowser/mainwindow/statusbar/progress.py
@@ -36,6 +36,7 @@ class Progress(QProgressBar):
             border-radius: 0px;
             border: 2px solid transparent;
             background-color: transparent;
+            font: {{ font['statusbar'] }};
         }
 
         QProgressBar::chunk {


### PR DESCRIPTION
The progress bar didn't specify a font, so if the system-supplied font was larger than the status bar font the entire status bar grew. With the status bar at the top this moved almost everything else.

See #886.