### PR TITLE
added dynamic autocomplete and jump command as a demo

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -23,6 +23,7 @@ import os
 import os.path
 import shlex
 import functools
+import re
 
 from PyQt5.QtWidgets import QApplication, QTabBar
 from PyQt5.QtCore import Qt, QUrl, QEvent, QUrlQuery
@@ -2045,6 +2046,25 @@ class CommandDispatcher:
             key: mark identifier; capital indicates a global mark
         """
         self._tabbed_browser.jump_mark(key)
+
+    @cmdutils.register(instance='command-dispatcher', scope='window')
+    @cmdutils.argument('where', completion=usertypes.Completion.jumps_list)
+    def jump(self, where):
+        """Go in the tab history back or forward
+
+        Args:
+            where: Where to go. The format is +|-<count>. -2 means go back 2 times
+        """
+
+        pattern = "^([\\-+>])([0-9]*)$"
+        sign = re.sub(pattern, "\\1", where)
+        if sign != ">":
+            count = int(re.sub(pattern, "\\2", where))
+
+            if sign == "-":
+                self.back(count = count)
+            elif sign == "+":
+                self.forward(count = count)
 
     def _open_if_changed(self, url=None, old_url=None, bg=False, tab=False,
                          window=False):

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -86,6 +86,9 @@ class Completer(QObject):
         else:
             model = instances.get(completion)
 
+        if hasattr(model, '__call__'):
+            model = model()
+
         if model is None:
             return None
         else:

--- a/qutebrowser/completion/models/instances.py
+++ b/qutebrowser/completion/models/instances.py
@@ -102,6 +102,15 @@ def init_bookmark_completions():
     model = miscmodels.BookmarkCompletionModel()
     _instances[usertypes.Completion.bookmark_by_url] = model
 
+def init_jumps_list_completion():
+    """Initialize jumps list completion model"""
+    _instances[usertypes.Completion.jumps_list] = retrieve_jumps_list
+
+def retrieve_jumps_list():
+    app = objreg.get('app')
+    window = app.activeWindow()
+    return (miscmodels.JumpsListCompletionModel(window.win_id))
+
 
 def init_session_completion():
     """Initialize session completion model."""
@@ -130,6 +139,7 @@ INITIALIZERS = {
     usertypes.Completion.option: _init_setting_completions,
     usertypes.Completion.value: _init_setting_completions,
     usertypes.Completion.quickmark_by_name: init_quickmark_completions,
+    usertypes.Completion.jumps_list: init_jumps_list_completion,
     usertypes.Completion.bookmark_by_url: init_bookmark_completions,
     usertypes.Completion.sessions: init_session_completion,
     usertypes.Completion.bind: _init_bind_completion,

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -26,6 +26,7 @@ from qutebrowser.config import config, configdata
 from qutebrowser.utils import objreg, log, qtutils
 from qutebrowser.commands import cmdutils
 from qutebrowser.completion.models import base
+import re
 
 
 class CommandCompletionModel(base.BaseCompletionModel):
@@ -260,6 +261,30 @@ class BindCompletionModel(base.BaseCompletionModel):
         cat = self.new_category("Commands")
         for (name, desc, misc) in cmdlist:
             self.new_item(cat, name, desc, misc)
+
+class JumpsListCompletionModel(base.BaseCompletionModel):
+
+    """A Completion model filled with the jumps list of the current tab"""
+
+    COLUMN_WIDTHS = (2, 45, 45)
+
+    def __init__(self, win_id, parent = None):
+        super().__init__(parent)
+        tabbed_browser = objreg.get('tabbed-browser', scope='window', window=win_id)
+        tab = tabbed_browser.widget(tabbed_browser.currentIndex())
+
+        cat = self.new_category("Jumps List")
+
+        history = tab.history
+        for idx, item in enumerate(history):
+            prefix = idx - history.current_idx()
+            if (prefix == 0):
+                prefix = ">"
+            prefix = str(prefix)
+            if re.match("^[0-9]", prefix):
+                prefix = "+" + prefix
+            self.new_item(cat, prefix, item.title(), item.url().toString(), sort = idx)
+        self.columns_to_filter = [0, 1, 2]
 
 
 def _get_cmd_completions(include_hidden, include_aliases, prefix=''):

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -240,6 +240,7 @@ KeyMode = enum('KeyMode', ['normal', 'hint', 'command', 'yesno', 'prompt',
 Completion = enum('Completion', ['command', 'section', 'option', 'value',
                                  'helptopic', 'quickmark_by_name',
                                  'bookmark_by_url', 'url', 'tab', 'sessions',
+                                 'jumps_list',
                                  'bind'])
 
 


### PR DESCRIPTION
This will add a more dynamic autocomplete model. It will allow you to pass a reference as a completion model, which will be called every time when the completion is needed. To exemplify, I've created the `jump` command like in `vimperator`. Everytime jump is called, the jump completer is called to build the list of the completion from the history of the current tab and display it. See the `completer.py`, line 89:

```
        if hasattr(model, '__call__'):
            model = model()
```