### PR TITLE
Check if javascript is enabled in webview

### DIFF
--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -629,8 +629,8 @@ class WebKitTab(browsertab.AbstractTab):
             callback(result)
 
     def has_js(self):
-        settings = QWebSettings.globalSettings()
-        return settings.testAttribute(QWebSettings.JavascriptEnabled)
+        return self._widget.settings().testAttribute(
+            QWebSettings.JavascriptEnabled)
 
     def icon(self):
         return self._widget.icon()


### PR DESCRIPTION
While `has_js` is a method on a tab, qutebrowser checks if javascript is globally enabled for qtwebkit, instead of locally. Testing the value for the local tab instead makes more sense, and gives the correct result for users using #1273, and later when #499 is done.