### PR TITLE
Pintab

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -560,6 +560,7 @@ class AbstractTab(QWidget):
         self._mouse_event_filter = mouse.MouseEventFilter(
             self, widget_class=self.WIDGET_CLASS, parent=self)
         self.backend = None
+        self.pin = False
 
         # FIXME:qtwebengine  Should this be public api via self.hints?
         #                    Also, should we get it out of objreg?

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -227,6 +227,10 @@ class CommandDispatcher:
         tab = self._cntwidget(count)
         if tab is None:
             return
+
+        if tab.pin is True:
+            return
+
         tabbar = self._tabbed_browser.tabBar()
         selection_override = self._get_selection_override(left, right,
                                                           opposite)
@@ -237,6 +241,24 @@ class CommandDispatcher:
             tabbar.setSelectionBehaviorOnRemove(selection_override)
             self._tabbed_browser.close_tab(tab)
             tabbar.setSelectionBehaviorOnRemove(old_selection_behavior)
+
+    @cmdutils.register(instance='command-dispatcher', scope='window', name='pin')
+    @cmdutils.argument('count', count=True)
+    def tab_pin(self, count=None):
+        tab = self._cntwidget(count)
+        if tab is None:
+            return
+        print(tab.pin)
+        tab.pin = True
+
+    @cmdutils.register(instance='command-dispatcher', scope='window', name='unpin')
+    @cmdutils.argument('count', count=True)
+    def tab_unpin(self, count=None):
+        tab = self._cntwidget(count)
+        if tab is None:
+            return
+        print(tab.pin)
+        tab.pin = False
 
     @cmdutils.register(instance='command-dispatcher', name='open',
                        maxsplit=0, scope='window')
@@ -281,6 +303,9 @@ class CommandDispatcher:
                     else:
                         # Explicit count with a tab that doesn't exist.
                         return
+               # elif curtab.pin is True:
+                    #TODO: include message saying that this is pinned therefore cannot open a new url
+               #     return
                 else:
                     curtab.openurl(cur_url)
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -243,22 +243,28 @@ class CommandDispatcher:
             tabbar.setSelectionBehaviorOnRemove(old_selection_behavior)
 
     @cmdutils.register(instance='command-dispatcher', scope='window', name='pin')
+    @cmdutils.argument('index')
     @cmdutils.argument('count', count=True)
-    def tab_pin(self, count=None):
+    def tab_pin(self, index=1, count=None):
         tab = self._cntwidget(count)
         if tab is None:
             return
-        print(tab.pin)
         tab.pin = True
+        self.tab_move(int(index))
 
     @cmdutils.register(instance='command-dispatcher', scope='window', name='unpin')
+    @cmdutils.argument('index')
     @cmdutils.argument('count', count=True)
-    def tab_unpin(self, count=None):
+    def tab_unpin(self, index=None, count=None):
         tab = self._cntwidget(count)
         if tab is None:
             return
-        print(tab.pin)
         tab.pin = False
+        if index is not None:
+            self.tab_move(int(index))
+        else:
+            self.tab_move(self._count())
+
 
     @cmdutils.register(instance='command-dispatcher', name='open',
                        maxsplit=0, scope='window')
@@ -303,9 +309,8 @@ class CommandDispatcher:
                     else:
                         # Explicit count with a tab that doesn't exist.
                         return
-               # elif curtab.pin is True:
-                    #TODO: include message saying that this is pinned therefore cannot open a new url
-               #     return
+                elif curtab.pin is True:
+                     raise cmdexc.CommandError("Tab is pinned!")
                 else:
                     curtab.openurl(cur_url)
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -229,7 +229,10 @@ class CommandDispatcher:
             return
 
         if tab.pin is True:
-            return
+            result = message.ask("Are you sure you want to close a pinned tab?", 
+                        mode=usertypes.PromptMode.yesno, default=False)
+            if result is False or result is None:
+                return
 
         tabbar = self._tabbed_browser.tabBar()
         selection_override = self._get_selection_override(left, right,

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -310,7 +310,7 @@ class CommandDispatcher:
                         # Explicit count with a tab that doesn't exist.
                         return
                 elif curtab.pin is True:
-                     raise cmdexc.CommandError("Tab is pinned!")
+                     message.info("Tab is pinned!")
                 else:
                     curtab.openurl(cur_url)
 

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -1652,6 +1652,8 @@ KEY_DATA = collections.OrderedDict([
         ('follow-selected', RETURN_KEYS),
         ('follow-selected -t', ['<Ctrl-Return>', '<Ctrl-Enter>']),
         ('repeat-command', ['.']),
+        ('pin', ['<Ctrl-p>']),
+        ('unpin', ['<Ctrl-O>']),
     ])),
 
     ('insert', collections.OrderedDict([

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -205,6 +205,7 @@ class SessionManager(QObject):
             if 'scroll-pos' in user_data:
                 pos = user_data['scroll-pos']
                 data['scroll-pos'] = {'x': pos.x(), 'y': pos.y()}
+        data['pin'] = tab.pin
         return data
 
     def _save_tab(self, tab, active):
@@ -331,6 +332,9 @@ class SessionManager(QObject):
             elif 'scroll-pos' in histentry:
                 pos = histentry['scroll-pos']
                 user_data['scroll-pos'] = QPoint(pos['x'], pos['y'])
+
+            if 'pin' in histentry:
+                new_tab.pin = histentry['pin']
 
             active = histentry.get('active', False)
             url = QUrl.fromEncoded(histentry['url'].encode('ascii'))


### PR DESCRIPTION
Initial development to support pin tabs #926 

Done so far:
Two new commands pin/unpin, both accept a index to help the organization (maybe this should be more a flag and not exactly two commands)
Crtl+p to pin, Crtl+O to unpin (not sure which should a good default shortcut)
If user tries to close a pinned tab it's asked to confirm
If user tries to open a URL in a pinned tab it receives a message with a information that the tab is pinned and ignore the openurl command
Preserve the pinned information across restart if session is activated

Missing:
Visual indication of the tab being pinned
Tab appearance being distinct over other tabs
Make pinned tabs to be the firsts on the tab bar

This is not ready, but it would be good to get some feedback earlier

