### PR TITLE
WebEngine prompts

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -797,8 +797,6 @@ Valid values:
 
 Default: +pass:[ask]+
 
-This setting is only available with the QtWebKit backend.
-
 [[network-dns-prefetch]]
 === dns-prefetch
 Whether to try to pre-fetch DNS entries to speed up browsing.

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -161,7 +161,6 @@
 |<<content-geolocation,geolocation>>|Allow websites to request geolocations.
 |<<content-notifications,notifications>>|Allow websites to show notifications.
 |<<content-media-capture,media-capture>>|Allow websites to record audio/video.
-|<<content-mouse-lock,mouse-lock>>|Allow websites to lock the mouse pointer.
 |<<content-javascript-can-open-windows-automatically,javascript-can-open-windows-automatically>>|Whether JavaScript programs can open new windows without user interaction.
 |<<content-javascript-can-close-windows,javascript-can-close-windows>>|Whether JavaScript programs can close windows.
 |<<content-javascript-can-access-clipboard,javascript-can-access-clipboard>>|Whether JavaScript programs can read or write to the clipboard.
@@ -1455,20 +1454,6 @@ Default: +pass:[ask]+
 [[content-media-capture]]
 === media-capture
 Allow websites to record audio/video.
-
-Valid values:
-
- * +true+
- * +false+
- * +ask+
-
-Default: +pass:[ask]+
-
-This setting is only available with the QtWebEngine backend.
-
-[[content-mouse-lock]]
-=== mouse-lock
-Allow websites to lock the mouse pointer.
 
 Valid values:
 

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -160,6 +160,8 @@
 |<<content-hyperlink-auditing,hyperlink-auditing>>|Enable or disable hyperlink auditing (<a ping>).
 |<<content-geolocation,geolocation>>|Allow websites to request geolocations.
 |<<content-notifications,notifications>>|Allow websites to show notifications.
+|<<content-media-capture,media-capture>>|Allow websites to record audio/video.
+|<<content-mouse-lock,mouse-lock>>|Allow websites to lock the mouse pointer.
 |<<content-javascript-can-open-windows-automatically,javascript-can-open-windows-automatically>>|Whether JavaScript programs can open new windows without user interaction.
 |<<content-javascript-can-close-windows,javascript-can-close-windows>>|Whether JavaScript programs can close windows.
 |<<content-javascript-can-access-clipboard,javascript-can-access-clipboard>>|Whether JavaScript programs can read or write to the clipboard.
@@ -1449,6 +1451,34 @@ Valid values:
  * +ask+
 
 Default: +pass:[ask]+
+
+[[content-media-capture]]
+=== media-capture
+Allow websites to record audio/video.
+
+Valid values:
+
+ * +true+
+ * +false+
+ * +ask+
+
+Default: +pass:[ask]+
+
+This setting is only available with the QtWebEngine backend.
+
+[[content-mouse-lock]]
+=== mouse-lock
+Allow websites to lock the mouse pointer.
+
+Valid values:
+
+ * +true+
+ * +false+
+ * +ask+
+
+Default: +pass:[ask]+
+
+This setting is only available with the QtWebEngine backend.
 
 [[content-javascript-can-open-windows-automatically]]
 === javascript-can-open-windows-automatically

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,6 +21,7 @@ markers =
     qtwebengine_createWindow: Tests using createWindow with QtWebEngine (QTBUG-54419)
     qtwebengine_flaky: Tests which are flaky (and currently skipped) with QtWebEngine
     qtwebengine_osx_xfail: Tests which fail on OS X with QtWebEngine
+    js_prompt: Tests needing to display a javascript prompt
     this: Used to mark tests during development
 qt_log_level_fail = WARNING
 qt_log_ignore =

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,7 +14,6 @@ markers =
     end2end: End to end tests which run qutebrowser as subprocess
     xfail_norun: xfail the test with out running it
     ci: Tests which should only run on CI.
-    flaky_once: Try to rerun this test once if it fails
     qtwebengine_todo: Features still missing with QtWebEngine
     qtwebengine_skip: Tests not applicable with QtWebEngine
     qtwebkit_skip: Tests not applicable with QtWebKit

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -75,6 +75,23 @@ class UnsupportedOperationError(WebTabError):
     """Raised when an operation is not supported with the given backend."""
 
 
+class AbstractCertificateErrorWrapper:
+
+    """A wrapper over an SSL/certificate error."""
+
+    def __init__(self, error):
+        self._error = error
+
+    def __str__(self):
+        raise NotImplementedError
+
+    def __repr__(self):
+        raise NotImplementedError
+
+    def is_overridable(self):
+        raise NotImplementedError
+
+
 class TabData:
 
     """A simple namespace with a fixed set of attributes.

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -75,23 +75,6 @@ class UnsupportedOperationError(WebTabError):
     """Raised when an operation is not supported with the given backend."""
 
 
-class AbstractCertificateErrorWrapper:
-
-    """A wrapper over an SSL/certificate error."""
-
-    def __init__(self, error):
-        self._error = error
-
-    def __str__(self):
-        raise NotImplementedError
-
-    def __repr__(self):
-        raise NotImplementedError
-
-    def is_overridable(self):
-        raise NotImplementedError
-
-
 class TabData:
 
     """A simple namespace with a fixed set of attributes.

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1992,7 +1992,7 @@ class CommandDispatcher:
                 tab.send_event(release_event)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
-                       debug=True)
+                       debug=True, backend=usertypes.Backend.QtWebKit)
     def debug_clear_ssl_errors(self):
         """Clear remembered SSL error answers."""
         self._current_widget().clear_ssl_errors()

--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -19,7 +19,15 @@
 
 """Various utilities shared between webpage/webview subclasses."""
 
+import html
+
 from qutebrowser.config import config
+from qutebrowser.utils import usertypes, message, log
+
+
+class CallSuper(Exception):
+
+    """Raised when the caller should call the superclass instead."""
 
 
 def custom_headers():
@@ -39,3 +47,66 @@ def custom_headers():
         headers[b'Accept-Language'] = accept_language.encode('ascii')
 
     return sorted(headers.items())
+
+
+def authentication_required(url, authenticator, abort_on):
+    """Ask a prompt for an authentication question."""
+    msg = '<b>{}</b> says:<br/>{}'.format(
+        html.escape(url.toDisplayString()),
+        html.escape(authenticator.realm()))
+    answer = message.ask(title="Authentication required", text=msg,
+                         mode=usertypes.PromptMode.user_pwd,
+                         abort_on=abort_on)
+    if answer is not None:
+        authenticator.setUser(answer.user)
+        authenticator.setPassword(answer.password)
+
+
+def javascript_confirm(url, js_msg, abort_on):
+    """Display a javascript confirm prompt."""
+    log.js.debug("confirm: {}".format(js_msg))
+    if config.get('ui', 'modal-js-dialog'):
+        raise CallSuper
+
+    msg = 'From <b>{}</b>:<br/>{}'.format(html.escape(url.toDisplayString()),
+                                          html.escape(js_msg))
+    ans = message.ask('Javascript confirm', msg,
+                      mode=usertypes.PromptMode.yesno,
+                      abort_on=abort_on)
+    return bool(ans)
+
+
+def javascript_prompt(url, js_msg, default, abort_on):
+    """Display a javascript prompt."""
+    log.js.debug("prompt: {}".format(js_msg))
+    if config.get('ui', 'modal-js-dialog'):
+        raise CallSuper
+    if config.get('content', 'ignore-javascript-prompt'):
+        return (False, "")
+
+    msg = '<b>{}</b> asks:<br/>{}'.format(html.escape(url.toDisplayString()),
+                                          html.escape(js_msg))
+    answer = message.ask('Javascript prompt', msg,
+                         mode=usertypes.PromptMode.text,
+                         default=default,
+                         abort_on=abort_on)
+
+    if answer is None:
+        return (False, "")
+    else:
+        return (True, answer)
+
+
+def javascript_alert(url, js_msg, abort_on):
+    """Display a javascript alert."""
+    log.js.debug("alert: {}".format(js_msg))
+    if config.get('ui', 'modal-js-dialog'):
+        raise CallSuper
+
+    if config.get('content', 'ignore-javascript-alert'):
+        return
+
+    msg = 'From <b>{}</b>:<br/>{}'.format(html.escape(url.toDisplayString()),
+                                          html.escape(js_msg))
+    message.ask('Javascript alert', msg, mode=usertypes.PromptMode.alert,
+                abort_on=abort_on)

--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -157,3 +157,37 @@ def ignore_certificate_errors(url, errors, abort_on):
     else:
         raise ValueError("Invalid ssl_strict value {!r}".format(ssl_strict))
     raise AssertionError("Not reached")
