### PR TITLE
Cancel register key input with escape

### DIFF
--- a/qutebrowser/keyinput/modeparsers.py
+++ b/qutebrowser/keyinput/modeparsers.py
@@ -291,7 +291,6 @@ class RegisterKeyParser(keyparser.CommandKeyParser):
         Return:
             True if event has been handled, False otherwise.
         """
-
         if super().handle(e):
             return True
 

--- a/qutebrowser/keyinput/modeparsers.py
+++ b/qutebrowser/keyinput/modeparsers.py
@@ -290,6 +290,10 @@ class RegisterKeyParser(keyparser.BaseKeyParser):
         Return:
             True if event has been handled, False otherwise.
         """
+        if e.key() == Qt.Key_Escape:
+            self.request_leave.emit(self._mode, "register key cancelled", True)
+            return True
+
         if utils.keyevent_to_string(e) is None:
             # this is a modifier key, let it pass and keep going
             return False

--- a/qutebrowser/keyinput/modeparsers.py
+++ b/qutebrowser/keyinput/modeparsers.py
@@ -267,7 +267,7 @@ class CaretKeyParser(keyparser.CommandKeyParser):
         self.read_config('caret')
 
 
-class RegisterKeyParser(keyparser.BaseKeyParser):
+class RegisterKeyParser(keyparser.CommandKeyParser):
 
     """KeyParser for modes that record a register key.
 
@@ -280,6 +280,7 @@ class RegisterKeyParser(keyparser.BaseKeyParser):
         super().__init__(win_id, parent, supports_count=False,
                          supports_chains=False)
         self._mode = mode
+        self.read_config('register')
 
     def handle(self, e):
         """Override handle to always match the next key and use the register.
@@ -290,8 +291,8 @@ class RegisterKeyParser(keyparser.BaseKeyParser):
         Return:
             True if event has been handled, False otherwise.
         """
-        if e.key() == Qt.Key_Escape:
-            self.request_leave.emit(self._mode, "register key cancelled", True)
+
+        if super().handle(e):
             return True
 
         if utils.keyevent_to_string(e) is None:
@@ -327,7 +328,3 @@ class RegisterKeyParser(keyparser.BaseKeyParser):
     def on_keyconfig_changed(self, mode):
         """RegisterKeyParser has no config section (no bindable keys)."""
         pass
-
-    def execute(self, cmdstr, _keytype, count=None):
-        """Should never be called on RegisterKeyParser."""
-        assert False

--- a/tests/end2end/features/keyinput.feature
+++ b/tests/end2end/features/keyinput.feature
@@ -259,4 +259,4 @@ Feature: Keyboard input
     Scenario: Cancelling key input
         When I run :record-macro
         And I press the key "<Escape>"
-        Then "Leaving mode KeyMode.record_macro (reason: register key cancelled)" should be logged
+        Then "Leaving mode KeyMode.record_macro (reason: leave current)" should be logged

--- a/tests/end2end/features/keyinput.feature
+++ b/tests/end2end/features/keyinput.feature
@@ -255,3 +255,8 @@ Feature: Keyboard input
         And I press the key "a"
         And I wait for "hints: *" in the log
         Then no crash should happen
+
+    Scenario: Cancelling key input
+        When I run :record-macro
+        And I press the key "<Escape>"
+        Then "Leaving mode KeyMode.record_macro (reason: register key cancelled)" should be logged


### PR DESCRIPTION
See #2108. I implemented it as a general `RegisterKeyParser` feature, so it also works for `run-macro`, `set-mark` and `jump-mark`. 