### PR TITLE
Add "QUTE_COMMANDLINE_TEXT" environment variable for userscripts.

### DIFF
--- a/doc/userscripts.asciidoc
+++ b/doc/userscripts.asciidoc
@@ -38,6 +38,7 @@ The following environment variables will be set when a userscript is launched:
 - `QUTE_CONFIG_DIR`: Path of the directory containing qutebrowser's configuration.
 - `QUTE_DATA_DIR`: Path of the directory containing qutebrowser's data.
 - `QUTE_DOWNLOAD_DIR`: Path of the downloads directory.
+- `QUTE_COMMANDLINE_TEXT`: Text currently in qutebrowser's command line. (Depends on which window the userscript is launched in)
 
 In `command` mode:
 

--- a/qutebrowser/commands/userscripts.py
+++ b/qutebrowser/commands/userscripts.py
@@ -419,6 +419,8 @@ def run_async(tab, cmd, *args, win_id, env, verbose=False):
     env['QUTE_CONFIG_DIR'] = standarddir.config()
     env['QUTE_DATA_DIR'] = standarddir.data()
     env['QUTE_DOWNLOAD_DIR'] = downloads.download_dir()
+    env['QUTE_COMMANDLINE_TEXT'] = objreg.get('status-command', scope='window',
+                                              window=win_id).text()
 
     cmd_path = os.path.expanduser(cmd)
 


### PR DESCRIPTION
[Comment from #937](https://github.com/The-Compiler/qutebrowser/issues/937#issuecomment-274883241).

Although it makes more sense to pass this environment variable while in command mode only, it seemed to be more trouble than it's worth to get it to do that, so it passes the variable regardless of what mode you're in.

I looked into adding a test, but I wasn't sure what to do. Since `grep -r QUTE_TITLE tests/` came up with nothing, I presume it's not so important, but i'll add a test if neccessary, though I'll need some guidance if so.