+
+
+def feature_permission(url, option, msg, yes_action, no_action, abort_on):
+    """Handle a feature permission request.
+
+    Args:
+        url: The URL the request was done for.
+        option: A (section, option) tuple for the option to check.
+        msg: A string like "show notifications"
+        yes_action: A callable to call if the request was approved
+        no_action: A callable to call if the request was denied
+        abort_on: A list of signals which interrupt the question.
+
+    Return:
+        The Question object if a question was asked, None otherwise.
+    """
+    config_val = config.get(*option)
+    if config_val == 'ask':
+        if url.isValid():
+            text = "Allow the website at <b>{}</b> to {}?".format(
+                html.escape(url.toDisplayString()), msg)
+        else:
+            text = "Allow the website to {}?".format(msg)
+
+        return message.confirm_async(
+            yes_action=yes_action, no_action=no_action,
+            cancel_action=no_action, abort_on=abort_on,
+            title='Permission request', text=text)
+    elif config_val:
+        yes_action()
+        return None
+    else:
+        no_action()
+        return None

--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -53,9 +53,13 @@ def custom_headers():
 
 def authentication_required(url, authenticator, abort_on):
     """Ask a prompt for an authentication question."""
-    msg = '<b>{}</b> says:<br/>{}'.format(
-        html.escape(url.toDisplayString()),
-        html.escape(authenticator.realm()))
+    realm = authenticator.realm()
+    if realm:
+        msg = '<b>{}</b> says:<br/>{}'.format(
+            html.escape(url.toDisplayString()), html.escape(realm))
+    else:
+        msg = '<b>{}</b> needs authentication'.format(
+            html.escape(url.toDisplayString()))
     answer = message.ask(title="Authentication required", text=msg,
                          mode=usertypes.PromptMode.user_pwd,
                          abort_on=abort_on)

--- a/qutebrowser/browser/webengine/certificateerror.py
+++ b/qutebrowser/browser/webengine/certificateerror.py
@@ -1,0 +1,45 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2016 Florian Bruhin (The Compiler) <mail@qutebrowser.org>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Wrapper over a QWebEngineCertificateError."""
+
+
+from PyQt5.QtWebEngineWidgets import QWebEngineCertificateError
+
+from qutebrowser.utils import usertypes, utils, debug
+
+
+class CertificateErrorWrapper(usertypes.AbstractCertificateErrorWrapper):
+
+    """A wrapper over a QWebEngineCertificateError."""
+
+    def __init__(self, error):
+        self._error = error
+
+    def __str__(self):
+        return self._error.errorDescription()
+
+    def __repr__(self):
+        return utils.get_repr(
+            self, error=debug.qenum_key(QWebEngineCertificateError,
+                                        self._error.error()),
+            string=str(self))
+
+    def is_overridable(self):
+        return self._error.isOverridable()

--- a/qutebrowser/browser/webengine/certificateerror.py
+++ b/qutebrowser/browser/webengine/certificateerror.py
@@ -29,9 +29,6 @@ class CertificateErrorWrapper(usertypes.AbstractCertificateErrorWrapper):
 
     """A wrapper over a QWebEngineCertificateError."""
 
-    def __init__(self, error):
-        self._error = error
-
     def __str__(self):
         return self._error.errorDescription()
 

--- a/qutebrowser/browser/webengine/certificateerror.py
+++ b/qutebrowser/browser/webengine/certificateerror.py
@@ -19,8 +19,9 @@
 
 """Wrapper over a QWebEngineCertificateError."""
 
-
+# pylint: disable=no-name-in-module,import-error,useless-suppression
 from PyQt5.QtWebEngineWidgets import QWebEngineCertificateError
+# pylint: enable=no-name-in-module,import-error,useless-suppression
 
 from qutebrowser.utils import usertypes, utils, debug
 

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -569,7 +569,7 @@ class WebEngineTab(browsertab.AbstractTab):
         self._widget.setHtml(html, base_url)
 
     def clear_ssl_errors(self):
-        log.stub()
+        raise browsertab.UnsupportedOperationError
 
     @pyqtSlot()
     def _on_history_trigger(self):

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -30,8 +30,7 @@ from PyQt5.QtGui import QKeyEvent, QIcon
 # pylint: disable=no-name-in-module,import-error,useless-suppression
 from PyQt5.QtWidgets import QOpenGLWidget, QApplication
 from PyQt5.QtWebEngineWidgets import (QWebEnginePage, QWebEngineScript,
-                                      QWebEngineProfile,
-                                      QWebEngineCertificateError)
+                                      QWebEngineProfile)
 # pylint: enable=no-name-in-module,import-error,useless-suppression
 
 from qutebrowser.browser import browsertab, mouse, shared
@@ -77,26 +76,6 @@ _JS_WORLD_MAP = {
     usertypes.JsWorld.user: QWebEngineScript.UserWorld,
     usertypes.JsWorld.jseval: QWebEngineScript.UserWorld + 1,
 }
-
-
-class CertificateErrorWrapper(browsertab.AbstractCertificateErrorWrapper):
-
-    """A wrapper over a QWebEngineCertificateError."""
-
-    def __init__(self, error):
-        self._error = error
-
-    def __str__(self):
-        return self._error.errorDescription()
-
-    def __repr__(self):
-        return utils.get_repr(
-            self, error=debug.qenum_key(QWebEngineCertificateError,
-                                        self._error.error()),
-            string=str(self))
-
-    def is_overridable(self):
-        return self._error.isOverridable()
 
 
 class WebEnginePrinting(browsertab.AbstractPrinting):

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -538,6 +538,7 @@ class WebEngineTab(browsertab.AbstractTab):
                 self._widget.page().runJavaScript(code, callback)
 
     def shutdown(self):
+        self.shutting_down.emit()
         self._widget.shutdown()
 
     def reload(self, *, force=False):

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -30,7 +30,8 @@ from PyQt5.QtGui import QKeyEvent, QIcon
 # pylint: disable=no-name-in-module,import-error,useless-suppression
 from PyQt5.QtWidgets import QOpenGLWidget, QApplication
 from PyQt5.QtWebEngineWidgets import (QWebEnginePage, QWebEngineScript,
-                                      QWebEngineProfile)
+                                      QWebEngineProfile,
+                                      QWebEngineCertificateError)
 # pylint: enable=no-name-in-module,import-error,useless-suppression
 
 from qutebrowser.browser import browsertab, mouse, shared
@@ -38,7 +39,7 @@ from qutebrowser.browser.webengine import (webview, webengineelem, tabhistory,
                                            interceptor, webenginequtescheme,
                                            webenginedownloads)
 from qutebrowser.utils import (usertypes, qtutils, log, javascript, utils,
-                               objreg, message)
+                               objreg, message, debug)
 
 
 _qute_scheme_handler = None
@@ -76,6 +77,26 @@ _JS_WORLD_MAP = {
     usertypes.JsWorld.user: QWebEngineScript.UserWorld,
     usertypes.JsWorld.jseval: QWebEngineScript.UserWorld + 1,
 }
+
+
+class CertificateErrorWrapper(browsertab.AbstractCertificateErrorWrapper):
+
+    """A wrapper over a QWebEngineCertificateError."""
+
+    def __init__(self, error):
+        self._error = error
+
+    def __str__(self):
+        return self._error.errorDescription()
+
+    def __repr__(self):
+        return utils.get_repr(
+            self, error=debug.qenum_key(QWebEngineCertificateError,
+                                        self._error.error()),
+            string=str(self))
+
+    def is_overridable(self):
+        return self._error.isOverridable()
 
 
 class WebEnginePrinting(browsertab.AbstractPrinting):

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -22,7 +22,6 @@
 
 """Wrapper over a QWebEngineView."""
 
-import html
 import functools
 
 from PyQt5.QtCore import pyqtSlot, Qt, QEvent, QPoint, QUrl, QTimer
@@ -38,7 +37,7 @@ from qutebrowser.browser.webengine import (webview, webengineelem, tabhistory,
                                            interceptor, webenginequtescheme,
                                            webenginedownloads)
 from qutebrowser.utils import (usertypes, qtutils, log, javascript, utils,
-                               objreg, message, debug)
+                               objreg)
 
 
 _qute_scheme_handler = None

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -132,7 +132,8 @@ class WebEnginePage(QWebEnginePage):
             QWebEnginePage.Geolocation: ('content', 'geolocation'),
             QWebEnginePage.MediaAudioCapture: ('content', 'media-capture'),
             QWebEnginePage.MediaVideoCapture: ('content', 'media-capture'),
-            QWebEnginePage.MediaAudioVideoCapture: ('content', 'media-capture'),
+            QWebEnginePage.MediaAudioVideoCapture:
+                ('content', 'media-capture'),
         }
         messages = {
             QWebEnginePage.Geolocation: 'access your location',
@@ -232,7 +233,8 @@ class WebEnginePage(QWebEnginePage):
         # WORKAROUND
         # Can't override javaScriptPrompt with older PyQt versions
         # https://www.riverbankcomputing.com/pipermail/pyqt/2016-November/038293.html
-        def javaScriptPrompt(self, url, js_msg, default, result):
+        def javaScriptPrompt(self, url, js_msg, default):
+            """Override javaScriptPrompt to use qutebrowser prompts."""
             if self._is_shutting_down:
                 return (False, "")
             try:

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -130,12 +130,12 @@ class WebEnginePage(QWebEnginePage):
         self.certificate_error.emit()
         url = error.url()
         error = webenginetab.CertificateErrorWrapper(error)
+        log.webview.debug("Certificate error: {}".format(error))
 
-        # FIXME
-        error_page = jinja.render('error.html',
-                                  title="Error while loading page",
-                                  url=url.toDisplayString(), error=str(error),
-                                  icon='', qutescheme=False)
+        url_string = url.toDisplayString()
+        error_page = jinja.render(
+            'error.html', title="Error loading page: {}".format(url_string),
+            url=url_string, error=str(error), icon='')
 
         if not error.is_overridable():
             log.webview.error("Non-overridable certificate error: "
@@ -147,7 +147,6 @@ class WebEnginePage(QWebEnginePage):
             url, [error], abort_on=[self.loadStarted, self.shutting_down])
 
         if not ignore:
-            log.webview.error("Certificate error: {}".format(error))
             self.setHtml(error_page)
 
         return ignore

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -133,7 +133,6 @@ class WebEnginePage(QWebEnginePage):
             QWebEnginePage.MediaAudioCapture: ('content', 'media-capture'),
             QWebEnginePage.MediaVideoCapture: ('content', 'media-capture'),
             QWebEnginePage.MediaAudioVideoCapture: ('content', 'media-capture'),
-            QWebEnginePage.MouseLock: ('content', 'mouse-lock'),
         }
         messages = {
             QWebEnginePage.Geolocation: 'access your location',
@@ -141,6 +140,15 @@ class WebEnginePage(QWebEnginePage):
             QWebEnginePage.MediaVideoCapture: 'record video',
             QWebEnginePage.MediaAudioVideoCapture: 'record audio/video',
         }
+        assert options.keys() == messages.keys()
+
+        if feature not in options:
+            log.webview.error("Unhandled feature permission {}".format(
+                debug.qenum_key(QWebEnginePage, feature)))
+            self.setFeaturePermission(url, feature,
+                                      QWebEnginePage.PermissionDeniedByUser)
+            return
+
         yes_action = functools.partial(
             self.setFeaturePermission, url, feature,
             QWebEnginePage.PermissionGrantedByUser)

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -27,7 +27,7 @@ from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEnginePage
 # pylint: enable=no-name-in-module,import-error,useless-suppression
 
 from qutebrowser.browser import shared
-from qutebrowser.browser.webengine import webenginetab, certificateerror
+from qutebrowser.browser.webengine import certificateerror
 from qutebrowser.config import config
 from qutebrowser.utils import log, debug, usertypes, objreg, qtutils, jinja
 
@@ -127,6 +127,7 @@ class WebEnginePage(QWebEnginePage):
         self.shutting_down.emit()
 
     def certificateError(self, error):
+        """Handle certificate errors coming from Qt."""
         self.certificate_error.emit()
         url = error.url()
         error = certificateerror.CertificateErrorWrapper(error)
@@ -147,9 +148,9 @@ class WebEnginePage(QWebEnginePage):
 
         # We can't really know when to show an error page, as the error might
         # have happened when loading some resource.
-        # However, self.url() is not available yet and self.requestedUrl() might
-        # not match the URL we get from the error - so we just apply a heuristic
-        # here.
+        # However, self.url() is not available yet and self.requestedUrl()
+        # might not match the URL we get from the error - so we just apply a
+        # heuristic here.
         # See https://bugreports.qt.io/browse/QTBUG-56207
         log.webview.debug("ignore {}, URL {}, requested {}".format(
             ignore, url, self.requestedUrl()))
@@ -159,6 +160,7 @@ class WebEnginePage(QWebEnginePage):
         return ignore
 
     def javaScriptConfirm(self, url, js_msg):
+        """Override javaScriptConfirm to use qutebrowser prompts."""
         if self._is_shutting_down:
             return False
         try:
@@ -181,7 +183,7 @@ class WebEnginePage(QWebEnginePage):
     #         return super().javaScriptPrompt(url, js_msg, default)
 
     def javaScriptAlert(self, url, js_msg):
-        """Override javaScriptAlert to use the statusbar."""
+        """Override javaScriptAlert to use qutebrowser prompts."""
         if self._is_shutting_down:
             return
         try:

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -27,7 +27,7 @@ from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEnginePage
 # pylint: enable=no-name-in-module,import-error,useless-suppression
 
 from qutebrowser.browser import shared
-from qutebrowser.browser.webengine import webenginetab
+from qutebrowser.browser.webengine import webenginetab, certificateerror
 from qutebrowser.config import config
 from qutebrowser.utils import log, debug, usertypes, objreg, qtutils, jinja
 
@@ -129,7 +129,7 @@ class WebEnginePage(QWebEnginePage):
     def certificateError(self, error):
         self.certificate_error.emit()
         url = error.url()
-        error = webenginetab.CertificateErrorWrapper(error)
+        error = certificateerror.CertificateErrorWrapper(error)
         log.webview.debug("Certificate error: {}".format(error))
 
         url_string = url.toDisplayString()

--- a/qutebrowser/browser/webkit/certificateerror.py
+++ b/qutebrowser/browser/webkit/certificateerror.py
@@ -29,9 +29,6 @@ class CertificateErrorWrapper(usertypes.AbstractCertificateErrorWrapper):
 
     """A wrapper over a QSslError."""
 
-    def __init__(self, error):
-        self._error = error
-
     def __str__(self):
         return self._error.errorString()
 
@@ -49,7 +46,7 @@ class CertificateErrorWrapper(usertypes.AbstractCertificateErrorWrapper):
                          self._error.error()))
 
     def __eq__(self, other):
-        return self._error == other._error
+        return self._error == other._error  # pylint: disable=protected-access
 
     def is_overridable(self):
         return True

--- a/qutebrowser/browser/webkit/certificateerror.py
+++ b/qutebrowser/browser/webkit/certificateerror.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Wrapper over a QSslCertificateError."""
+"""Wrapper over a QSslError."""
 
 
 from PyQt5.QtNetwork import QSslError

