### PR TITLE
Add Keywords entry to comply with freedesktop guidelines

### DIFF
--- a/qutebrowser.desktop
+++ b/qutebrowser.desktop
@@ -8,3 +8,4 @@ Exec=qutebrowser %u
 Terminal=false
 StartupNotify=false
 MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;
+Keywords=Browser


### PR DESCRIPTION
Debians lintian pointed out that a .desktop file should contain a Keywords-entry