### PR TITLE
jseval when javascript disabled in qtwebkit

### DIFF
--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -624,7 +624,8 @@ class WebKitTab(browsertab.AbstractTab):
     def run_js_async(self, code, callback=None, *, world=None):
         if world is not None and world != usertypes.JsWorld.jseval:
             log.webview.warning("Ignoring world ID {}".format(world))
-        result = self._widget.page().mainFrame().evaluateJavaScript(code)
+        result = self._widget.page().mainFrame().documentElement() \
+            .evaluateJavaScript(code)
         if callback is not None:
             callback(result)
 

--- a/tests/end2end/features/javascript.feature
+++ b/tests/end2end/features/javascript.feature
@@ -71,3 +71,8 @@ Feature: Javascript stuff
         And I run :tab-only
         And I run :jseval if (window.open('about:blank')) { console.log('window opened'); } else { console.log('error while opening window'); }
         Then the javascript message "error while opening window" should be logged
+
+    Scenario: Executing jseval when javascript is disabled
+        When I set content -> allow-javascript to false
+        And I run :jseval console.log('jseval executed')
+        Then the javascript message "jseval executed" should be logged


### PR DESCRIPTION
Some time ago, I found out that javascript does work, also when disabled in qtwebkit, when executed from a webelement. We can use this to enable `jseval` for users disabling javascript.