### PR TITLE
Blacklist some modes for :enter-mode

### DIFF
--- a/qutebrowser/keyinput/modeman.py
+++ b/qutebrowser/keyinput/modeman.py
@@ -265,6 +265,10 @@ class ModeManager(QObject):
             m = usertypes.KeyMode[mode]
         except KeyError:
             raise cmdexc.CommandError("Mode {} does not exist!".format(mode))
+        if m in [usertypes.KeyMode.hint, usertypes.KeyMode.command,
+                 usertypes.KeyMode.yesno, usertypes.KeyMode.prompt]:
+            raise cmdexc.CommandError(
+                "Mode {} can't be entered manually!".format(mode))
         self.enter(m, 'command')
 
     @pyqtSlot(usertypes.KeyMode, str, bool)

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -642,3 +642,9 @@ Feature: Various utility commands.
         And I run :command-accept
         And I set general -> private-browsing to false
         Then the message "blah" should be shown
+
+    ## Modes blacklisted for :enter-mode
+
+    Scenario: Trying to enter command mode with :enter-mode
+        When I run :enter-mode command
+        Then the error "Mode command can't be entered manually!" should be shown


### PR DESCRIPTION
This disallows using :enter-mode with modes that don't work properly when entered that way. Fixes #1137.