### PR TITLE
Fixed problems with tab completion after moving tabs (#2141)

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1028,17 +1028,13 @@ class CommandDispatcher:
             raise cmdexc.CommandError("Can't move tab to position {}!".format(
                 new_idx + 1))
 
-        tab = self._current_widget()
         cur_idx = self._current_index()
-        icon = self._tabbed_browser.tabIcon(cur_idx)
-        label = self._tabbed_browser.page_title(cur_idx)
         cmdutils.check_overflow(cur_idx, 'int')
         cmdutils.check_overflow(new_idx, 'int')
         self._tabbed_browser.setUpdatesEnabled(False)
         try:
             color = self._tabbed_browser.tab_indicator_color(cur_idx)
-            self._tabbed_browser.removeTab(cur_idx)
-            self._tabbed_browser.insertTab(new_idx, tab, icon, label)
+            self._tabbed_browser.tabBar().moveTab(cur_idx, new_idx)
             self._set_current_index(new_idx)
             self._tabbed_browser.set_tab_indicator_color(new_idx, color)
         finally:

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1031,10 +1031,7 @@ class CommandDispatcher:
         cur_idx = self._current_index()
         cmdutils.check_overflow(cur_idx, 'int')
         cmdutils.check_overflow(new_idx, 'int')
-        color = self._tabbed_browser.tab_indicator_color(cur_idx)
         self._tabbed_browser.tabBar().moveTab(cur_idx, new_idx)
-        self._set_current_index(new_idx)
-        self._tabbed_browser.set_tab_indicator_color(new_idx, color)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0, no_replace_variables=True)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1031,14 +1031,10 @@ class CommandDispatcher:
         cur_idx = self._current_index()
         cmdutils.check_overflow(cur_idx, 'int')
         cmdutils.check_overflow(new_idx, 'int')
-        self._tabbed_browser.setUpdatesEnabled(False)
-        try:
-            color = self._tabbed_browser.tab_indicator_color(cur_idx)
-            self._tabbed_browser.tabBar().moveTab(cur_idx, new_idx)
-            self._set_current_index(new_idx)
-            self._tabbed_browser.set_tab_indicator_color(new_idx, color)
-        finally:
-            self._tabbed_browser.setUpdatesEnabled(True)
+        color = self._tabbed_browser.tab_indicator_color(cur_idx)
+        self._tabbed_browser.tabBar().moveTab(cur_idx, new_idx)
+        self._set_current_index(new_idx)
+        self._tabbed_browser.set_tab_indicator_color(new_idx, color)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0, no_replace_variables=True)

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -160,6 +160,7 @@ class TabCompletionModel(base.BaseCompletionModel):
                 tab.title_changed.connect(self.rebuild)
                 tab.shutting_down.connect(self.delayed_rebuild)
             tabbed_browser.new_tab.connect(self.on_new_tab)
+            tabbed_browser.tabBar().tabMoved.connect(self.rebuild)
         objreg.get("app").new_window.connect(self.on_new_window)
         self.rebuild()
 

--- a/tests/end2end/features/completion.feature
+++ b/tests/end2end/features/completion.feature
@@ -102,3 +102,15 @@ Feature: Using completion
         And I run :completion-item-del
         Then the following tabs should be open:
             - data/hello.txt (active)
+
+    Scenario: Go to tab after moving a tab
+        Given I have a fresh instance
+        When I open data/hello.txt
+        And I open data/hello2.txt in a new tab
+        # Tricking completer into not updating tabs
+        And I run :set-cmd-text -s :buffer
+        And I run :tab-move 1
+        And I run :buffer hello2.txt
+        Then the following tabs should be open:
+            - data/hello2.txt (active)
+            - data/hello.txt

--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -586,7 +586,7 @@ class TabbedBrowserStub(QObject):
         del self.tabs[idx]
 
     def tabBar(self):
-        return QTabBar(self._qtabbar)
+        return self._qtabbar
 
 
 class ApplicationStub(QObject):

--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -27,7 +27,7 @@ from unittest import mock
 from PyQt5.QtCore import pyqtSignal, QPoint, QProcess, QObject
 from PyQt5.QtNetwork import (QNetworkRequest, QAbstractNetworkCache,
                              QNetworkCacheMetaData)
-from PyQt5.QtWidgets import QCommonStyle, QLineEdit, QWidget
+from PyQt5.QtWidgets import QCommonStyle, QLineEdit, QWidget, QTabBar
 
 from qutebrowser.browser import browsertab, history
 from qutebrowser.config import configexc
@@ -571,6 +571,7 @@ class TabbedBrowserStub(QObject):
         super().__init__(parent)
         self.tabs = []
         self.shutting_down = False
+        self._qtabbar = QTabBar()
 
     def count(self):
         return len(self.tabs)
@@ -583,6 +584,9 @@ class TabbedBrowserStub(QObject):
 
     def on_tab_close_requested(self, idx):
         del self.tabs[idx]
+
+    def tabBar(self):
+        return QTabBar(self._qtabbar)
 
 
 class ApplicationStub(QObject):


### PR DESCRIPTION
It was a bit hard to recreate the issue #2141 in tests, since the completer seems to update the pages by itself from time to time. The current feature test is a bit weird, but indeed fails in the old version and passes in the new one.
Not really sure if I changed `TabbedBrowserStub` test helper correctly (I had to, since in the old version it didn't have tabBar() method).