--- a/qutebrowser/browser/webkit/certificateerror.py
+++ b/qutebrowser/browser/webkit/certificateerror.py
@@ -1,0 +1,55 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2016 Florian Bruhin (The Compiler) <mail@qutebrowser.org>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Wrapper over a QSslCertificateError."""
+
+
+from PyQt5.QtNetwork import QSslError
+
+from qutebrowser.utils import usertypes, utils, debug
+
+
+class CertificateErrorWrapper(usertypes.AbstractCertificateErrorWrapper):
+
+    """A wrapper over a QSslError."""
+
+    def __init__(self, error):
+        self._error = error
+
+    def __str__(self):
+        return self._error.errorString()
+
+    def __repr__(self):
+        return utils.get_repr(
+            self, error=debug.qenum_key(QSslError, self._error.error()),
+            string=str(self))
+
+    def __hash__(self):
+        try:
+            # Qt >= 5.4
+            return hash(self._error)
+        except TypeError:
+            return hash((self._error.certificate().toDer(),
+                         self._error.error()))
+
+    def __eq__(self, other):
+        return self._error == other._error
+
+    def is_overridable(self):
+        return True

--- a/qutebrowser/browser/webkit/network/networkmanager.py
+++ b/qutebrowser/browser/webkit/network/networkmanager.py
@@ -26,14 +26,13 @@ import html
 
 from PyQt5.QtCore import (pyqtSlot, pyqtSignal, PYQT_VERSION, QCoreApplication,
                           QUrl, QByteArray)
-from PyQt5.QtNetwork import (QNetworkAccessManager, QNetworkReply, QSslError,
-                             QSslSocket)
+from PyQt5.QtNetwork import QNetworkAccessManager, QNetworkReply, QSslSocket
 
 from qutebrowser.config import config
 from qutebrowser.utils import (message, log, usertypes, utils, objreg, qtutils,
-                               urlutils, debug)
+                               urlutils)
 from qutebrowser.browser import shared
-from qutebrowser.browser.webkit import webkittab, certificateerror
+from qutebrowser.browser.webkit import certificateerror
 from qutebrowser.browser.webkit.network import (webkitqutescheme, networkreply,
                                                 filescheme)
 

--- a/qutebrowser/browser/webkit/network/networkmanager.py
+++ b/qutebrowser/browser/webkit/network/networkmanager.py
@@ -197,23 +197,6 @@ class NetworkManager(QNetworkAccessManager):
             abort_on.append(tab.load_started)
         return abort_on
 
-    def _ask(self, title, text, mode, owner=None, default=None):
-        """Ask a blocking question in the statusbar.
-
-        Args:
-            title: The title to display to the user.
-            text: The text to display to the user.
-            mode: A PromptMode.
-            owner: An object which will abort the question if destroyed, or
-                   None.
-
-        Return:
-            The answer the user gave or None if the prompt was cancelled.
-        """
-        abort_on = self._get_abort_signals(owner)
-        return message.ask(title=title, text=text, mode=mode,
-                           abort_on=abort_on, default=default)
-
     def shutdown(self):
         """Abort all running requests."""
         self.setNetworkAccessible(QNetworkAccessManager.NotAccessible)
@@ -325,9 +308,10 @@ class NetworkManager(QNetworkAccessManager):
             msg = '<b>{}</b> says:<br/>{}'.format(
                 html.escape(proxy.hostName()),
                 html.escape(authenticator.realm()))
-            answer = self._ask(
-                "Proxy authentication required", msg,
-                mode=usertypes.PromptMode.user_pwd)
+            abort_on = self._get_abort_signals()
+            answer = message.ask(
+                title="Proxy authentication required", text=msg,
+                mode=usertypes.PromptMode.user_pwd, abort_on=abort_on)
             if answer is not None:
                 authenticator.setUser(answer.user)
                 authenticator.setPassword(answer.password)

--- a/qutebrowser/browser/webkit/network/networkmanager.py
+++ b/qutebrowser/browser/webkit/network/networkmanager.py
@@ -33,7 +33,7 @@ from qutebrowser.config import config
 from qutebrowser.utils import (message, log, usertypes, utils, objreg, qtutils,
                                urlutils, debug)
 from qutebrowser.browser import shared
-from qutebrowser.browser.webkit import webkittab
+from qutebrowser.browser.webkit import webkittab, certificateerror
 from qutebrowser.browser.webkit.network import (webkitqutescheme, networkreply,
                                                 filescheme)
 
@@ -233,7 +233,7 @@ class NetworkManager(QNetworkAccessManager):
             reply: The QNetworkReply that is encountering the errors.
             errors: A list of errors.
         """
