### PR TITLE
Ignore non-register keys

### DIFF
--- a/qutebrowser/keyinput/modeparsers.py
+++ b/qutebrowser/keyinput/modeparsers.py
@@ -294,11 +294,11 @@ class RegisterKeyParser(keyparser.CommandKeyParser):
         if super().handle(e):
             return True
 
-        if utils.keyevent_to_string(e) is None:
-            # this is a modifier key, let it pass and keep going
-            return False
-
         key = e.text()
+
+        if key == '' or utils.keyevent_to_string(e) is None:
+            # this is not a proper register key, let it pass and keep going
+            return False
 
         tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                     window=self._win_id)

--- a/tests/end2end/features/keyinput.feature
+++ b/tests/end2end/features/keyinput.feature
@@ -260,3 +260,19 @@ Feature: Keyboard input
         When I run :record-macro
         And I press the key "<Escape>"
         Then "Leaving mode KeyMode.record_macro (reason: leave current)" should be logged
+
+    Scenario: Ignoring non-register keys
+        Given I open data/scroll/simple.html
+        And I run :tab-only
+        When I run :scroll down with count 2
+        And I wait until the scroll position changed
+        And I run :record-macro
+        And I press the key "<Menu>"
+        And I press the key "c"
+        And I run :scroll up
+        And I wait until the scroll position changed
+        And I run :record-macro
+        And I run :run-macro
+        And I press the key "c"
+        And I wait until the scroll position changed to 0/0
+        Then the page should not be scrolled


### PR DESCRIPTION
Ignore all keys with an empty .text() return value, not just modifier keys. You can still use unusual things like ß for registers, but XF86WakeUp is out. Fixes #2125.