### PR TITLE
insert-text without javascript

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -761,10 +761,6 @@ class AbstractTab(QWidget):
         """
         raise NotImplementedError
 
-    def has_js(self):
-        """Check if qutebrowser can run javascript in this tab."""
-        raise NotImplementedError
-
     def shutdown(self):
         raise NotImplementedError
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1539,8 +1539,6 @@ class CommandDispatcher:
             text: The text to insert.
         """
         tab = self._current_widget()
-        if not tab.has_js():
-            raise cmdexc.CommandError("This command needs javascript enabled.")
 
         def _insert_text_cb(elem):
             if elem is None:

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -528,10 +528,6 @@ class WebEngineTab(browsertab.AbstractTab):
             else:
                 self._widget.page().runJavaScript(code, callback)
 
-    def has_js(self):
-        # QtWebEngine can run JS even if the page can't
-        return True
-
     def shutdown(self):
         log.stub()
 

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -628,10 +628,6 @@ class WebKitTab(browsertab.AbstractTab):
         if callback is not None:
             callback(result)
 
-    def has_js(self):
-        settings = QWebSettings.globalSettings()
-        return settings.testAttribute(QWebSettings.JavascriptEnabled)
-
     def icon(self):
         return self._widget.icon()
 

--- a/tests/end2end/features/yankpaste.feature
+++ b/tests/end2end/features/yankpaste.feature
@@ -263,8 +263,10 @@ Feature: Yanking and pasting.
         And I run :click-element id qute-textarea
         And I wait for "Clicked editable element!" in the log
         And I run :insert-text Hello world
+        And I press the keys "<Ctrl+a>"
+        And I run :yank selection
         # Compare
-        Then the javascript message "textarea contents: Hello world" should be logged
+        Then the clipboard should contain "Hello world"
 
     Scenario: Inserting text into a text field at specific position
         When I set general -> log-javascript-console to info

--- a/tests/end2end/features/yankpaste.feature
+++ b/tests/end2end/features/yankpaste.feature
@@ -256,6 +256,16 @@ Feature: Yanking and pasting.
         # Compare
         Then the javascript message "textarea contents: Hello world" should be logged
 
+    Scenario: Inserting text into an empty text field with javascript disabled
+        When I set general -> log-javascript-console to info
+        And I set content -> allow-javascript to false
+        And I open data/paste_primary.html
+        And I run :click-element id qute-textarea
+        And I wait for "Clicked editable element!" in the log
+        And I run :insert-text Hello world
+        # Compare
+        Then the javascript message "textarea contents: Hello world" should be logged
+
     Scenario: Inserting text into a text field at specific position
         When I set general -> log-javascript-console to info
         And I open data/paste_primary.html

--- a/tests/end2end/features/yankpaste.feature
+++ b/tests/end2end/features/yankpaste.feature
@@ -265,6 +265,7 @@ Feature: Yanking and pasting.
         And I run :insert-text Hello world
         And I press the keys "<Ctrl+a>"
         And I run :yank selection
+        And I set content -> allow-javascript to true
         # Compare
         Then the clipboard should contain "Hello world"
 


### PR DESCRIPTION
The javascript of `insert-text` is run in the context of a webelement, which means we don't necessarily need it to be enabled for the content.