-        errors = [webkittab.CertificateErrorWrapper(e) for e in errors]
+        errors = [certificateerror.CertificateErrorWrapper(e) for e in errors]
         log.webview.debug("Certificate errors: {!r}".format(
             ' / '.join(str(err) for err in errors)))
         try:

--- a/qutebrowser/browser/webkit/network/networkmanager.py
+++ b/qutebrowser/browser/webkit/network/networkmanager.py
@@ -234,7 +234,8 @@ class NetworkManager(QNetworkAccessManager):
             errors: A list of errors.
         """
         errors = [webkittab.CertificateErrorWrapper(e) for e in errors]
-        log.webview.debug("Certificate errors {!r}".format(errors))
+        log.webview.debug("Certificate errors: {!r}".format(
+            ' / '.join(str(err) for err in errors)))
         try:
             host_tpl = urlutils.host_tuple(reply.url())
         except ValueError:

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -34,7 +34,7 @@ from PyQt5.QtPrintSupport import QPrinter
 from qutebrowser.browser import browsertab
 from qutebrowser.browser.webkit import webview, tabhistory, webkitelem
 from qutebrowser.browser.webkit.network import proxy, webkitqutescheme
-from qutebrowser.utils import qtutils, objreg, usertypes, utils, log, debug
+from qutebrowser.utils import qtutils, objreg, usertypes, utils, log
 
 
 def init():

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -30,7 +30,6 @@ from PyQt5.QtWidgets import QApplication
 from PyQt5.QtWebKitWidgets import QWebPage, QWebFrame
 from PyQt5.QtWebKit import QWebSettings
 from PyQt5.QtPrintSupport import QPrinter
-from PyQt5.QtNetwork import QSslError
 
 from qutebrowser.browser import browsertab
 from qutebrowser.browser.webkit import webview, tabhistory, webkitelem
@@ -48,36 +47,6 @@ def init():
     log.init.debug("Initializing js-bridge...")
     js_bridge = webkitqutescheme.JSBridge(qapp)
     objreg.register('js-bridge', js_bridge)
-
-
-class CertificateErrorWrapper(browsertab.AbstractCertificateErrorWrapper):
-
-    """A wrapper over a QSslError."""
-
-    def __init__(self, error):
-        self._error = error
-
-    def __str__(self):
-        return self._error.errorString()
-
-    def __repr__(self):
-        return utils.get_repr(
-            self, error=debug.qenum_key(QSslError, self._error.error()),
-            string=str(self))
-
-    def __hash__(self):
-        try:
-            # Qt >= 5.4
-            return hash(self._error)
-        except TypeError:
-            return hash((self._error.certificate().toDer(),
-                         self._error.error()))
-
-    def __eq__(self, other):
-        return self._error == other._error
-
-    def is_overridable(self):
-        return True
 
 
 class WebKitPrinting(browsertab.AbstractPrinting):

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -30,11 +30,12 @@ from PyQt5.QtWidgets import QApplication
 from PyQt5.QtWebKitWidgets import QWebPage, QWebFrame
 from PyQt5.QtWebKit import QWebSettings
 from PyQt5.QtPrintSupport import QPrinter
+from PyQt5.QtNetwork import QSslError
 
 from qutebrowser.browser import browsertab
 from qutebrowser.browser.webkit import webview, tabhistory, webkitelem
 from qutebrowser.browser.webkit.network import proxy, webkitqutescheme
-from qutebrowser.utils import qtutils, objreg, usertypes, utils, log
+from qutebrowser.utils import qtutils, objreg, usertypes, utils, log, debug
 
 
 def init():
@@ -47,6 +48,36 @@ def init():
     log.init.debug("Initializing js-bridge...")
     js_bridge = webkitqutescheme.JSBridge(qapp)
     objreg.register('js-bridge', js_bridge)
+
+
+class CertificateErrorWrapper(browsertab.AbstractCertificateErrorWrapper):
+
+    """A wrapper over a QSslError."""
+
+    def __init__(self, error):
+        self._error = error
+
+    def __str__(self):
+        return self._error.errorString()
+
+    def __repr__(self):
+        return utils.get_repr(
+            self, error=debug.qenum_key(QSslError, self._error.error()),
+            string=str(self))
+
+    def __hash__(self):
+        try:
+            # Qt >= 5.4
+            return hash(self._error)
+        except TypeError:
+            return hash((self._error.certificate().toDer(),
+                         self._error.error()))
+
+    def __eq__(self, other):
+        return self._error == other._error
+
+    def is_overridable(self):
+        return True
 
 
 class WebKitPrinting(browsertab.AbstractPrinting):

--- a/qutebrowser/browser/webkit/webpage.py
+++ b/qutebrowser/browser/webkit/webpage.py
@@ -95,7 +95,7 @@ class BrowserPage(QWebPage):
         # See http://www.riverbankcomputing.com/pipermail/pyqt/2014-June/034385.html
 
         def javaScriptPrompt(self, frame, js_msg, default):
-            """Override javaScriptPrompt to use the statusbar."""
+            """Override javaScriptPrompt to use qutebrowser prompts."""
             if self._is_shutting_down:
                 return (False, "")
             try:
@@ -434,7 +434,7 @@ class BrowserPage(QWebPage):
         return handler(opt, out)
 
     def javaScriptAlert(self, frame, js_msg):
-        """Override javaScriptAlert to use the statusbar."""
+        """Override javaScriptAlert to use qutebrowser prompts."""
         if self._is_shutting_down:
             return
         try:

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -821,6 +821,16 @@ def data(readonly=False):
              SettingValue(typ.BoolAsk(), 'ask'),
              "Allow websites to show notifications."),
 
+            ('media-capture',
+             SettingValue(typ.BoolAsk(), 'ask',
+                          backends=[usertypes.Backend.QtWebEngine]),
+             "Allow websites to record audio/video."),
+
+            ('mouse-lock',
+             SettingValue(typ.BoolAsk(), 'ask',
+                          backends=[usertypes.Backend.QtWebEngine]),
+             "Allow websites to lock the mouse pointer."),
+
             ('javascript-can-open-windows-automatically',
              SettingValue(typ.Bool(), 'false'),
              "Whether JavaScript programs can open new windows without user "

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -430,8 +430,7 @@ def data(readonly=False):
              "Whether to send DNS requests over the configured proxy."),
 
             ('ssl-strict',
-             SettingValue(typ.BoolAsk(), 'ask',
-                          backends=[usertypes.Backend.QtWebKit]),
+             SettingValue(typ.BoolAsk(), 'ask'),
              "Whether to validate SSL handshakes."),
 
             ('dns-prefetch',

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -826,11 +826,6 @@ def data(readonly=False):
                           backends=[usertypes.Backend.QtWebEngine]),
              "Allow websites to record audio/video."),
 
-            ('mouse-lock',
-             SettingValue(typ.BoolAsk(), 'ask',
-                          backends=[usertypes.Backend.QtWebEngine]),
-             "Allow websites to lock the mouse pointer."),
-
             ('javascript-can-open-windows-automatically',
              SettingValue(typ.Bool(), 'false'),
              "Whether JavaScript programs can open new windows without user "

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -402,3 +402,20 @@ class Timer(QTimer):
             super().start(msec)
         else:
             super().start()
+
+
+class AbstractCertificateErrorWrapper:
+
+    """A wrapper over an SSL/certificate error."""
+
+    def __init__(self, error):
+        self._error = error
+
+    def __str__(self):
+        raise NotImplementedError
+
+    def __repr__(self):
+        raise NotImplementedError
+
+    def is_overridable(self):
+        raise NotImplementedError

--- a/scripts/dev/check_coverage.py
+++ b/scripts/dev/check_coverage.py
@@ -74,8 +74,8 @@ PERFECT_FILES = [
 
     ('tests/unit/browser/test_signalfilter.py',
         'qutebrowser/browser/signalfilter.py'),
-    ('tests/unit/browser/test_shared.py',
-        'qutebrowser/browser/shared.py'),
+    (None,
+        'qutebrowser/browser/webkit/certificateerror.py'),
     # ('tests/unit/browser/test_tab.py',
     #     'qutebrowser/browser/tab.py'),
 

--- a/scripts/dev/run_vulture.py
+++ b/scripts/dev/run_vulture.py
@@ -98,6 +98,7 @@ def whitelist_generator():
         yield 'scripts.dev.pylint_checkers.config.' + attr
 
     yield 'scripts.dev.pylint_checkers.modeline.process_module'
+    yield 'scripts.dev.pylint_checkers.qute_pylint.config.msgs'
 
     for attr in ['_get_default_metavar_for_optional',
                  '_get_default_metavar_for_positional', '_metavar_formatter']:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ import warnings
 
 import pytest
 import hypothesis
+from PyQt5.QtCore import PYQT_VERSION
 
 pytest.register_assert_rewrite('helpers')
 
@@ -122,6 +123,14 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(pytest.mark.xfail(run=False))
         if item.get_marker('flaky_once'):
             item.add_marker(pytest.mark.flaky())
+        if item.get_marker('js_prompt'):
+            if config.webengine:
+                js_prompt_pyqt_version = 0x050700
+            else:
+                js_prompt_pyqt_version = 0x050300
+            item.add_marker(pytest.mark.skipif(
+                PYQT_VERSION <= js_prompt_pyqt_version,
+                reason='JS prompts are not supported with this PyQt version'))
 
         if deselected:
             deselected_items.append(item)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,8 +121,6 @@ def pytest_collection_modifyitems(config, items):
         _apply_platform_markers(item)
         if item.get_marker('xfail_norun'):
             item.add_marker(pytest.mark.xfail(run=False))
-        if item.get_marker('flaky_once'):
-            item.add_marker(pytest.mark.flaky())
         if item.get_marker('js_prompt'):
             if config.webengine:
                 js_prompt_pyqt_version = 0x050700

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -352,6 +352,15 @@ def javascript_message_when(quteproc, message):
     quteproc.wait_for_js(message)
 
 
+@bdd.when("I clear SSL errors")
+def clear_ssl_errors(request, quteproc):
+    if request.config.webengine:
+        quteproc.terminate()
+        quteproc.start()
+    else:
+        quteproc.send_cmd(':debug-clear-ssl-errors')
+
+
 ## Then
 
 

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -75,9 +75,8 @@ Feature: Downloading things from a website.
         And I run :leave-mode
         Then no crash should happen
 
-    @qtwebengine_todo: ssl-strict is not implemented yet
     Scenario: Downloading with SSL errors (issue 1413)
-        When I run :debug-clear-ssl-errors
+        When I clear SSL errors
         And I set network -> ssl-strict to ask
         And I download an SSL page
         And I wait for "Entering mode KeyMode.* (reason: question asked)" in the log

--- a/tests/end2end/features/history.feature
+++ b/tests/end2end/features/history.feature
@@ -34,7 +34,7 @@ Feature: Page history
         Then the history file should contain:
             http://localhost:(port)/data/%C3%A4%C3%B6%C3%BC.html Chäschüechli
             
-    @flaky_once @qtwebengine_todo: Error page message is not implemented
+    @flaky @qtwebengine_todo: Error page message is not implemented
     Scenario: History with an error
         When I run :open file:///does/not/exist
         And I wait for "Error while loading file:///does/not/exist: Error opening /does/not/exist: *" in the log

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -382,7 +382,7 @@ Feature: Various utility commands.
         And I press the key "<Ctrl-C>"
         Then no crash should happen
 
-    @pyqt>=5.3.1 @qtwebengine_skip: JS prompt is not implemented yet
+    @js_prompt
     Scenario: Focusing download widget via Tab (original issue)
         When I open data/prompt/jsprompt.html
         And I run :click-element id button

--- a/tests/end2end/features/prompts.feature
+++ b/tests/end2end/features/prompts.feature
@@ -101,7 +101,7 @@ Feature: Prompts
         Then the javascript message "Alert done" should be logged
         And the javascript message "notification permission granted" should be logged
 
-    @qtwebengine_todo: Permissions are not implemented yet
+    @qtwebengine_todo: Notifications are not implemented in QtWebEngine
     Scenario: Async question interrupted by async one
         When I set content -> notifications to ask
         And I open data/prompt/notifications.html in a new tab
@@ -116,7 +116,7 @@ Feature: Prompts
         Then the javascript message "notification permission granted" should be logged
         And "Added quickmark test for *" should be logged
 
-    @qtwebengine_todo: Permissions are not implemented yet
+    @qtwebengine_todo: Notifications are not implemented in QtWebEngine
     Scenario: Async question interrupted by blocking one
         When I set content -> notifications to ask
         And I set content -> ignore-javascript-alert to false
@@ -199,21 +199,20 @@ Feature: Prompts
 
     # Geolocation
 
-    @qtwebengine_todo: Permissions are not implemented yet
     Scenario: Always rejecting geolocation
         When I set content -> geolocation to false
         And I open data/prompt/geolocation.html in a new tab
         And I run :click-element id button
         Then the javascript message "geolocation permission denied" should be logged
 
-    @ci @not_osx @qtwebengine_todo: Permissions are not implemented yet
+    @ci @not_osx
     Scenario: Always accepting geolocation
         When I set content -> geolocation to true
         And I open data/prompt/geolocation.html in a new tab
         And I run :click-element id button
         Then the javascript message "geolocation permission denied" should not be logged
 
-    @ci @not_osx @qtwebengine_todo: Permissions are not implemented yet
+    @ci @not_osx
     Scenario: geolocation with ask -> true
         When I set content -> geolocation to ask
         And I open data/prompt/geolocation.html in a new tab
@@ -222,7 +221,6 @@ Feature: Prompts
         And I run :prompt-accept yes
         Then the javascript message "geolocation permission denied" should not be logged
 
-    @qtwebengine_todo: Permissions are not implemented yet
     Scenario: geolocation with ask -> false
         When I set content -> geolocation to ask
         And I open data/prompt/geolocation.html in a new tab
@@ -231,7 +229,6 @@ Feature: Prompts
         And I run :prompt-accept no
         Then the javascript message "geolocation permission denied" should be logged
 
-    @qtwebengine_todo: Permissions are not implemented yet
     Scenario: geolocation with ask -> abort
         When I set content -> geolocation to ask
         And I open data/prompt/geolocation.html in a new tab
@@ -242,21 +239,21 @@ Feature: Prompts
 
     # Notifications
 
-    @qtwebengine_todo: Permissions are not implemented yet
+    @qtwebengine_todo: Notifications are not implemented in QtWebEngine
     Scenario: Always rejecting notifications
         When I set content -> notifications to false
         And I open data/prompt/notifications.html in a new tab
         And I run :click-element id button
         Then the javascript message "notification permission denied" should be logged
 
-    @qtwebengine_todo: Permissions are not implemented yet
+    @qtwebengine_todo: Notifications are not implemented in QtWebEngine
     Scenario: Always accepting notifications
         When I set content -> notifications to true
         And I open data/prompt/notifications.html in a new tab
         And I run :click-element id button
         Then the javascript message "notification permission granted" should be logged
 
-    @qtwebengine_todo: Permissions are not implemented yet
+    @qtwebengine_todo: Notifications are not implemented in QtWebEngine
     Scenario: notifications with ask -> false
         When I set content -> notifications to ask
         And I open data/prompt/notifications.html in a new tab
@@ -265,7 +262,7 @@ Feature: Prompts
         And I run :prompt-accept no
         Then the javascript message "notification permission denied" should be logged
 
-    @qtwebengine_todo: Permissions are not implemented yet
+    @qtwebengine_todo: Notifications are not implemented in QtWebEngine
     Scenario: notifications with ask -> true
         When I set content -> notifications to ask
         And I open data/prompt/notifications.html in a new tab
@@ -284,7 +281,7 @@ Feature: Prompts
         And I run :leave-mode
         Then the javascript message "notification permission aborted" should be logged
 
-    @qtwebengine_todo: Permissions are not implemented yet
+    @qtwebengine_todo: Notifications are not implemented in QtWebEngine
     Scenario: answering notification after closing tab
         When I set content -> notifications to ask
         And I open data/prompt/notifications.html in a new tab
@@ -467,7 +464,7 @@ Feature: Prompts
 
     # https://github.com/The-Compiler/qutebrowser/issues/1249#issuecomment-175205531
     # https://github.com/The-Compiler/qutebrowser/pull/2054#issuecomment-258285544
-    @qtwebengine_todo: Permissions are not implemented yet
+    @qtwebengine_todo: Notifications are not implemented in QtWebEngine
     Scenario: Interrupting SSL prompt during a notification prompt
         When I set content -> notifications to ask
         And I set network -> ssl-strict to ask

--- a/tests/end2end/features/prompts.feature
+++ b/tests/end2end/features/prompts.feature
@@ -166,16 +166,14 @@ Feature: Prompts
 
     # SSL
 
-    @qtwebengine_todo: SSL errors are not implemented yet
     Scenario: SSL error with ssl-strict = false
         When I run :debug-clear-ssl-errors
         And I set network -> ssl-strict to false
         And I load an SSL page
         And I wait until the SSL page finished loading
-        Then the error "SSL error: *" should be shown
+        Then the error "Certificate error: *" should be shown
         And the page should contain the plaintext "Hello World via SSL!"
 
-    @qtwebengine_todo: SSL errors are not implemented yet
     Scenario: SSL error with ssl-strict = true
         When I run :debug-clear-ssl-errors
         And I set network -> ssl-strict to true
@@ -183,7 +181,6 @@ Feature: Prompts
         Then "Error while loading *: SSL handshake failed" should be logged
         And the page should contain the plaintext "Unable to load page"
 
-    @qtwebengine_todo: SSL errors are not implemented yet
     Scenario: SSL error with ssl-strict = ask -> yes
         When I run :debug-clear-ssl-errors
         And I set network -> ssl-strict to ask
@@ -193,7 +190,6 @@ Feature: Prompts
         And I wait until the SSL page finished loading
         Then the page should contain the plaintext "Hello World via SSL!"
 
-    @qtwebengine_todo: SSL errors are not implemented yet
     Scenario: SSL error with ssl-strict = ask -> no
         When I run :debug-clear-ssl-errors
         And I set network -> ssl-strict to ask
@@ -473,7 +469,6 @@ Feature: Prompts
 
     # https://github.com/The-Compiler/qutebrowser/issues/1249#issuecomment-175205531
     # https://github.com/The-Compiler/qutebrowser/pull/2054#issuecomment-258285544
-    @qtwebengine_todo: SSL errors are not implemented yet
     Scenario: Interrupting SSL prompt during a notification prompt
         When I set content -> notifications to ask
         And I set network -> ssl-strict to ask

--- a/tests/end2end/features/prompts.feature
+++ b/tests/end2end/features/prompts.feature
@@ -167,7 +167,7 @@ Feature: Prompts
     # SSL
 
     Scenario: SSL error with ssl-strict = false
-        When I run :debug-clear-ssl-errors
+        When I clear SSL errors
         And I set network -> ssl-strict to false
         And I load an SSL page
         And I wait until the SSL page finished loading
@@ -175,14 +175,13 @@ Feature: Prompts
         And the page should contain the plaintext "Hello World via SSL!"
 
     Scenario: SSL error with ssl-strict = true
-        When I run :debug-clear-ssl-errors
+        When I clear SSL errors
         And I set network -> ssl-strict to true
         And I load an SSL page
-        Then "Error while loading *: SSL handshake failed" should be logged
-        And the page should contain the plaintext "Unable to load page"
+        Then a SSL error page should be shown
 
     Scenario: SSL error with ssl-strict = ask -> yes
-        When I run :debug-clear-ssl-errors
+        When I clear SSL errors
         And I set network -> ssl-strict to ask
         And I load an SSL page
         And I wait for a prompt
@@ -191,13 +190,12 @@ Feature: Prompts
         Then the page should contain the plaintext "Hello World via SSL!"
 
     Scenario: SSL error with ssl-strict = ask -> no
-        When I run :debug-clear-ssl-errors
+        When I clear SSL errors
         And I set network -> ssl-strict to ask
         And I load an SSL page
         And I wait for a prompt
         And I run :prompt-accept no
-        Then "Error while loading *: SSL handshake failed" should be logged
-        And the page should contain the plaintext "Unable to load page"
+        Then a SSL error page should be shown
 
     # Geolocation
 
@@ -469,6 +467,7 @@ Feature: Prompts
 
     # https://github.com/The-Compiler/qutebrowser/issues/1249#issuecomment-175205531
     # https://github.com/The-Compiler/qutebrowser/pull/2054#issuecomment-258285544
+    @qtwebengine_todo: Permissions are not implemented yet
     Scenario: Interrupting SSL prompt during a notification prompt
         When I set content -> notifications to ask
         And I set network -> ssl-strict to ask

--- a/tests/end2end/features/prompts.feature
+++ b/tests/end2end/features/prompts.feature
@@ -40,7 +40,7 @@ Feature: Prompts
         And I run :leave-mode
         Then the javascript message "confirm reply: false" should be logged
 
-    @pyqt>=5.3.1
+    @pyqt>=5.3.1 @qtwebengine_skip
     Scenario: Javascript prompt
         When I open data/prompt/jsprompt.html
         And I run :click-element id button
@@ -49,7 +49,7 @@ Feature: Prompts
         And I run :prompt-accept
         Then the javascript message "Prompt reply: prompt test" should be logged
 
-    @pyqt>=5.3.1
+    @pyqt>=5.3.1 @qtwebengine_skip
     Scenario: Javascript prompt with default
         When I open data/prompt/jsprompt.html
         And I run :click-element id button-default
@@ -57,7 +57,7 @@ Feature: Prompts
         And I run :prompt-accept
         Then the javascript message "Prompt reply: default" should be logged
 
-    @pyqt>=5.3.1
+    @pyqt>=5.3.1 @qtwebengine_skip
     Scenario: Rejected javascript prompt
         When I open data/prompt/jsprompt.html
         And I run :click-element id button
@@ -68,6 +68,7 @@ Feature: Prompts
 
     # Multiple prompts
 
+    @qtwebengine_skip: QtWebEngine refuses to load anything with a JS question
     Scenario: Blocking question interrupted by blocking one
         When I set content -> ignore-javascript-alert to false
         And I open data/prompt/jsalert.html
@@ -83,6 +84,7 @@ Feature: Prompts
         Then the javascript message "confirm reply: true" should be logged
         And the javascript message "Alert done" should be logged
 
+    @qtwebengine_skip: QtWebEngine refuses to load anything with a JS question
     Scenario: Blocking question interrupted by async one
         When I set content -> ignore-javascript-alert to false
         And I set content -> notifications to ask
@@ -99,6 +101,7 @@ Feature: Prompts
         Then the javascript message "Alert done" should be logged
         And the javascript message "notification permission granted" should be logged
 
+    @qtwebengine_todo: Permissions are not implemented yet
     Scenario: Async question interrupted by async one
         When I set content -> notifications to ask
         And I open data/prompt/notifications.html in a new tab
@@ -113,6 +116,7 @@ Feature: Prompts
         Then the javascript message "notification permission granted" should be logged
         And "Added quickmark test for *" should be logged
 
+    @qtwebengine_todo: Permissions are not implemented yet
     Scenario: Async question interrupted by blocking one
         When I set content -> notifications to ask
         And I set content -> ignore-javascript-alert to false
@@ -131,7 +135,7 @@ Feature: Prompts
 
     # Shift-Insert with prompt (issue 1299)
 
-    @pyqt>=5.3.1
+    @pyqt>=5.3.1 @qtwebengine_skip
     Scenario: Pasting via shift-insert in prompt mode
         When selection is supported
         And I put "insert test" into the primary selection
@@ -142,7 +146,7 @@ Feature: Prompts
         And I run :prompt-accept
         Then the javascript message "Prompt reply: insert test" should be logged
 
-    @pyqt>=5.3.1
+    @pyqt>=5.3.1 @qtwebengine_skip
     Scenario: Pasting via shift-insert without it being supported
         When selection is not supported
         And I put "insert test" into the primary selection
@@ -153,7 +157,7 @@ Feature: Prompts
         And I run :prompt-accept
         Then the javascript message "Prompt reply: " should be logged
 
-    @pyqt>=5.3.1
+    @pyqt>=5.3.1 @qtwebengine_skip
     Scenario: Using content -> ignore-javascript-prompt
         When I set content -> ignore-javascript-prompt to true
         And I open data/prompt/jsprompt.html
@@ -162,6 +166,7 @@ Feature: Prompts
 
     # SSL
 
+    @qtwebengine_todo: SSL errors are not implemented yet
     Scenario: SSL error with ssl-strict = false
         When I run :debug-clear-ssl-errors
         And I set network -> ssl-strict to false
@@ -170,6 +175,7 @@ Feature: Prompts
         Then the error "SSL error: *" should be shown
         And the page should contain the plaintext "Hello World via SSL!"
 
+    @qtwebengine_todo: SSL errors are not implemented yet
     Scenario: SSL error with ssl-strict = true
         When I run :debug-clear-ssl-errors
         And I set network -> ssl-strict to true
@@ -177,6 +183,7 @@ Feature: Prompts
         Then "Error while loading *: SSL handshake failed" should be logged
         And the page should contain the plaintext "Unable to load page"
 
+    @qtwebengine_todo: SSL errors are not implemented yet
     Scenario: SSL error with ssl-strict = ask -> yes
         When I run :debug-clear-ssl-errors
         And I set network -> ssl-strict to ask
@@ -186,6 +193,7 @@ Feature: Prompts
         And I wait until the SSL page finished loading
         Then the page should contain the plaintext "Hello World via SSL!"
 
+    @qtwebengine_todo: SSL errors are not implemented yet
     Scenario: SSL error with ssl-strict = ask -> no
         When I run :debug-clear-ssl-errors
         And I set network -> ssl-strict to ask
@@ -197,20 +205,21 @@ Feature: Prompts
 
     # Geolocation
 
+    @qtwebengine_todo: Permissions are not implemented yet
     Scenario: Always rejecting geolocation
         When I set content -> geolocation to false
         And I open data/prompt/geolocation.html in a new tab
         And I run :click-element id button
         Then the javascript message "geolocation permission denied" should be logged
 
-    @ci @not_osx
+    @ci @not_osx @qtwebengine_todo: Permissions are not implemented yet
     Scenario: Always accepting geolocation
         When I set content -> geolocation to true
         And I open data/prompt/geolocation.html in a new tab
         And I run :click-element id button
         Then the javascript message "geolocation permission denied" should not be logged
 
-    @ci @not_osx
+    @ci @not_osx @qtwebengine_todo: Permissions are not implemented yet
     Scenario: geolocation with ask -> true
         When I set content -> geolocation to ask
         And I open data/prompt/geolocation.html in a new tab
@@ -219,6 +228,7 @@ Feature: Prompts
         And I run :prompt-accept yes
         Then the javascript message "geolocation permission denied" should not be logged
 
+    @qtwebengine_todo: Permissions are not implemented yet
     Scenario: geolocation with ask -> false
         When I set content -> geolocation to ask
         And I open data/prompt/geolocation.html in a new tab
@@ -227,6 +237,7 @@ Feature: Prompts
         And I run :prompt-accept no
         Then the javascript message "geolocation permission denied" should be logged
 
+    @qtwebengine_todo: Permissions are not implemented yet
     Scenario: geolocation with ask -> abort
         When I set content -> geolocation to ask
         And I open data/prompt/geolocation.html in a new tab
@@ -237,18 +248,21 @@ Feature: Prompts
 
     # Notifications
 
+    @qtwebengine_todo: Permissions are not implemented yet
     Scenario: Always rejecting notifications
         When I set content -> notifications to false
         And I open data/prompt/notifications.html in a new tab
         And I run :click-element id button
         Then the javascript message "notification permission denied" should be logged
 
+    @qtwebengine_todo: Permissions are not implemented yet
     Scenario: Always accepting notifications
         When I set content -> notifications to true
         And I open data/prompt/notifications.html in a new tab
         And I run :click-element id button
         Then the javascript message "notification permission granted" should be logged
 
+    @qtwebengine_todo: Permissions are not implemented yet
     Scenario: notifications with ask -> false
         When I set content -> notifications to ask
         And I open data/prompt/notifications.html in a new tab
@@ -257,6 +271,7 @@ Feature: Prompts
         And I run :prompt-accept no
         Then the javascript message "notification permission denied" should be logged
 
+    @qtwebengine_todo: Permissions are not implemented yet
     Scenario: notifications with ask -> true
         When I set content -> notifications to ask
         And I open data/prompt/notifications.html in a new tab
@@ -275,6 +290,7 @@ Feature: Prompts
         And I run :leave-mode
         Then the javascript message "notification permission aborted" should be logged
 
+    @qtwebengine_todo: Permissions are not implemented yet
     Scenario: answering notification after closing tab
         When I set content -> notifications to ask
         And I open data/prompt/notifications.html in a new tab
@@ -287,55 +303,55 @@ Feature: Prompts
     # Page authentication
 
     Scenario: Successful webpage authentification
-        When I open basic-auth/user/password without waiting
+        When I open basic-auth/user1/password1 without waiting
         And I wait for a prompt
-        And I press the keys "user"
+        And I press the keys "user1"
         And I run :prompt-accept
-        And I press the keys "password"
+        And I press the keys "password1"
         And I run :prompt-accept
-        And I wait until basic-auth/user/password is loaded
+        And I wait until basic-auth/user1/password1 is loaded
         Then the json on the page should be:
             {
               "authenticated": true,
-              "user": "user"
+              "user": "user1"
             }
 
     Scenario: Authentication with :prompt-accept value
         When I open about:blank in a new tab
-        And I open basic-auth/user/password without waiting
+        And I open basic-auth/user2/password2 without waiting
         And I wait for a prompt
-        And I run :prompt-accept user:password
-        And I wait until basic-auth/user/password is loaded
+        And I run :prompt-accept user2:password2
+        And I wait until basic-auth/user2/password2 is loaded
         Then the json on the page should be:
             {
               "authenticated": true,
-              "user": "user"
+              "user": "user2"
             }
 
     Scenario: Authentication with invalid :prompt-accept value
         When I open about:blank in a new tab
-        And I open basic-auth/user/password without waiting
+        And I open basic-auth/user3/password3 without waiting
         And I wait for a prompt
         And I run :prompt-accept foo
-        And I run :prompt-accept user:password
+        And I run :prompt-accept user3:password3
         Then the error "Value needs to be in the format username:password, but foo was given" should be shown
 
     Scenario: Tabbing between username and password
         When I open about:blank in a new tab
-        And I open basic-auth/user/password without waiting
+        And I open basic-auth/user4/password4 without waiting
         And I wait for a prompt
         And I press the keys "us"
         And I run :prompt-item-focus next
-        And I press the keys "password"
+        And I press the keys "password4"
         And I run :prompt-item-focus prev
-        And I press the keys "er"
+        And I press the keys "er4"
         And I run :prompt-accept
         And I run :prompt-accept
-        And I wait until basic-auth/user/password is loaded
+        And I wait until basic-auth/user4/password4 is loaded
         Then the json on the page should be:
             {
               "authenticated": true,
-              "user": "user"
+              "user": "user4"
             }
 
     # :prompt-accept with value argument
@@ -350,7 +366,7 @@ Feature: Prompts
         Then the javascript message "Alert done" should be logged
         And the error "No value is permitted with alert prompts!" should be shown
 
-    @pyqt>=5.3.1
+    @pyqt>=5.3.1 @qtwebengine_skip
     Scenario: Javascript prompt with value
         When I set content -> ignore-javascript-prompt to false
         And I open data/prompt/jsprompt.html
@@ -396,6 +412,7 @@ Feature: Prompts
 
     # Other
 
+    @qtwebengine_skip
     Scenario: Shutting down with a question
         When I open data/prompt/jsconfirm.html
         And I run :click-element id button
@@ -429,32 +446,34 @@ Feature: Prompts
         Then "Added quickmark prompt-in-command-mode for *" should be logged
 
     # https://github.com/The-Compiler/qutebrowser/issues/1093
+    @qtwebengine_skip: QtWebEngine doesn't open the second page/prompt
     Scenario: Keyboard focus with multiple auth prompts
-        When I open basic-auth/user1/password1 without waiting
-        And I open basic-auth/user2/password2 in a new tab without waiting
+        When I open basic-auth/user5/password5 without waiting
+        And I open basic-auth/user6/password6 in a new tab without waiting
         And I wait for a prompt
         And I wait for a prompt
         # Second prompt (showed first)
-        And I press the keys "user2"
+        And I press the keys "user6"
         And I press the key "<Enter>"
-        And I press the keys "password2"
+        And I press the keys "password6"
         And I press the key "<Enter>"
-        And I wait until basic-auth/user2/password2 is loaded
+        And I wait until basic-auth/user6/password6 is loaded
         # First prompt
-        And I press the keys "user1"
+        And I press the keys "user5"
         And I press the key "<Enter>"
-        And I press the keys "password1"
+        And I press the keys "password5"
         And I press the key "<Enter>"
-        And I wait until basic-auth/user1/password1 is loaded
+        And I wait until basic-auth/user5/password5 is loaded
         # We're on the second page
         Then the json on the page should be:
             {
               "authenticated": true,
-              "user": "user2"
+              "user": "user6"
             }
 
     # https://github.com/The-Compiler/qutebrowser/issues/1249#issuecomment-175205531
     # https://github.com/The-Compiler/qutebrowser/pull/2054#issuecomment-258285544
+    @qtwebengine_todo: SSL errors are not implemented yet
     Scenario: Interrupting SSL prompt during a notification prompt
         When I set content -> notifications to ask
         And I set network -> ssl-strict to ask

--- a/tests/end2end/features/prompts.feature
+++ b/tests/end2end/features/prompts.feature
@@ -40,7 +40,7 @@ Feature: Prompts
         And I run :leave-mode
         Then the javascript message "confirm reply: false" should be logged
 
-    @pyqt>=5.3.1 @qtwebengine_skip
+    @js_prompt
     Scenario: Javascript prompt
         When I open data/prompt/jsprompt.html
         And I run :click-element id button
@@ -49,7 +49,7 @@ Feature: Prompts
         And I run :prompt-accept
         Then the javascript message "Prompt reply: prompt test" should be logged
 
-    @pyqt>=5.3.1 @qtwebengine_skip
+    @js_prompt
     Scenario: Javascript prompt with default
         When I open data/prompt/jsprompt.html
         And I run :click-element id button-default
@@ -57,7 +57,7 @@ Feature: Prompts
         And I run :prompt-accept
         Then the javascript message "Prompt reply: default" should be logged
 
-    @pyqt>=5.3.1 @qtwebengine_skip
+    @js_prompt
     Scenario: Rejected javascript prompt
         When I open data/prompt/jsprompt.html
         And I run :click-element id button
@@ -135,7 +135,7 @@ Feature: Prompts
 
     # Shift-Insert with prompt (issue 1299)
 
-    @pyqt>=5.3.1 @qtwebengine_skip
+    @js_prompt
     Scenario: Pasting via shift-insert in prompt mode
         When selection is supported
         And I put "insert test" into the primary selection
@@ -146,7 +146,7 @@ Feature: Prompts
         And I run :prompt-accept
         Then the javascript message "Prompt reply: insert test" should be logged
 
-    @pyqt>=5.3.1 @qtwebengine_skip
+    @js_prompt
     Scenario: Pasting via shift-insert without it being supported
         When selection is not supported
         And I put "insert test" into the primary selection
@@ -157,7 +157,7 @@ Feature: Prompts
         And I run :prompt-accept
         Then the javascript message "Prompt reply: " should be logged
 
-    @pyqt>=5.3.1 @qtwebengine_skip
+    @js_prompt
     Scenario: Using content -> ignore-javascript-prompt
         When I set content -> ignore-javascript-prompt to true
         And I open data/prompt/jsprompt.html
@@ -357,7 +357,7 @@ Feature: Prompts
         Then the javascript message "Alert done" should be logged
         And the error "No value is permitted with alert prompts!" should be shown
 
-    @pyqt>=5.3.1 @qtwebengine_skip
+    @js_prompt
     Scenario: Javascript prompt with value
         When I set content -> ignore-javascript-prompt to false
         And I open data/prompt/jsprompt.html

--- a/tests/end2end/features/test_prompts_bdd.py
+++ b/tests/end2end/features/test_prompts_bdd.py
@@ -64,3 +64,20 @@ def ssl_error_page(request, quteproc):
                       "loading page: *'")
     content = quteproc.get_content().strip()
     assert "Unable to load page" in content
+
+
+class AbstractCertificateErrorWrapper:
+
+    """A wrapper over an SSL/certificate error."""
+
+    def __init__(self, error):
+        self._error = error
+
+    def __str__(self):
+        raise NotImplementedError
+
+    def __repr__(self):
+        raise NotImplementedError
+
+    def is_overridable(self):
+        raise NotImplementedError

--- a/tests/end2end/features/test_prompts_bdd.py
+++ b/tests/end2end/features/test_prompts_bdd.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
 
-import pytest
 import pytest_bdd as bdd
 bdd.scenarios('prompts.feature')
 

--- a/tests/end2end/features/test_prompts_bdd.py
+++ b/tests/end2end/features/test_prompts_bdd.py
@@ -21,15 +21,6 @@ import pytest_bdd as bdd
 bdd.scenarios('prompts.feature')
 
 
-@bdd.when("I clear SSL errors")
-def clear_ssl_errors(request, quteproc):
-    if request.config.webengine:
-        quteproc.terminate()
-        quteproc.start()
-    else:
-        quteproc.send_cmd(':debug-clear-ssl-errors')
-
-
 @bdd.when("I load an SSL page")
 def load_ssl_page(quteproc, ssl_server):
     # We don't wait here as we can get an SSL question.

--- a/tests/end2end/features/test_prompts_bdd.py
+++ b/tests/end2end/features/test_prompts_bdd.py
@@ -22,9 +22,6 @@ import pytest_bdd as bdd
 bdd.scenarios('prompts.feature')
 
 
-pytestmark = pytest.mark.qtwebengine_todo("Prompts are not implemented")
-
-
 @bdd.when("I load an SSL page")
 def load_ssl_page(quteproc, ssl_server):
     # We don't wait here as we can get an SSL question.

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -235,7 +235,8 @@ class QuteProc(testprocess.Process):
         except testprocess.InvalidLine:
             if not line.strip():
                 return None
-            elif is_ignored_qt_message(line) or is_ignored_lowlevel_message(line):
+            elif (is_ignored_qt_message(line) or
+                  is_ignored_lowlevel_message(line)):
                 return None
             else:
                 raise

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -53,6 +53,19 @@ def is_ignored_qt_message(message):
     return False
 
 
+def is_ignored_lowlevel_message(message):
+    """Check if we want to ignore a lowlevel process output."""
+    if 'Running without the SUID sandbox!' in message:
+        return True
+    elif message.startswith('Xlib: sequence lost'):
+        # https://travis-ci.org/The-Compiler/qutebrowser/jobs/157941720
+        # ???
+        return True
+    elif 'CERT_PKIXVerifyCert for localhost failed' in message:
+        return True
+    return False
+
+
 class LogLine(testprocess.Line):
 
     """A parsed line from the qutebrowser log output.
@@ -222,14 +235,7 @@ class QuteProc(testprocess.Process):
         except testprocess.InvalidLine:
             if not line.strip():
                 return None
-            elif 'Running without the SUID sandbox!' in line:
-                # QtWebEngine error
-                return None
-            elif line.startswith('Xlib: sequence lost'):
-                # https://travis-ci.org/The-Compiler/qutebrowser/jobs/157941720
-                # ???
-                return None
-            elif is_ignored_qt_message(line):
+            elif is_ignored_qt_message(line) or is_ignored_lowlevel_message(line):
                 return None
             else:
                 raise

--- a/tests/end2end/fixtures/webserver.py
+++ b/tests/end2end/fixtures/webserver.py
@@ -81,7 +81,7 @@ class Request(testprocess.Line):
                 http.client.FOUND]
             path_to_statuses['/absolute-redirect/{}'.format(i)] = [
                 http.client.FOUND]
-        for suffix in ['', '1', '2']:
+        for suffix in ['', '1', '2', '3', '4', '5', '6']:
             key = '/basic-auth/user{}/password{}'.format(suffix, suffix)
             path_to_statuses[key] = [http.client.UNAUTHORIZED, http.client.OK]
 

--- a/tests/unit/utils/usertypes/test_misc.py
+++ b/tests/unit/utils/usertypes/test_misc.py
@@ -1,0 +1,27 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2016 Florian Bruhin (The Compiler) <mail@qutebrowser.org>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from qutebrowser.utils import usertypes
+
+
+def test_abstract_certificate_error_wrapper():
+    err = object()
+    wrapper = usertypes.AbstractCertificateErrorWrapper(err)
+    assert wrapper._error is err


### PR DESCRIPTION
Hopefully one of the last rather big QtWebEngine things :wink:

This implements various kinds of prompts (JS confirm/alert/prompt, HTTP authentication, SSL errors, feature permissions).

Should be ready to merge from my POV, but if you aren't tired of it yet, a review from @rcorre, @Kingdread and/or anyone else would be welcome!